### PR TITLE
repo: ignore seed_2.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 seed.txt
+seed_2.txt


### PR DESCRIPTION
## Summary
Adds an explicit ignore rule for the private local file `seed_2.txt`.

## What Changed
- updated `.gitignore`

## Validation
- `git check-ignore -v seed_2.txt` resolves through `.gitignore`
- `seed_2.txt` remains untracked
- file hash remained unchanged

## Notes
- no content files changed
- no wildcard ignore was introduced