### PR TITLE
technique: add signal-first-gate-promotion

### DIFF
--- a/TECHNIQUE_INDEX.md
+++ b/TECHNIQUE_INDEX.md
@@ -18,6 +18,7 @@ This file is the repository-wide map of public techniques.
 | AOA-T-0004 | intent-plan-dry-run-contract-chain | agent-workflows | promoted | Safe workflow that normalizes intent into a traceable plan, validates it with dry-run, and enforces contract checks |
 | AOA-T-0005 | new-intent-rollout-checklist | agent-workflows | promoted | Checklist for safely adding a new intent type to an intent-plan-dry-run chain without contract drift |
 | AOA-T-0006 | latest-alias-plus-history-copy | evaluation | promoted | Dual-write summary pattern that keeps a stable latest alias, preserves nested history, and prevents double-count accumulation |
+| AOA-T-0007 | signal-first-gate-promotion | evaluation | promoted | Staged pattern for promoting an observed validation signal into strict enforcement without losing diagnostics or widening the fail surface too early |
 
 ## Deprecated techniques
 

--- a/techniques/evaluation/signal-first-gate-promotion/TECHNIQUE.md
+++ b/techniques/evaluation/signal-first-gate-promotion/TECHNIQUE.md
@@ -1,0 +1,133 @@
+---
+id: AOA-T-0007
+name: signal-first-gate-promotion
+domain: evaluation
+status: promoted
+origin:
+  project: atm10-agent
+  path: docs/RUNBOOK.md
+  note: Derived from a real gate rollout where critical regressions were first observed in signal-only mode, then promoted through readiness, governance, progress, and transition telemetry before strict enforcement was enabled on a narrow surface.
+owners:
+  - 8Dionysus
+tags:
+  - evaluation
+  - gates
+  - rollout
+  - diagnostics
+summary: Staged pattern for promoting an observed validation signal into strict enforcement without losing diagnostics or widening the fail surface too early.
+---
+
+# signal-first-gate-promotion
+
+## Intent
+
+Turn an observed validation signal into a hard gate gradually, so the team can collect evidence, preserve diagnostics, and choose a narrow enforcement surface before fail-fast behavior becomes operational.
+
+## When to use
+
+- a machine-readable check already exists and can emit stable summaries
+- the team wants to observe regressions before converting them into hard failures
+- different execution surfaces need different risk levels
+- promotion to strict mode should be justified by history rather than one bad or good run
+
+## When not to use
+
+- the check is too immature to produce stable summary output
+- the project needs immediate hard blocking and does not need a staged rollout
+- there is no place to retain history or publish diagnostics across runs
+
+## Inputs
+
+- one summary-producing validation check
+- an observational mode such as `signal_only`
+- a stricter enforcement mode such as `fail_nightly`
+- history over repeated runs
+- decision telemetry layers that evaluate promotion readiness
+
+## Outputs
+
+- stable summaries from both observational and strict runs
+- evidence-based readiness and governance decisions
+- progress telemetry that shows remaining gap to promotion
+- one explicitly chosen strict enforcement surface
+- preserved diagnostics even when the strict surface fails
+
+## Core procedure
+
+1. Start with one stable summary-producing check in `signal_only` mode.
+2. Keep artifacts and summaries published even when the signal is bad.
+3. Add a readiness layer that measures whether the signal is stable enough for stricter enforcement.
+4. Add a governance layer that turns readiness history into explicit `go` or `hold`.
+5. Add a progress layer that reports the remaining gap to promotion.
+6. Add a transition layer that records promotion telemetry while strict enforcement is activated only on the chosen narrow surface.
+7. Keep other surfaces in signal mode until an explicit promotion decision exists.
+8. Preserve diagnostics with always-published summaries even after strict failures.
+
+## Contracts
+
+- the same underlying summary contract is used in both `signal_only` and strict modes
+- `signal_only` returns success for valid snapshots even when the signal is bad
+- strict mode returns non-zero only on the explicitly chosen enforcement surface
+- promotion is evidence-based through history, not implicit drift
+- readiness, governance, progress, and transition remain decision telemetry rather than hidden runtime logic
+- diagnostics remain published even when the strict surface goes red
+- non-promoted surfaces do not silently inherit strict behavior
+
+## Risks
+
+- promoting too early from a shallow history window
+- letting strict behavior spread from one intended surface into unrelated paths
+- losing diagnostic summaries exactly when strict mode starts failing
+- mixing decision telemetry with runtime gating so the rollout becomes harder to reason about
+
+## Validation
+
+Verify the technique by confirming that:
+- the observational mode always publishes machine-readable output
+- the same summary contract is still readable after strict mode is introduced
+- readiness uses history rather than a single run
+- governance makes `go` or `hold` explicit
+- progress reports the remaining gap to promotion
+- diagnostics still publish when the strict surface fails
+- non-promoted surfaces remain observational
+
+See `checks/gate-promotion-checklist.md`.
+
+## Adaptation notes
+
+What can vary across projects:
+- signal names and severity models
+- readiness windows and thresholds
+- history limits and streak rules
+- enforcement surfaces such as nightly jobs, scheduled workflows, release trains, or dedicated ops runs
+- manual override policy when it is explicit and auditable
+
+What should stay invariant:
+- promotion is staged rather than immediate
+- one narrow surface is chosen for strict enforcement
+- observational surfaces continue publishing diagnostics
+- evidence and decision layers stay explicit
+
+## Public sanitization notes
+
+ATM10-specific gateway names, exact thresholds, workflow names, and project-specific nightly paths were removed. The public version preserves only the reusable staged-promotion pattern and the distinction between observation surfaces and strict surfaces.
+
+## Example
+
+See `examples/minimal-signal-first-rollout.md`.
+
+## Checks
+
+See `checks/gate-promotion-checklist.md`.
+
+## Promotion history
+
+- born in `atm10-agent`
+- validated through summary contracts, history-based readiness, explicit `go|hold` governance, progress telemetry, and a narrow strict enforcement surface
+- promoted to `aoa-techniques` on 2026-03-13
+
+## Future evolution
+
+- add a companion technique for remediation snapshots built on top of promoted gates
+- add a variant for multi-surface promotion across release trains
+- add guidance for demotion back to signal mode after unstable strict rollout

--- a/techniques/evaluation/signal-first-gate-promotion/checks/gate-promotion-checklist.md
+++ b/techniques/evaluation/signal-first-gate-promotion/checks/gate-promotion-checklist.md
@@ -1,0 +1,9 @@
+# gate-promotion-checklist
+
+- signal-only mode publishes machine-readable output
+- strict mode is introduced only on an explicit enforcement surface
+- readiness uses history rather than a single run
+- governance makes `go` or `hold` explicit
+- progress reports the remaining gap to promotion
+- diagnostics still publish when the strict surface fails
+- non-promoted surfaces do not silently inherit strict failure behavior

--- a/techniques/evaluation/signal-first-gate-promotion/examples/minimal-signal-first-rollout.md
+++ b/techniques/evaluation/signal-first-gate-promotion/examples/minimal-signal-first-rollout.md
@@ -1,0 +1,52 @@
+# minimal-signal-first-rollout
+
+This example shows a generic staged promotion path from observation to strict enforcement.
+
+## 1. Start in `signal_only`
+
+Run one summary-producing check in observational mode:
+
+```bash
+python scripts/check_service_health.py --policy signal_only --summary-json runs/health/latest_summary.json
+```
+
+- the summary is still published when the signal is bad
+- exit behavior stays non-blocking while the signal is being calibrated
+
+## 2. Add readiness over recent history
+
+Build a readiness summary from recent published runs:
+
+```bash
+python scripts/check_service_health_readiness.py --history-dir runs/health-history --policy report_only --summary-json runs/health-readiness/readiness_summary.json
+```
+
+The readiness layer asks whether the signal has been stable enough for a stricter rollout.
+
+## 3. Make governance explicit
+
+Turn readiness evidence into a formal decision:
+
+```bash
+python scripts/check_service_health_governance.py --readiness-dir runs/health-readiness --policy report_only --summary-json runs/health-governance/governance_summary.json
+```
+
+The output should be a clear `go` or `hold`, not an implicit guess.
+
+## 4. Publish progress telemetry
+
+Track the remaining gap:
+
+- runs still needed
+- streak still needed
+- reason codes explaining why promotion is not complete yet
+
+## 5. Promote one narrow strict surface
+
+When governance says `go`, enable strict behavior only on one narrow surface such as a nightly job:
+
+- nightly: strict `fail_nightly`
+- pull requests: still `signal_only`
+- local debugging: still observational
+
+Diagnostics should continue to publish even if the strict nightly run goes red.


### PR DESCRIPTION
## Summary
Adds the public technique AOA-T-0007 as promoted.

## What Changed
- Added TECHNIQUE.md for signal-first-gate-promotion
- Added a generic rollout example
- Added a validation checklist
- Updated TECHNIQUE_INDEX.md

## Validation
- Diff is scoped to 4 files
- Technique doc includes the required sections
- Content was reviewed for public hygiene and removes ATM10-specific gateway and workflow naming

## Notes
- No scripts, schemas, or automation tooling were added
- Remediation, integrity, and optional-source rendering patterns are intentionally deferred to later PRs