### PR TITLE
[codex] Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## What Changed
+<!-- 1-3 short bullets. Keep it concrete; do not restate the whole diff. -->
+- ...
+
+## Why
+<!-- State the reason for the change, bug, gap, or opportunity. -->
+- ...
+
+## Validation
+<!-- List only checks that actually ran. If none, say Not run. -->
+- ...
+
+## Boundary / Direction Impact
+<!-- Optional.
+Use this section only when the change shifts a boundary, owner-fit, route, contract, provenance posture, proof semantics, runtime posture, or recurring composition logic.
+Allowed short answers:
+- None.
+- No boundary shift.
+- Exposed a new owner-fit: ...
+- Tightens/loosens the boundary between ... and ...
+- Changes the route from ... to ...
+Note compatibility impact, workflow contract shifts, boundary tightening/loosening, reusable execution assumptions, or control-plane consequences.
+-->
+- ...
+
+## Risk / Follow-ups
+<!-- Note remaining risk, deliberate non-goals, or next follow-up work. -->
+- ...


### PR DESCRIPTION
## What Changed
- added `.github/pull_request_template.md`
- kept the visible PR structure common across repositories
- tailored the hidden `Boundary / Direction Impact` prompt to the repository family

## Why
This gives solo + Codex sessions a stable PR rhythm without turning future project shifts into a rigid ontology.

## Validation
- `git diff --check`
