### PR TITLE
technique: add source-of-truth-layout

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -13,6 +13,7 @@ This file is the repository-wide map of public techniques.
 | id | name | domain | status | summary |
 |---|---|---|---|---|
 | AOA-T-0001 | plan-diff-apply-verify-report | agent-workflows | promoted | Change protocol for safe, reviewable agent operations |
+| AOA-T-0002 | source-of-truth-layout | docs | promoted | Repository document role separation to reduce drift |
 
 ## Deprecated techniques
 

--- a/techniques/docs/source-of-truth-layout/TECHNIQUE.md
+++ b/techniques/docs/source-of-truth-layout/TECHNIQUE.md
@@ -1,0 +1,142 @@
+---
+id: AOA-T-0002
+name: source-of-truth-layout
+domain: docs
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/SOURCE_OF_TRUTH.md
+  note: Derived from a real solo+AI repository with explicit document-role policy and reduced doc drift.
+owners:
+  - 8Dionysus
+tags:
+  - docs
+  - repo-hygiene
+  - anti-drift
+  - reusable
+summary: Repository document role separation pattern that keeps status, plans, history, decisions, and run instructions in distinct canonical homes.
+---
+
+# source-of-truth-layout
+
+## Intent
+
+Reduce documentation drift by giving each recurring kind of project information one canonical document home and one clear update route.
+
+## When to use
+
+- multi-document repositories that mix planning, execution, history, and operations
+- solo+AI or human+agent projects where many edits happen quickly
+- long-running repositories where status, commands, and decisions tend to spread across multiple files
+- repositories that want lightweight entrypoint docs without losing detailed history
+
+## When not to use
+
+- very small repositories where one short `README` is enough
+- projects that already use an external system as the single authoritative home for plans, runbooks, and decisions
+- repositories that are unwilling to maintain an explicit document-role map
+
+## Inputs
+
+- current repository document set
+- recurring information classes such as status, plans, run history, decisions, and commands
+- update events that should route to one primary document
+
+## Outputs
+
+- explicit document role map
+- update-routing rules
+- lightweight entrypoint docs
+- lower risk of duplicated or contradictory status
+
+## Core procedure
+
+1. Inventory the recurring information classes in the repository.
+2. Assign one primary document to each class of information.
+3. Keep entrypoint documents short and link outward instead of duplicating detail.
+4. Define update-routing rules so each meaningful change lands in one primary document first.
+5. Review the document map regularly and remove accidental duplication.
+
+Recommended role map:
+
+| Document | Primary role |
+|---|---|
+| `README` | Short human-facing entrypoint |
+| `MANIFEST` | Short machine/human snapshot |
+| `TODO` | Active execution plan |
+| `PLANS` | Goals, milestones, DoD, and risks |
+| `SESSION_*` | Long history, runs, experiments, and artifacts |
+| `DECISIONS` | Architecture and policy changes |
+| `RUNBOOK` | Runnable commands and operating procedures |
+| `ARCHIVED_TRACKS` | Recoverable or paused directions |
+
+Recommended update-routing rules:
+
+- architecture or policy change -> `DECISIONS`
+- command, setup, or operator procedure change -> `RUNBOOK`
+- active work item or current focus change -> `TODO`
+- goals, milestones, or DoD change -> `PLANS`
+- completed run, experiment, or detailed chronology -> `SESSION_*`
+- lightweight status summary -> `README` or `MANIFEST`
+
+## Contracts
+
+- each recurring information class has one canonical home
+- each meaningful change routes to exactly one primary document first
+- `README` and `MANIFEST` stay lightweight and mostly link outward
+- long run history does not live in `README` or `TODO`
+- decisions do not hide inside session logs or runbooks
+
+## Risks
+
+- over-structuring a repository that is too small to need this layout
+- letting the role map go stale after repo evolution
+- creating duplicate summaries anyway because contributors ignore routing rules
+
+## Validation
+
+Verify the technique by confirming that:
+- each major document has an explicit role
+- a sample change can be routed to one primary document without ambiguity
+- active status is not duplicated across multiple documents
+- long history and artifact detail stay out of lightweight entrypoint docs
+
+See `checks/doc-role-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- `MANIFEST` can be omitted in smaller repositories
+- `SESSION_*` can be daily, weekly, or milestone-based
+- `ARCHIVED_TRACKS` is optional if the project has no recoverable sidelines
+- filenames can vary as long as the role map stays explicit
+
+What should stay invariant:
+- one canonical home per recurring information class
+- explicit update-routing rules
+- lightweight entrypoint docs
+- deliberate separation between active work, long history, decisions, and runnable operations
+
+## Public sanitization notes
+
+Project-specific milestone names, metrics, run IDs, nightly workflow details, local paths, and environment-specific operational details were removed. The published version keeps only the reusable document-role pattern and update-routing logic.
+
+## Example
+
+See `examples/minimal-doc-routing.md`.
+
+## Checks
+
+See `checks/doc-role-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated through active use across `README`, `MANIFEST`, `TODO`, `PLANS`, `DECISIONS`, `RUNBOOK`, and `SESSION_*` documents
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add adaptation notes from a second repository
+- add a companion technique for lightweight status snapshots
+- add an optional machine-readable role-map format if the repository later needs automated checks

--- a/techniques/docs/source-of-truth-layout/checks/doc-role-checklist.md
+++ b/techniques/docs/source-of-truth-layout/checks/doc-role-checklist.md
@@ -1,0 +1,12 @@
+# Doc Role Checklist
+
+Use this checklist to validate whether a repository really follows `source-of-truth-layout`.
+
+- Each major document has one explicit primary role.
+- Active status is not duplicated across multiple documents.
+- Long run history is not stored in `README` or `TODO`.
+- Setup commands and operator procedures live in `RUNBOOK`.
+- Architecture and policy changes live in `DECISIONS`.
+- Current work lives in `TODO`.
+- Goals, milestones, DoD, and risks live in `PLANS`.
+- Entry-point docs stay lightweight and mostly link to canonical detail.

--- a/techniques/docs/source-of-truth-layout/examples/minimal-doc-routing.md
+++ b/techniques/docs/source-of-truth-layout/examples/minimal-doc-routing.md
@@ -1,0 +1,26 @@
+# Minimal Doc Routing
+
+This example shows how a repository can route common updates without duplicating status across many files.
+
+## Document map
+
+- `README` keeps a short project overview and links to canonical docs.
+- `MANIFEST` keeps a compact machine/human snapshot.
+- `TODO` tracks active work.
+- `PLANS` tracks goals, milestones, and risks.
+- `DECISIONS` records architecture and policy changes.
+- `RUNBOOK` stores runnable commands and operating procedures.
+- `SESSION_2026-03-13` stores detailed run history for the day.
+
+## Example routing
+
+- A new architectural rule is added: write it to `DECISIONS`.
+- The startup command changes: update `RUNBOOK`.
+- The team begins a new active task: update `TODO`.
+- A milestone moves from planned to complete: update `PLANS`.
+- A smoke run finishes and produces detailed notes: append the result to `SESSION_2026-03-13`.
+- The top-level project status changes: keep the summary short in `README` or `MANIFEST` and link to the detailed docs instead of copying long history.
+
+## Anti-drift rule
+
+If the same status paragraph starts appearing in `README`, `TODO`, and `PLANS`, move the detail back to its canonical home and leave only short references elsewhere.


### PR DESCRIPTION
## Summary
Adds the second public technique `AOA-T-0002` as `promoted`.

## What Changed
- added the technique document
- added a minimal public-safe doc-routing example
- added a document-role checklist
- updated `TECHNIQUE_INDEX.md`

## Validation
- diff is scoped to 4 files
- `TECHNIQUE.md` includes the required sections
- content was reviewed for public hygiene
- `seed_2.txt` remains unstaged and outside the PR

## Notes
- no scripts, schemas, or additional techniques included
- no `.gitignore` changes in this PR