### PR TITLE
technique: add contract-first-smoke-summary

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -14,6 +14,7 @@ This file is the repository-wide map of public techniques.
 |---|---|---|---|---|
 | AOA-T-0001 | plan-diff-apply-verify-report | agent-workflows | promoted | Change protocol for safe, reviewable agent operations |
 | AOA-T-0002 | source-of-truth-layout | docs | promoted | Repository document role separation to reduce drift |
+| AOA-T-0003 | contract-first-smoke-summary | evaluation | promoted | Runnable smoke pattern with machine-readable summary as the primary validation contract |
 
 ## Deprecated techniques
 

--- a/techniques/evaluation/contract-first-smoke-summary/TECHNIQUE.md
+++ b/techniques/evaluation/contract-first-smoke-summary/TECHNIQUE.md
@@ -1,0 +1,126 @@
+---
+id: AOA-T-0003
+name: contract-first-smoke-summary
+domain: evaluation
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/RUNBOOK.md
+  note: Derived from a real repository pattern where runnable smoke entrypoints emit machine-readable summaries consumed by CI, UI, and agents.
+owners:
+  - 8Dionysus
+tags:
+  - evaluation
+  - smoke
+  - contracts
+  - ci
+summary: Runnable smoke pattern where each smoke path emits a machine-readable summary that becomes the primary validation contract.
+---
+
+# contract-first-smoke-summary
+
+## Intent
+
+Make smoke checks reviewable, automatable, and reusable by treating the machine-readable summary as the primary contract instead of relying on console text alone.
+
+## When to use
+
+- repositories with runnable smoke scripts or operational probes
+- CI pipelines that need stable pass or fail signals
+- local operator tools or dashboards that consume validation results
+- agent workflows that need structured outputs instead of log scraping
+
+## When not to use
+
+- one-off manual checks with no need for repeatability
+- cases where a full test suite already provides the only required contract surface
+- checks that cannot produce any stable artifact or status signal
+
+## Inputs
+
+- a runnable smoke entrypoint
+- expected output artifacts
+- explicit success and failure conditions
+- one stable summary output path or `--summary-json` surface
+
+## Outputs
+
+- smoke run artifacts
+- one machine-readable summary file
+- explicit `ok` or `error` status
+- enough observed fields to support basic diagnosis
+
+## Core procedure
+
+1. Define the smoke entrypoint and the scenario it is meant to validate.
+2. Define the expected artifacts the smoke run should create.
+3. Emit a stable machine-readable summary file such as `summary.json`, `smoke_summary.json`, or `contract_summary.json`.
+4. Make exit behavior explicit:
+   - return `0` when the summary contract is satisfied
+   - return non-zero when the contract fails
+5. Wire the same summary into CI reports, artifact uploads, local dashboards, or agent surfaces.
+6. Preserve summary writing on failure whenever possible so diagnosis does not depend on raw logs alone.
+
+## Contracts
+
+- each smoke path produces one machine-readable summary
+- the summary contains an explicit success or error status
+- the summary contains enough observed data to diagnose basic failures
+- the summary path is stable, either by convention or via a stable `--summary-json` flag
+- exit code aligns with summary status
+- console output may help humans, but it is not the primary contract surface
+
+## Risks
+
+- creating overly shallow summaries that say `error` without useful context
+- changing summary shape too often and breaking downstream consumers
+- treating summary generation as optional and falling back to log parsing under pressure
+
+## Validation
+
+Verify the technique by confirming that:
+- the summary file is always written on success and is written on failure whenever possible
+- the summary is valid machine-readable JSON
+- status in the summary matches the process exit behavior
+- a downstream consumer can read the summary without scraping console logs
+
+See `checks/summary-contract-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- summary filenames
+- run directory layout
+- domain-specific observed fields
+- additional contract-check layers
+- downstream consumers such as CI, dashboards, local tools, or agents
+
+What should stay invariant:
+- one machine-readable summary per smoke path
+- explicit status and outcome semantics
+- stable summary discovery
+- no dependence on raw logs as the only source of truth
+
+## Public sanitization notes
+
+Project-specific workflow names, run directory conventions, threshold values, and ATM10-specific scenarios were removed. The published version keeps the reusable pattern: runnable smoke entrypoints, structured summaries, and explicit contract-based pass or fail behavior.
+
+## Example
+
+See `examples/minimal-smoke-summary-flow.md`.
+
+## Checks
+
+See `checks/summary-contract-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated across multiple smoke paths that publish structured summary artifacts for CI and operator use
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add an adaptation example from a non-Python repository
+- add a companion technique for summary history plus latest-alias patterns
+- add optional guidance for backward-compatible summary evolution

--- a/techniques/evaluation/contract-first-smoke-summary/checks/summary-contract-checklist.md
+++ b/techniques/evaluation/contract-first-smoke-summary/checks/summary-contract-checklist.md
@@ -1,0 +1,11 @@
+# Summary Contract Checklist
+
+Use this checklist to validate whether a smoke path really follows `contract-first-smoke-summary`.
+
+- A summary file is produced for the smoke path.
+- The summary is machine-readable JSON.
+- The summary includes an explicit success or error status.
+- The summary captures enough observed data for basic diagnosis.
+- Exit code aligns with summary status.
+- Downstream consumers can use the summary without scraping raw logs.
+- Summary discovery is stable through a fixed path or a stable `--summary-json` flag.

--- a/techniques/evaluation/contract-first-smoke-summary/examples/minimal-smoke-summary-flow.md
+++ b/techniques/evaluation/contract-first-smoke-summary/examples/minimal-smoke-summary-flow.md
@@ -1,0 +1,35 @@
+# Minimal Smoke Summary Flow
+
+This example shows a generic smoke path that publishes a machine-readable summary instead of relying on console logs as the main contract.
+
+## Scenario
+
+A repository has a smoke script that checks whether a local service can start and respond to one request.
+
+## Flow
+
+1. Run the smoke entrypoint.
+2. Create normal run artifacts.
+3. Write `smoke_summary.json` with an explicit status.
+4. Exit with `0` when the summary contract is satisfied.
+5. Exit non-zero when the contract fails.
+6. Upload or read the same summary in CI, dashboards, or agent tooling.
+
+## Example summary shape
+
+```json
+{
+  "checked_at_utc": "2026-03-13T12:00:00Z",
+  "ok": true,
+  "status": "ok",
+  "observed": {
+    "request_count": 1,
+    "latency_ms": 120
+  },
+  "violations": []
+}
+```
+
+## Anti-drift rule
+
+If downstream tooling must parse console logs to understand whether the smoke run passed, the summary contract is not strong enough yet.


### PR DESCRIPTION
## Summary
Adds the third public technique `AOA-T-0003` as `promoted`.

## What Changed
- added the technique document
- added a minimal public-safe smoke summary example
- added a summary contract checklist
- updated `TECHNIQUE_INDEX.md`

## Validation
- diff is scoped to 4 files
- `TECHNIQUE.md` includes the required sections
- content was reviewed for public hygiene
- `seed_2.txt` remains ignored and unchanged

## Notes
- no scripts, schemas, or repo-wide validation automation included
- this PR queues the next content step and does not merge it yet