### PR TITLE
Normalize latest release changelog contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is intentionally simple and human-first.
 
 ## [0.4.0] - 2026-04-10
 
+### Summary
+
+- this release adds workspace ingress and mutation-gate techniques, audit-to-closeout proof loops, promotion-readiness surfaces, live technique receipt publishing, and antifragility/via-negativa guidance
+- pinned validation evidence, repo/root scouting, and current-practice posture are strengthened while new shared-substrate and owner-sync techniques are promoted into the public set
+- `aoa-techniques` remains a curated public corpus and documentation surface rather than a package or registry authority
+
+### Validation
+
+- `python scripts/release_check.py`
+
+### Notes
+
+- detailed corpus, generated-surface, report, and validation-asset coverage for this release remains enumerated below under `Added`, `Changed`, and `Included in this release`
+
 ### Added
 
 - workspace ingress and mutation-gate techniques plus audit-to-closeout


### PR DESCRIPTION
## Summary
- normalize the latest tagged changelog section to the new `Summary` / `Validation` / `Notes` contract
- keep existing `Added` / `Changed` / `Included in this release` detail intact

## Why
`aoa release audit --phase preflight` now requires the latest tagged section to expose the contract that powers GitHub Release highlights and postpublish validation.

## Verification
- `git diff --check`
- spot-checked `aoa release audit --phase preflight` contract parsing before publish
