### PR TITLE
Align technique promotion readiness matrix

### DIFF
--- a/docs/PROMOTION_READINESS_MATRIX.md
+++ b/docs/PROMOTION_READINESS_MATRIX.md
@@ -10,7 +10,8 @@ For the current actionable first wave, open [Promotion Wave A Runbook](PROMOTION
 
 ## Current Posture
 
-- current promoted corpus: `49` techniques
+- current promoted corpus: `74` techniques
+- matrix categorization status: `49` promoted techniques are explicitly categorized in the pack matrix below; `25` newer `v0.4` / session-harvest / recovery-wave promoted techniques (`AOA-T-0075` through `AOA-T-0099`) are tracked in generated promotion readiness and need one matrix-expansion pass before canonical-promotion debate
 - current approve-now queue: none
 - closest current queue item: [AOA-T-0032](../techniques/evaluation/context-report-for-ci/TECHNIQUE.md), because it now leads the remaining active Wave A set and has the clearest report-only contract among the still-promoted bundles
 - latest graduation wave: [AOA-T-0028](../techniques/agent-workflows/confirmation-gated-mutating-action/TECHNIQUE.md), [AOA-T-0031](../techniques/agent-workflows/shell-composable-agent-invocation/TECHNIQUE.md), [AOA-T-0044](../techniques/history/versionable-session-transcripts/TECHNIQUE.md), and [AOA-T-0053](../techniques/history/local-first-session-index/TECHNIQUE.md) moved to `canonical` on 2026-03-28 after exact-fit public reinforcement from GitHub Copilot coding-agent approvals, OpenAI Codex CLI `codex exec`, `claude-code-log`, and `coding-agent-search (cass)`
@@ -57,6 +58,7 @@ It narrows the next search space and closes false-positive local lanes, but it d
 | `external live-adopter lane` | `34` | Already has donor intake, documentation-first adaptation, and canonical-readiness review; still needs another real adopter outside the donor repo. |
 | `internal-origin second-consumer lane` | `9` | Internal or origin-lineage bundle needs another downstream consumer plus sibling-boundary reinforcement. |
 | `fresh extraction lane` | `3` | Has origin evidence only. The next step is second-context plus canonical-readiness scaffolding, not promotion debate. |
+| `v0.4 matrix-expansion lane` | `25` | Newer `v0.4`, session-harvest, and recovery-wave promoted bundles `AOA-T-0075` through `AOA-T-0099` are present in generated promotion readiness; the maintainer-facing pack matrix still needs bundle-by-bundle categorization before canonical-promotion debate. |
 
 ## Swarm Rule
 
@@ -335,19 +337,22 @@ Shared blocker: the donor Telegram family and repo-local adaptation both show a 
 
 ## Suggested Wave Order
 
-1. `Wave A - evidence-prep leaders`
+1. `Wave 0 - v0.4 matrix expansion`
+   - `AOA-T-0075` through `AOA-T-0099`
+   - goal: categorize newer promoted bundles from generated promotion readiness into this maintainer-facing pack matrix before any canonical-promotion debate
+2. `Wave A - evidence-prep leaders`
    - `AOA-T-0032`, `AOA-T-0026`, `AOA-T-0036`
    - goal: close the smallest honest blocker for the strongest current candidates without flipping status yet
-2. `Wave B - pack proof waves`
+3. `Wave B - pack proof waves`
    - shell-agent fast path
    - runtime operator stack
    - instruction-surface cluster
    - history artifacts
    - goal: secure one more live adopter per coherent pack, then reopen bundle-local canonical reviews
-3. `Wave C - fresh extraction follow-through`
+4. `Wave C - fresh extraction follow-through`
    - `AOA-T-0046`, `AOA-T-0047`, `AOA-T-0048`
    - goal: add second-context and canonical-readiness scaffolding only after a real non-origin consumer exists
-4. `Wave D - narrow status-transition PRs`
+5. `Wave D - narrow status-transition PRs`
    - open one `promoted -> canonical` PR per technique only after that bundle's own `canonical-readiness.md` can honestly switch to `approve for canonical promotion`
 
 ## Notes

--- a/tests/test_roadmap_parity.py
+++ b/tests/test_roadmap_parity.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import unittest
+from collections import Counter
 from pathlib import Path
 
 
@@ -28,6 +30,21 @@ CURRENT_RELEASE_SURFACES = (
 
 
 class RoadmapParityTestCase(unittest.TestCase):
+    def test_promotion_readiness_matrix_matches_generated_promoted_corpus(self) -> None:
+        catalog = json.loads((REPO_ROOT / "generated/technique_catalog.min.json").read_text(encoding="utf-8"))
+        techniques = catalog["techniques"]
+        status_counts = Counter(technique["status"] for technique in techniques)
+        promoted_count = status_counts["promoted"]
+
+        readiness_matrix = (REPO_ROOT / "docs/PROMOTION_READINESS_MATRIX.md").read_text(encoding="utf-8")
+
+        self.assertEqual(promoted_count, 74)
+        self.assertIn(f"current promoted corpus: `{promoted_count}` techniques", readiness_matrix)
+        self.assertIn("`49` promoted techniques are explicitly categorized", readiness_matrix)
+        self.assertIn("`25` newer `v0.4`", readiness_matrix)
+        self.assertIn("`v0.4 matrix-expansion lane` | `25`", readiness_matrix)
+        self.assertIn("`AOA-T-0075` through `AOA-T-0099`", readiness_matrix)
+
     def test_roadmap_matches_current_v0_4_0_release_contour(self) -> None:
         roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- update the promotion readiness matrix to match the generated promoted corpus count
- add the v0.4 matrix-expansion lane for newer promoted techniques AOA-T-0075 through AOA-T-0099
- add a roadmap parity test to keep the matrix aligned with the generated catalog

## Validation
- `python -m pytest -q tests/test_roadmap_parity.py`
- `python scripts/validate_repo.py`
- `python -m pytest -q tests`
- `git diff --check`

## Public-share review
- scope is limited to docs and tests
- no generated state, runtime logs, environment files, or credentials are included