### PR TITLE
Add current-direction route locks

### DIFF
--- a/tests/test_current_direction_routes.py
+++ b/tests/test_current_direction_routes.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CurrentDirectionRoutesTestCase(unittest.TestCase):
+    def test_root_entrypoints_route_to_roadmap(self) -> None:
+        roadmap_path = REPO_ROOT / "ROADMAP.md"
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertTrue(roadmap_path.is_file())
+        self.assertIn("ROADMAP.md", readme)
+        self.assertIn("ROADMAP.md", agents)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small regression lock for the repo's current-direction surface
- keep root `README.md` and `AGENTS.md` routed to the repo's canonical `ROADMAP.md` or equivalent current entry surface

## Testing
- run the repo-native targeted test for `tests/test_current_direction_routes.py`
