### PR TITLE
[codex] Add release audit baseline

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -1,4 +1,4 @@
-name: Repo Validation
+name: Release Audit
 
 on:
   push:
@@ -7,7 +7,8 @@ on:
   pull_request:
 
 jobs:
-  validate:
+  release_audit:
+    name: Release Audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,5 +22,5 @@ jobs:
       - name: Install validator dependencies
         run: python -m pip install -r requirements-dev.txt
 
-      - name: Run bounded release check
+      - name: Run release audit
         run: python scripts/release_check.py


### PR DESCRIPTION
## What changed
- renamed the default CI workflow/job to `Release Audit` while preserving the existing repo-owned release check entrypoint

## Why
- standardize the required release check name across the federation without changing the repo-local release proof loop

## Validation
- `python scripts/release_check.py`