### PR TITLE
Align roadmap with v0.4 technique wave

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,12 @@ Historical note:
 
 - current verification path: read-only current-state checks via `python scripts/validate_repo.py` plus `python -m unittest discover -s tests`, and bounded release-prep parity via `python scripts/release_check.py`
 - current corpus split: `99` bundles, `25 canonical`, `74 promoted`
+- current release contour: `v0.4.0` carries the workspace ingress and mutation
+  gate, audit-to-closeout proof loop, recommendation-truth-versus-host
+  actionability split, canonical-owner mirror, GitHub-only owner endcap, pinned
+  validation matrix, antifragility recovery, receipt-first failure analysis,
+  isolated-service-stop, live receipt publishing, promotion-readiness, and via
+  negativa surfaces listed below
 - repo-only hardening is largely landed; the main open work is now external-evidence execution rather than missing internal infrastructure
 - recent canonical closures since the baseline below:
   - [AOA-T-0018](techniques/docs/markdown-technique-section-lift/TECHNIQUE.md)
@@ -31,9 +37,18 @@ Historical note:
   - [Promotion Wave A Runbook](docs/PROMOTION_WAVE_A_RUNBOOK.md)
   - [External Evidence Sprint Runbook](docs/EXTERNAL_EVIDENCE_SPRINT_RUNBOOK.md)
   - [External Evidence Ledger](docs/EXTERNAL_EVIDENCE_LEDGER.md)
-- latest internal-origin promoted additions:
+- latest internal-origin promoted additions and `v0.4.0` practice wave:
   - [AOA-T-0089](techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md)
   - [AOA-T-0090](techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md)
+  - [AOA-T-0091](techniques/agent-workflows/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md)
+  - [AOA-T-0092](techniques/agent-workflows/audit-to-closeout-proof-loop/TECHNIQUE.md)
+  - [AOA-T-0093](techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md)
+  - [AOA-T-0094](techniques/docs/canonical-owner-with-validated-mirror/TECHNIQUE.md)
+  - [AOA-T-0095](techniques/agent-workflows/github-only-owner-endcap-with-reality-sync/TECHNIQUE.md)
+  - [AOA-T-0096](techniques/agent-workflows/pinned-validation-matrix-before-generated-publish/TECHNIQUE.md)
+  - [AOA-T-0097](techniques/system-recovery/degrade-reground-recover/TECHNIQUE.md)
+  - [AOA-T-0098](techniques/validation-patterns/receipt-first-failure-analysis/TECHNIQUE.md)
+  - [AOA-T-0099](techniques/system-recovery/isolated-service-stop-on-shared-substrate/TECHNIQUE.md)
 - current closest promoted queue item: [AOA-T-0032](techniques/evaluation/context-report-for-ci/TECHNIQUE.md)
 - current external-evidence lead sprint:
   - [AOA-T-0032](techniques/evaluation/context-report-for-ci/TECHNIQUE.md)
@@ -48,6 +63,10 @@ Historical note:
 - current long-gap holds remain:
   - [AOA-T-0005](techniques/agent-workflows/new-intent-rollout-checklist/TECHNIQUE.md)
   - [AOA-T-0022](techniques/docs/risk-and-negative-effect-lift/TECHNIQUE.md)
+- Roadmap drift is a technique-layer risk: if this file lags the public index
+  and release notes, readers may treat shipped promoted techniques as invisible
+  or infer status changes that belong in technique bundles and generated
+  manifests, not in the roadmap
 
 ## Baseline
 

--- a/tests/test_roadmap_parity.py
+++ b/tests/test_roadmap_parity.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+CURRENT_RELEASE_TECHNIQUES = (
+    ("AOA-T-0091", "techniques/agent-workflows/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md"),
+    ("AOA-T-0092", "techniques/agent-workflows/audit-to-closeout-proof-loop/TECHNIQUE.md"),
+    ("AOA-T-0093", "techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md"),
+    ("AOA-T-0094", "techniques/docs/canonical-owner-with-validated-mirror/TECHNIQUE.md"),
+    ("AOA-T-0095", "techniques/agent-workflows/github-only-owner-endcap-with-reality-sync/TECHNIQUE.md"),
+    ("AOA-T-0096", "techniques/agent-workflows/pinned-validation-matrix-before-generated-publish/TECHNIQUE.md"),
+    ("AOA-T-0097", "techniques/system-recovery/degrade-reground-recover/TECHNIQUE.md"),
+    ("AOA-T-0098", "techniques/validation-patterns/receipt-first-failure-analysis/TECHNIQUE.md"),
+    ("AOA-T-0099", "techniques/system-recovery/isolated-service-stop-on-shared-substrate/TECHNIQUE.md"),
+)
+
+
+CURRENT_RELEASE_SURFACES = (
+    "generated/technique_promotion_readiness.min.json",
+    "scripts/publish_live_receipts.py",
+    "docs/VIA_NEGATIVA_CHECKLIST.md",
+)
+
+
+class RoadmapParityTestCase(unittest.TestCase):
+    def test_roadmap_matches_current_v0_4_0_release_contour(self) -> None:
+        roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        technique_index = (REPO_ROOT / "TECHNIQUE_INDEX.md").read_text(encoding="utf-8")
+
+        self.assertIn("Current release: `v0.4.0`", readme)
+        self.assertIn("## [0.4.0]", changelog)
+        self.assertIn("`v0.4.0`", roadmap)
+        self.assertIn("`99` bundles", roadmap)
+        self.assertIn("Roadmap drift", roadmap)
+        self.assertIn("does not change technique status", roadmap)
+
+        for technique_id, technique_path in CURRENT_RELEASE_TECHNIQUES:
+            with self.subTest(technique=technique_id):
+                self.assertTrue((REPO_ROOT / technique_path).is_file())
+                self.assertIn(technique_id, technique_index)
+                self.assertIn(technique_id, roadmap)
+                self.assertIn(technique_path, roadmap)
+
+        for surface in CURRENT_RELEASE_SURFACES:
+            with self.subTest(surface=surface):
+                self.assertTrue((REPO_ROOT / surface).is_file())
+                self.assertIn(surface, readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update ROADMAP.md current live snapshot with the v0.4.0 technique wave through AOA-T-0091..AOA-T-0099
- call out live receipt publishing, promotion-readiness, pinned validation, antifragility, via-negativa, and owner-sync posture without changing technique status
- add roadmap parity coverage against README/CHANGELOG release markers, TECHNIQUE_INDEX IDs, and key current surfaces

## Validation
- python -m unittest tests.test_roadmap_parity
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py