### PR TITLE
technique: add latest-alias-plus-history-copy

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -17,6 +17,7 @@ This file is the repository-wide map of public techniques.
 | AOA-T-0003 | contract-first-smoke-summary | evaluation | promoted | Runnable smoke pattern with machine-readable summary as the primary validation contract |
 | AOA-T-0004 | intent-plan-dry-run-contract-chain | agent-workflows | promoted | Safe workflow that normalizes intent into a traceable plan, validates it with dry-run, and enforces contract checks |
 | AOA-T-0005 | new-intent-rollout-checklist | agent-workflows | promoted | Checklist for safely adding a new intent type to an intent-plan-dry-run chain without contract drift |
+| AOA-T-0006 | latest-alias-plus-history-copy | evaluation | promoted | Dual-write summary pattern that keeps a stable latest alias, preserves nested history, and prevents double-count accumulation |
 
 ## Deprecated techniques
 

--- a/techniques/evaluation/latest-alias-plus-history-copy/TECHNIQUE.md
+++ b/techniques/evaluation/latest-alias-plus-history-copy/TECHNIQUE.md
@@ -1,0 +1,129 @@
+---
+id: AOA-T-0006
+name: latest-alias-plus-history-copy
+domain: evaluation
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/RUNBOOK.md
+  note: Derived from a real summary pipeline that writes a stable latest alias plus a nested history copy and uses anti-double-count readers for collectors and review surfaces.
+owners:
+  - 8Dionysus
+tags:
+  - evaluation
+  - summaries
+  - history
+  - contracts
+summary: Dual-write summary pattern that keeps a stable latest alias, preserves nested history, and prevents double-count accumulation.
+---
+
+# latest-alias-plus-history-copy
+
+## Intent
+
+Keep machine-readable summaries easy to discover for consumers while also preserving a trustworthy run-by-run history that scanners can accumulate without double-counting.
+
+## When to use
+
+- summary-producing checks need one stable consumer-facing path
+- history collectors or trend scanners need per-run rows
+- review surfaces need both latest state and historical accumulation
+- the project is introducing history retention without breaking existing consumers
+
+## When not to use
+
+- summaries are purely ephemeral and no latest or history contract is needed
+- consumers already address immutable per-run objects directly and do not need an alias
+- the project cannot keep reader behavior explicit when both alias and history are present
+
+## Inputs
+
+- one machine-readable summary payload
+- one stable latest alias path
+- one per-run directory
+- reader logic that scans history for accumulation
+
+## Outputs
+
+- stable latest alias for the newest summary
+- nested history copy under `run_dir`
+- path metadata linking both outputs when producers emit paths
+- reader behavior that avoids alias plus history double-counting
+
+## Core procedure
+
+1. Define one stable latest alias path for the current summary.
+2. Create a per-run directory for each execution.
+3. Write the same summary payload to the latest alias and to a history copy under `run_dir`.
+4. Expose both paths in artifact metadata when the producer emits path fields such as `summary_json` and `history_summary_json`.
+5. Make collectors scan nested history copies first when building accumulation or trends.
+6. Allow fallback to the top-level latest alias only for legacy layouts where no history rows exist yet.
+7. If the pattern is introduced as a hotfix, start valid accumulation from the first dual-write run instead of inventing backfill.
+
+## Contracts
+
+- the latest alias path is stable and consumer-facing
+- the history copy lives under `run_dir`
+- the history copy path differs from the latest alias path
+- schema and status match between latest alias and history copy
+- readers avoid double-counting by preferring nested history rows
+- fallback behavior is explicit and limited to legacy layouts without history rows
+- if path metadata is emitted, it matches the actual file layout
+
+## Risks
+
+- latest alias and history copy can drift if only one path is updated
+- collectors can silently double-count if they read both alias and nested rows as independent runs
+- ad hoc backfill can corrupt accumulation windows if older single-write runs are mixed with dual-write runs without policy
+
+## Validation
+
+Verify the technique by confirming that:
+- the latest alias exists at the stable expected path
+- the history copy exists under `run_dir`
+- the history copy differs from the latest alias
+- emitted `summary_json` and `history_summary_json` fields match real files when present
+- schema and status match between the alias and history copy
+- collectors ignore the alias when nested history rows are available
+- fallback to latest alias happens only when no nested rows exist
+
+See `checks/dual-write-history-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- summary filenames
+- run directory naming conventions
+- whether `run.json` is emitted alongside the summary
+- local filesystem, object-store, or equivalent alias and history layouts
+- explicit backfill policies for migrations
+
+What should stay invariant:
+- one stable latest alias exists for consumers
+- one nested history copy exists for accumulation
+- readers prefer nested history rows
+- fallback behavior is explicit instead of accidental
+
+## Public sanitization notes
+
+ATM10-specific gateway names, nightly workflow names, UTC guardrail details, and repo-specific run roots were removed. The public version keeps only the reusable dual-write and anti-double-count pattern for machine-readable summaries.
+
+## Example
+
+See `examples/minimal-latest-history-layout.md`.
+
+## Checks
+
+See `checks/dual-write-history-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated through dual-write summary producers, nested-history-first collectors, and integrity checks over alias and history invariants
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add a companion technique for integrity checks over published summary layouts
+- add an adaptation example for object-store backed artifacts
+- add guidance for safe migration from single-write to dual-write history

--- a/techniques/evaluation/latest-alias-plus-history-copy/checks/dual-write-history-checklist.md
+++ b/techniques/evaluation/latest-alias-plus-history-copy/checks/dual-write-history-checklist.md
@@ -1,0 +1,9 @@
+# dual-write-history-checklist
+
+- latest alias exists at the stable expected path
+- history copy exists under `run_dir`
+- history copy differs from latest alias
+- emitted `summary_json` and `history_summary_json` match actual files when present
+- schema and status match between latest alias and history copy
+- readers exclude the alias when nested history rows exist
+- legacy fallback is explicit and only used when no nested rows exist

--- a/techniques/evaluation/latest-alias-plus-history-copy/examples/minimal-latest-history-layout.md
+++ b/techniques/evaluation/latest-alias-plus-history-copy/examples/minimal-latest-history-layout.md
@@ -1,0 +1,41 @@
+# minimal-latest-history-layout
+
+This example shows a generic dual-write layout for a machine-readable summary.
+
+## Layout
+
+```text
+runs/
+  latest-check/
+    summary.json
+    20260313_101500-check/
+      run.json
+      summary.json
+```
+
+- `runs/latest-check/summary.json` is the stable latest alias.
+- `runs/latest-check/20260313_101500-check/summary.json` is the history copy for one execution.
+
+## Producer metadata
+
+If the producer emits path metadata, keep both paths explicit:
+
+```json
+{
+  "paths": {
+    "run_dir": "runs/latest-check/20260313_101500-check",
+    "summary_json": "runs/latest-check/summary.json",
+    "history_summary_json": "runs/latest-check/20260313_101500-check/summary.json"
+  }
+}
+```
+
+## Reader rule
+
+Use nested history rows first:
+
+1. Scan `runs/latest-check/**/summary.json`.
+2. If nested rows exist, accumulate only those rows.
+3. If no nested rows exist, fall back to `runs/latest-check/summary.json` for legacy compatibility.
+
+This keeps the latest alias easy to consume without letting scanners count the same run twice.


### PR DESCRIPTION
## Summary
Adds the public technique AOA-T-0006 as promoted.

## What Changed
- Added TECHNIQUE.md for latest-alias-plus-history-copy
- Added a generic layout example
- Added a validation checklist
- Updated TECHNIQUE_INDEX.md

## Validation
- Diff is scoped to 4 files
- Technique doc includes the required sections
- Content was reviewed for public hygiene and removes ATM10-specific gateway and nightly naming

## Notes
- No scripts, schemas, or automation tooling were added
- signal-first-gate-promotion and 	elemetry-integrity-snapshot are intentionally deferred to later PRs