### PR TITLE
[codex] Align required check contracts

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -1,4 +1,4 @@
-name: Release Audit
+name: Repo Validation
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release_audit:
-    name: Release Audit
+    name: Repo Validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- rename the stable validation check from `Release Audit` to `Repo Validation`
- keep the underlying workflow behavior unchanged while aligning the required status contract on `main`
- preserve repo-specific extra checks where they exist

## Why
The repo family had drift between legacy check names and the branch protection contract. This change makes the required check surface consistent across repositories and easier to reason about in a solo + Codex workflow.

## Validation
- YAML parse for the touched workflow file
- `git diff --check`
