### PR TITLE
technique: add new-intent-rollout-checklist

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -16,6 +16,7 @@ This file is the repository-wide map of public techniques.
 | AOA-T-0002 | source-of-truth-layout | docs | promoted | Repository document role separation to reduce drift |
 | AOA-T-0003 | contract-first-smoke-summary | evaluation | promoted | Runnable smoke pattern with machine-readable summary as the primary validation contract |
 | AOA-T-0004 | intent-plan-dry-run-contract-chain | agent-workflows | promoted | Safe workflow that normalizes intent into a traceable plan, validates it with dry-run, and enforces contract checks |
+| AOA-T-0005 | new-intent-rollout-checklist | agent-workflows | promoted | Checklist for safely adding a new intent type to an intent-plan-dry-run chain without contract drift |
 
 ## Deprecated techniques
 

--- a/techniques/agent-workflows/new-intent-rollout-checklist/TECHNIQUE.md
+++ b/techniques/agent-workflows/new-intent-rollout-checklist/TECHNIQUE.md
@@ -1,0 +1,126 @@
+---
+id: AOA-T-0005
+name: new-intent-rollout-checklist
+domain: agent-workflows
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/RUNBOOK.md
+  note: Derived from a real CI rollout policy for safely adding a new intent_type to a dry-run automation chain without contract drift.
+owners:
+  - 8Dionysus
+tags:
+  - agent-workflow
+  - automation
+  - rollout
+  - dry-run
+summary: Checklist for safely adding a new intent type to an intent-plan-dry-run chain without contract drift.
+---
+
+# new-intent-rollout-checklist
+
+## Intent
+
+Add a new `intent_type` to an existing `intent -> plan -> dry-run -> contract-check` pipeline without losing traceability, artifact consistency, or dry-run safety.
+
+## When to use
+
+- an automation chain already exists and supports dry-run validation
+- new intent types need a repeatable onboarding path
+- CI or operator review depends on machine-readable summaries
+- the team wants extension work to stay bounded and reviewable
+
+## When not to use
+
+- there is no stable intent-chain contract yet
+- the rollout path performs real side effects before dry-run validation
+- the system does not use fixtures, artifacts, or regression checks
+
+## Inputs
+
+- an existing intent-chain workflow with normalization, dry-run, and contract-check steps
+- a canonical fixture location for new intent payloads
+- a contract-check step that can assert expected routing
+- CI or another review surface that publishes artifacts
+
+## Outputs
+
+- one canonical fixture for the new intent
+- one dedicated smoke path for the new intent rollout
+- one machine-readable contract summary for the new intent path
+- at least one regression test covering the dry-run chain
+
+## Core procedure
+
+1. Add one canonical fixture for the new intent rollout.
+2. Ensure the fixture includes traceability fields such as `intent_id` and `trace_id` when policy requires them.
+3. Add a dedicated chain smoke step that runs the new fixture through the existing intent-to-plan-to-dry-run path.
+4. Add a strict contract-check step with explicit `expected_intent_type`.
+5. Wire the resulting summary output into CI reports or published artifacts.
+6. Add at least one regression test that exercises the dry-run chain for the new intent.
+
+## Contracts
+
+- one canonical fixture exists for each new intent rollout
+- the rollout path stays dry-run only
+- contract-check validates expected intent routing
+- machine-readable summary output is published
+- artifact paths match between smoke and check steps
+- traceability metadata is preserved when required by policy
+- exit behavior is explicit on contract failure
+
+## Risks
+
+- fixture drift can make the rollout look green while real inputs diverge
+- intent routing can regress silently if contract checks stop asserting the expected type
+- traceability fields can disappear during normalization if the rollout checklist is applied only partially
+
+## Validation
+
+Verify the technique by confirming that:
+- the canonical fixture exists and matches the new intent contract
+- the smoke path runs the new intent through the full dry-run chain
+- contract-check produces a machine-readable summary and fails on routing drift
+- artifact paths used by the smoke step and check step stay aligned
+- at least one regression test covers the new intent rollout
+
+See `checks/intent-rollout-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- fixture locations and naming conventions
+- minimum action or step thresholds
+- summary filenames
+- whether `trace_id` and `intent_id` are optional or required
+- CI systems and artifact publishing surfaces
+
+What should stay invariant:
+- each new intent rollout has one canonical fixture
+- rollout uses the existing dry-run chain rather than a parallel shortcut path
+- contract-check asserts the expected routing explicitly
+- rollout produces machine-readable output suitable for review
+
+## Public sanitization notes
+
+ATM10-specific intent names, fixture payload details, UI-specific behavior, and project run directory naming were removed. The public version keeps only the reusable rollout checklist and placeholder pattern such as `<new_intent_type>`.
+
+## Example
+
+See `examples/minimal-intent-rollout.md`.
+
+## Checks
+
+See `checks/intent-rollout-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated through canonical fixtures, dry-run smoke, contract-checks, and regression tests
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add a companion technique for troubleshooting failed new-intent rollouts
+- add a variant for non-CI operator approval workflows
+- add cross-version guidance for evolving intent schemas safely

--- a/techniques/agent-workflows/new-intent-rollout-checklist/checks/intent-rollout-checklist.md
+++ b/techniques/agent-workflows/new-intent-rollout-checklist/checks/intent-rollout-checklist.md
@@ -1,0 +1,9 @@
+# intent-rollout-checklist
+
+- canonical fixture exists for the new intent path
+- fixture includes required traceability fields when policy requires them
+- dedicated smoke path exists for the new intent
+- contract-check asserts the expected intent type
+- machine-readable summary is produced and published
+- regression test exists for the new intent rollout
+- rollout remains dry-run only

--- a/techniques/agent-workflows/new-intent-rollout-checklist/examples/minimal-intent-rollout.md
+++ b/techniques/agent-workflows/new-intent-rollout-checklist/examples/minimal-intent-rollout.md
@@ -1,0 +1,50 @@
+# minimal-intent-rollout
+
+This example shows a generic checklist-shaped rollout for a new dry-run intent path.
+
+## 1. Add the canonical fixture
+
+Create one public fixture placeholder such as:
+
+```json
+{
+  "schema_version": "intent_v1",
+  "intent_type": "<new_intent_type>",
+  "intent_id": "intent-demo-001",
+  "trace_id": "trace-demo-001",
+  "goal": "Describe the operator-facing goal here"
+}
+```
+
+Store it in a stable location such as `tests/fixtures/intent_<new_intent_type>.json`.
+
+## 2. Add one dedicated chain smoke command
+
+```bash
+python scripts/intent_chain_smoke.py \
+  --intent-json tests/fixtures/intent_<new_intent_type>.json \
+  --runs-dir runs/ci-smoke-intent-chain-<new_intent_type>
+```
+
+## 3. Add one strict contract-check command
+
+```bash
+python scripts/check_intent_chain_contract.py \
+  --runs-dir runs/ci-smoke-intent-chain-<new_intent_type> \
+  --expected-intent-type <new_intent_type> \
+  --require-trace-id \
+  --require-intent-id \
+  --summary-json runs/ci-smoke-intent-chain-<new_intent_type>/contract_summary.json
+```
+
+## 4. Publish the artifacts
+
+Make the smoke run and contract summary part of the same review surface:
+
+- include one summary row for `<new_intent_type>` in CI output
+- upload `contract_summary.json` with the rest of the smoke artifacts
+- keep the artifact path stable so humans and agents can find it without log scraping
+
+## 5. Add one regression expectation
+
+Add at least one automated test that proves the new intent flows through normalization, dry-run, and contract-check without real side effects.


### PR DESCRIPTION
## Summary
Adds the public technique AOA-T-0005 as promoted.

## What Changed
- Added TECHNIQUE.md for 
ew-intent-rollout-checklist
- Added a generic rollout example
- Added a validation checklist
- Updated TECHNIQUE_INDEX.md

## Validation
- Diff is scoped to 4 files
- Technique doc includes the required sections
- Content was reviewed for public hygiene and removes ATM10-specific intent names and fixture payload details

## Notes
- No scripts, schemas, or automation tooling were added
- Troubleshooting and gateway rollout patterns are intentionally deferred to later PRs