### PR TITLE
[codex] Show current release on README front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Public library of reusable techniques for coding agents and humans.
 
 `aoa-techniques` is the public practice canon of AoA. It is not a snippet dump and not an “awesome list”. A technique here is a minimal reproducible unit of engineering practice: a workflow, validation pattern, safety protocol, documentation layout, evaluation loop, or transfer method that can travel cleanly across projects.
 
+> Current release: `v0.4.0`. See [CHANGELOG](CHANGELOG.md) for release notes.
+
 ## Start here
 
 Use the shortest route by need:


### PR DESCRIPTION
## What changed
- add a short `Current release` banner to the top-level README so the GitHub main page shows the latest released version
- fix the stale `v0.1.0` wording in `aoa-playbooks` so the README no longer advertises an old public baseline

## Why
The release tags and changelogs were updated, but the repository front pages did not surface the new release versions clearly. That left the public main pages stale or silent.

## Validation
- audited each README banner against the repository's latest tag
- local README-only doc diff review
