### PR TITLE
[codex] Update GitHub Actions refs for Node24 compatibility

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What changed
- updated pinned `actions/checkout` references to `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- updated pinned `actions/setup-python` references to `a309ff8b426b58ec0e2a45f0f869d46889d02405` where present

## Why
GitHub Actions is moving off Node20-based action runtimes, and these workflows still referenced older Node20-era releases.

## Validation
- `git diff --check`
- parsed `.github/workflows/*.yml` and `.yaml` with `yaml.safe_load`
