### PR TITLE
technique: add intent-plan-dry-run-contract-chain

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -15,6 +15,7 @@ This file is the repository-wide map of public techniques.
 | AOA-T-0001 | plan-diff-apply-verify-report | agent-workflows | promoted | Change protocol for safe, reviewable agent operations |
 | AOA-T-0002 | source-of-truth-layout | docs | promoted | Repository document role separation to reduce drift |
 | AOA-T-0003 | contract-first-smoke-summary | evaluation | promoted | Runnable smoke pattern with machine-readable summary as the primary validation contract |
+| AOA-T-0004 | intent-plan-dry-run-contract-chain | agent-workflows | promoted | Safe workflow that normalizes intent into a traceable plan, validates it with dry-run, and enforces contract checks |
 
 ## Deprecated techniques
 

--- a/techniques/agent-workflows/intent-plan-dry-run-contract-chain/TECHNIQUE.md
+++ b/techniques/agent-workflows/intent-plan-dry-run-contract-chain/TECHNIQUE.md
@@ -1,0 +1,125 @@
+---
+id: AOA-T-0004
+name: intent-plan-dry-run-contract-chain
+domain: agent-workflows
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/RUNBOOK.md
+  note: Derived from a real automation workflow where intent payloads are normalized into traceable plans, validated through dry-run, and enforced by contract checks.
+owners:
+  - 8Dionysus
+tags:
+  - agent-workflow
+  - automation
+  - dry-run
+  - traceability
+summary: Safe workflow that normalizes intent into a traceable plan, validates it with dry-run, and enforces contract checks before any real execution path exists.
+---
+
+# intent-plan-dry-run-contract-chain
+
+## Intent
+
+Turn high-level intent into a traceable, reviewable, non-executing automation path before any real action is allowed.
+
+## When to use
+
+- automation systems that start from intent-like inputs
+- agent workflows that need a reviewable planning layer before execution
+- teams that want dry-run-first automation with explicit artifacts
+- systems where traceability matters across adapter, planner, and validator steps
+
+## When not to use
+
+- simple scripts that do not need an intent abstraction
+- systems that already execute real actions directly without a dry-run safety layer
+- workflows where no stable artifacts or contract checks are required
+
+## Inputs
+
+- a stable intent payload
+- an adapter or normalizer that turns intent into a plan
+- a dry-run-only executor
+- a contract-check step for produced artifacts
+
+## Outputs
+
+- normalized plan artifact
+- dry-run execution artifacts
+- chain summary or equivalent linking artifacts together
+- contract-check result suitable for CI or operator review
+
+## Core procedure
+
+1. Define a stable intent payload that expresses what should happen at a high level.
+2. Normalize the intent into a plan and attach planning metadata such as intent type, schema version, adapter identity, and optional traceability IDs.
+3. Run a dry-run-only executor against the normalized plan.
+4. Emit explicit chain artifacts such as `run.json`, plan output, and chain summary.
+5. Run a contract-check over the produced artifacts.
+6. Wire the contract result into CI, dashboards, or operator review surfaces before any real execution path is considered.
+
+## Contracts
+
+- the adapter does not perform real input events or equivalent side effects
+- the normalized plan carries workflow metadata such as intent type, schema version, adapter identity, and optional traceability IDs
+- the execution step remains dry-run only
+- chain artifacts are explicit and linkable
+- contract checks validate expected intent type or equivalent routing and minimum structural completeness
+- exit behavior is explicit and reviewable
+
+## Risks
+
+- false confidence if dry-run artifacts look complete but do not reflect real execution constraints
+- metadata drift between intent, normalized plan, and contract-check layers
+- overfitting the chain to one project's payload shape
+
+## Validation
+
+Verify the technique by confirming that:
+- the intent payload is accepted or rejected by explicit normalization rules
+- the normalized plan is written as an artifact before dry-run validation
+- the dry-run step performs no real side effects
+- chain artifacts can be traced across adapter, dry-run, and contract-check stages
+- contract-check output can fail the workflow on structural or routing violations
+
+See `checks/chain-contract-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- intent schema names
+- plan schema names
+- artifact filenames
+- whether trace or intent IDs are optional or required
+- dry-run engines and downstream validators
+
+What should stay invariant:
+- intent is normalized before execution
+- dry-run happens before any real action path
+- chain artifacts are explicit
+- contract-check validates the produced artifacts rather than relying on logs alone
+
+## Public sanitization notes
+
+ATM10-specific intent names, UI coordinates, fixture payload details, and project-specific run naming were removed. The published version preserves only the reusable chain pattern: intent input, normalized plan, dry-run artifacts, and contract validation.
+
+## Example
+
+See `examples/minimal-intent-chain.md`.
+
+## Checks
+
+See `checks/chain-contract-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated through adapter, dry-run chain, contract-check, and regression-test layers
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add a companion technique for onboarding new intent types safely
+- add examples from a non-UI automation system
+- add optional guidance for compatibility evolution across intent and plan schemas

--- a/techniques/agent-workflows/intent-plan-dry-run-contract-chain/checks/chain-contract-checklist.md
+++ b/techniques/agent-workflows/intent-plan-dry-run-contract-chain/checks/chain-contract-checklist.md
@@ -1,0 +1,11 @@
+# Chain Contract Checklist
+
+Use this checklist to validate whether a workflow really follows `intent-plan-dry-run-contract-chain`.
+
+- The intent payload is well-formed and validated before planning.
+- A normalized plan artifact is written.
+- The execution step is dry-run only and performs no real side effects.
+- Chain artifacts such as `run.json`, plan output, and summary files exist.
+- Contract-check validates expected intent routing or equivalent dispatch rules.
+- Exit behavior is explicit.
+- Traceability metadata is preserved when required.

--- a/techniques/agent-workflows/intent-plan-dry-run-contract-chain/examples/minimal-intent-chain.md
+++ b/techniques/agent-workflows/intent-plan-dry-run-contract-chain/examples/minimal-intent-chain.md
@@ -1,0 +1,42 @@
+# Minimal Intent Chain
+
+This example shows a generic automation chain that turns high-level intent into a dry-run-only validation path.
+
+## Input intent
+
+```json
+{
+  "schema_version": "example_intent_v1",
+  "intent_type": "open_status_panel",
+  "goal": "open the status panel and inspect current state",
+  "intent_id": "intent-001",
+  "trace_id": "trace-001"
+}
+```
+
+## Flow
+
+1. Normalize the intent into a plan artifact.
+2. Attach planning metadata such as `intent_type`, adapter identity, and traceability IDs.
+3. Run a dry-run executor against the plan.
+4. Emit `run.json`, `automation_plan.json`, and `chain_summary.json`.
+5. Run a contract-check that validates expected routing and structural completeness.
+
+## Contract-check summary
+
+```json
+{
+  "ok": true,
+  "status": "ok",
+  "observed": {
+    "intent_type": "open_status_panel",
+    "trace_id": "trace-001",
+    "intent_id": "intent-001"
+  },
+  "violations": []
+}
+```
+
+## Traceability note
+
+If the workflow requires `trace_id` or `intent_id`, the contract-check should fail when those fields are missing rather than silently downgrading traceability.


### PR DESCRIPTION
## Summary
Adds the public technique AOA-T-0004 as promoted.

## What Changed
- Added TECHNIQUE.md for intent-plan-dry-run-contract-chain
- Added a generic example outline
- Added a validation checklist
- Updated TECHNIQUE_INDEX.md

## Validation
- Diff is scoped to 4 files
- Technique doc includes the required sections
- Content was reviewed for public hygiene and strips ATM10-specific payloads and coordinates

## Notes
- No scripts, schemas, or automation tooling were added
- 
ew-intent-rollout-checklist is intentionally deferred to a later PR