### PR TITLE
[codex] Add Agon recurrence technique manifests

### DIFF
--- a/docs/AGON_RECURRENCE_ADAPTER.md
+++ b/docs/AGON_RECURRENCE_ADAPTER.md
@@ -1,0 +1,34 @@
+# Agon Recurrence Adapter
+
+This repository exposes its Agon-facing surfaces to the recurrence control plane through owner-owned manifests.
+
+The adapter is observation-only.
+
+It can produce recurrence pressure such as:
+
+```text
+hint
+watch
+candidate
+review_ready
+```
+
+It cannot produce:
+
+```text
+arena session
+verdict
+scar
+retention schedule
+rank mutation
+Tree-of-Sophia promotion
+automatic source rewrite
+```
+
+The owner repository keeps its meaning. Recurrence only notices when a shape returns.
+
+## Component
+
+```text
+component:agon:technique-binding-surfaces
+```

--- a/manifests/recurrence/component.agon.technique-binding-surfaces.json
+++ b/manifests/recurrence/component.agon.technique-binding-surfaces.json
@@ -1,0 +1,190 @@
+{
+  "beacon_rules": [
+    {
+      "beacon_ref": "agon.techniques.practice_pressure",
+      "decision_surface": "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+      "kind": "new_technique_candidate",
+      "match_categories": [
+        "repeat_pattern",
+        "review_signal"
+      ],
+      "match_signals": [
+        "lawful_move_needs_practice",
+        "technique_candidate_repeated",
+        "practice_gap_repeated"
+      ],
+      "notes": "Lawful moves can request practice; recurrence must not promote techniques automatically.",
+      "observation_inputs": [
+        "agon-technique-binding-candidates"
+      ],
+      "recommended_actions": [
+        "review technique candidate boundedness",
+        "check overlap before promotion"
+      ],
+      "status_ladder": [
+        "hint",
+        "watch",
+        "candidate",
+        "review_ready"
+      ],
+      "suppress_when": [
+        "live_protocol_claim_present",
+        "hidden_authority_detected"
+      ],
+      "target_repo": "aoa-techniques",
+      "thresholds": {
+        "candidate_observations": 2,
+        "min_unique_evidence_refs": 2,
+        "min_unique_sources": 2,
+        "review_ready_observations": 3,
+        "watch_observations": 1
+      }
+    },
+    {
+      "beacon_ref": "agon.techniques.canon_overclaim_guard",
+      "decision_surface": "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+      "kind": "overclaim_alarm",
+      "match_categories": [
+        "overclaim_risk"
+      ],
+      "match_signals": [
+        "technique_claims_move_law",
+        "technique_claims_arena_authority"
+      ],
+      "notes": "Technique surfaces do not own Agon law.",
+      "observation_inputs": [
+        "agon-technique-bridge-docs"
+      ],
+      "recommended_actions": [
+        "return move law to center",
+        "keep technique as reusable practice"
+      ],
+      "status_ladder": [
+        "hint",
+        "watch",
+        "candidate",
+        "review_ready"
+      ],
+      "suppress_when": [
+        "live_protocol_claim_present",
+        "hidden_authority_detected"
+      ],
+      "target_repo": "aoa-techniques",
+      "thresholds": {
+        "candidate_observations": 2,
+        "min_unique_evidence_refs": 2,
+        "min_unique_sources": 2,
+        "review_ready_observations": 3,
+        "watch_observations": 1
+      }
+    }
+  ],
+  "candidate_targets": [
+    "generated/agon_technique_binding_candidates.min.json"
+  ],
+  "component_ref": "component:agon:technique-binding-surfaces",
+  "consumer_edges": [
+    {
+      "kind": "handoff_home",
+      "notes": "Owner remains the review home for its own Agon recurrence signals.",
+      "required": true,
+      "suggested_action": "observe",
+      "suggested_commands": [],
+      "target": "docs/AGON_RECURRENCE_ADAPTER.md",
+      "target_repo": "aoa-techniques"
+    }
+  ],
+  "contract_surfaces": [
+    "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+    "docs/AGON_WAVE4_TECHNIQUE_LANDING.md",
+    "docs/AGON_RECURRENCE_ADAPTER.md"
+  ],
+  "decision_surfaces": [
+    "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+    "docs/AGON_WAVE4_TECHNIQUE_LANDING.md"
+  ],
+  "description": "Requested-only technique binding candidates behind lawful moves.",
+  "documentation_surfaces": [
+    "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+    "docs/AGON_WAVE4_TECHNIQUE_LANDING.md",
+    "docs/AGON_RECURRENCE_ADAPTER.md"
+  ],
+  "drift_signals": [
+    {
+      "recommended_action": "revalidate",
+      "severity": "medium",
+      "signal": "agon_surface_changed_without_recurrence_review"
+    },
+    {
+      "recommended_action": "defer",
+      "severity": "high",
+      "signal": "agon_stop_line_blur_detected"
+    }
+  ],
+  "freshness": {
+    "open_window_days": 7,
+    "repeat_trigger_threshold": 2,
+    "stale_after_days": 14
+  },
+  "generated_surfaces": [
+    "generated/agon_technique_binding_candidates.min.json"
+  ],
+  "observation_inputs": [
+    {
+      "input_ref": "agon-technique-binding-candidates",
+      "kind": "other",
+      "notes": "Requested-only practice candidates behind lawful moves.",
+      "path_globs": [
+        "generated/agon_technique_binding_candidates.min.json",
+        "config/agon_technique_binding_candidates.seed.json"
+      ]
+    },
+    {
+      "input_ref": "agon-technique-bridge-docs",
+      "kind": "review_note",
+      "notes": "Owner boundary for practice candidates.",
+      "path_globs": [
+        "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md"
+      ]
+    }
+  ],
+  "owner_repo": "aoa-techniques",
+  "proof_surfaces": [
+    "python scripts/validate_agon_technique_binding_candidates.py"
+  ],
+  "refresh_routes": [
+    {
+      "action": "revalidate",
+      "commands": [
+        "python scripts/validate_agon_technique_binding_candidates.py"
+      ],
+      "notes": "Owner-local validation path. Recurrence may suggest this route; it must not run it as hidden authority."
+    }
+  ],
+  "rollback_anchors": [
+    "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md",
+    "docs/AGON_WAVE4_TECHNIQUE_LANDING.md"
+  ],
+  "schema_version": "aoa_recurrence_component_v2",
+  "signal_edges": [
+    {
+      "kind": "implemented_by_skill",
+      "notes": "Some practice pressure may later request bounded skill workflows.",
+      "target": "component:agon:skill-binding-surfaces",
+      "target_repo": "aoa-skills"
+    },
+    {
+      "kind": "summarized_by",
+      "notes": "Center can observe technique pressure without owning practice canon.",
+      "target": "component:agon:center-surfaces",
+      "target_repo": "Agents-of-Abyss"
+    }
+  ],
+  "source_inputs": [],
+  "tags": [
+    "agon",
+    "techniques",
+    "practice",
+    "recurrence"
+  ]
+}

--- a/manifests/recurrence/hooks/component.agon.technique-binding-surfaces.hooks.json
+++ b/manifests/recurrence/hooks/component.agon.technique-binding-surfaces.hooks.json
@@ -1,0 +1,141 @@
+{
+  "bindings": [
+    {
+      "binding_ref": "agon.technique-binding-surfaces.agon-technique-binding-candidates.watch",
+      "component_ref": "component:agon:technique-binding-surfaces",
+      "config": {
+        "json_field_signals": [
+          {
+            "attributes_from_fields": [
+              "schema_version",
+              "status",
+              "wave"
+            ],
+            "category": "review_signal",
+            "field": "schema_version",
+            "match": "exists",
+            "signal": "agon_recurrence_surface_seen"
+          },
+          {
+            "attributes_from_fields": [
+              "live_protocol",
+              "runtime_effect"
+            ],
+            "category": "overclaim_risk",
+            "field": "live_protocol",
+            "match": "equals",
+            "signal": "live_protocol_claim_present",
+            "value": true
+          }
+        ],
+        "phrase_signals": [
+          {
+            "category": "repeat_pattern",
+            "mode": "any",
+            "notes": "documentation repeats a pre-protocol stop-line",
+            "phrases": [
+              "no verdict",
+              "no scar",
+              "no arena"
+            ],
+            "signal": "agon_stop_line_repeated"
+          }
+        ],
+        "record_id_field": "surface_ref"
+      },
+      "event": "generated_surface_refreshed",
+      "input_ref": "agon-technique-binding-candidates",
+      "notes": "Observation only. This hook binding must not create arena sessions, verdicts, scars, or automatic owner mutations.",
+      "owner_repo": "aoa-techniques",
+      "path_globs": [
+        "generated/agon_technique_binding_candidates.min.json",
+        "config/agon_technique_binding_candidates.seed.json"
+      ],
+      "producer": "runtime_candidate_watch",
+      "signal_rules": [
+        {
+          "attributes_from_fields": [
+            "schema_version",
+            "status"
+          ],
+          "category": "change_pressure",
+          "match": "always",
+          "signal": "agon_recurrence_surface_changed",
+          "source_inputs": [
+            "agon-technique-binding-candidates"
+          ]
+        }
+      ]
+    },
+    {
+      "binding_ref": "agon.technique-binding-surfaces.agon-technique-bridge-docs.watch",
+      "component_ref": "component:agon:technique-binding-surfaces",
+      "config": {
+        "json_field_signals": [
+          {
+            "attributes_from_fields": [
+              "schema_version",
+              "status",
+              "wave"
+            ],
+            "category": "review_signal",
+            "field": "schema_version",
+            "match": "exists",
+            "signal": "agon_recurrence_surface_seen"
+          },
+          {
+            "attributes_from_fields": [
+              "live_protocol",
+              "runtime_effect"
+            ],
+            "category": "overclaim_risk",
+            "field": "live_protocol",
+            "match": "equals",
+            "signal": "live_protocol_claim_present",
+            "value": true
+          }
+        ],
+        "phrase_signals": [
+          {
+            "category": "repeat_pattern",
+            "mode": "any",
+            "notes": "documentation repeats a pre-protocol stop-line",
+            "phrases": [
+              "no verdict",
+              "no scar",
+              "no arena"
+            ],
+            "signal": "agon_stop_line_repeated"
+          }
+        ],
+        "record_id_field": "surface_ref"
+      },
+      "event": "session_stop",
+      "input_ref": "agon-technique-bridge-docs",
+      "notes": "Observation only. This hook binding must not create arena sessions, verdicts, scars, or automatic owner mutations.",
+      "owner_repo": "aoa-techniques",
+      "path_globs": [
+        "docs/AGON_MOVE_TECHNIQUE_BRIDGE.md"
+      ],
+      "producer": "harvest_pattern_watch",
+      "signal_rules": [
+        {
+          "attributes_from_fields": [
+            "schema_version",
+            "status"
+          ],
+          "category": "change_pressure",
+          "match": "always",
+          "signal": "agon_recurrence_surface_changed",
+          "source_inputs": [
+            "agon-technique-bridge-docs"
+          ]
+        }
+      ]
+    }
+  ],
+  "component_ref": "component:agon:technique-binding-surfaces",
+  "notes": "Agon recurrence adapter hook bindings. Hooks produce observations and review pressure only.",
+  "owner_repo": "aoa-techniques",
+  "schema_version": "aoa_hook_binding_set_v1"
+}


### PR DESCRIPTION
## Summary
- add the Agon recurrence adapter note for technique posture
- publish technique-binding recurrence component and hook-binding manifests
- keep lawful-move practice pressure reviewable without auto-promotion

## Verification
- python scripts/validate_agon_technique_binding_candidates.py