### PR TITLE
[codex] Fix Agon technique review follow-ups

### DIFF
--- a/manifests/recurrence/component.agon.technique-binding-surfaces.json
+++ b/manifests/recurrence/component.agon.technique-binding-surfaces.json
@@ -9,9 +9,8 @@
         "review_signal"
       ],
       "match_signals": [
-        "lawful_move_needs_practice",
-        "technique_candidate_repeated",
-        "practice_gap_repeated"
+        "agon_stop_line_repeated",
+        "agon_recurrence_surface_seen"
       ],
       "notes": "Lawful moves can request practice; recurrence must not promote techniques automatically.",
       "observation_inputs": [
@@ -48,12 +47,11 @@
         "overclaim_risk"
       ],
       "match_signals": [
-        "technique_claims_move_law",
-        "technique_claims_arena_authority"
+        "live_protocol_claim_present"
       ],
       "notes": "Technique surfaces do not own Agon law.",
       "observation_inputs": [
-        "agon-technique-bridge-docs"
+        "agon-technique-binding-candidates"
       ],
       "recommended_actions": [
         "return move law to center",
@@ -66,7 +64,6 @@
         "review_ready"
       ],
       "suppress_when": [
-        "live_protocol_claim_present",
         "hidden_authority_detected"
       ],
       "target_repo": "aoa-techniques",

--- a/manifests/recurrence/hooks/component.agon.technique-binding-surfaces.hooks.json
+++ b/manifests/recurrence/hooks/component.agon.technique-binding-surfaces.hooks.json
@@ -34,9 +34,10 @@
             "mode": "any",
             "notes": "documentation repeats a pre-protocol stop-line",
             "phrases": [
-              "no verdict",
-              "no scar",
-              "no arena"
+              "arena session",
+              "skill workflow",
+              "proof verdict",
+              "durable scar"
             ],
             "signal": "agon_stop_line_repeated"
           }
@@ -101,9 +102,10 @@
             "mode": "any",
             "notes": "documentation repeats a pre-protocol stop-line",
             "phrases": [
-              "no verdict",
-              "no scar",
-              "no arena"
+              "arena session",
+              "skill workflow",
+              "proof verdict",
+              "durable scar"
             ],
             "signal": "agon_stop_line_repeated"
           }

--- a/scripts/build_agon_technique_binding_candidates.py
+++ b/scripts/build_agon_technique_binding_candidates.py
@@ -16,6 +16,13 @@ EXPECTED_INDEX_SCHEMA = "agon-technique-binding-candidates-index/0.1"
 EXPECTED_BRIDGE_KIND = "practice_candidate"
 EXPECTED_TOTAL = 12
 EXPECTED_REPO = "aoa-techniques"
+REQUIRED_MUST_NOT_BOUNDARIES = (
+    "lawful move vocabulary",
+    "create skill workflow",
+    "proof verdict",
+    "scars",
+    "arena",
+)
 
 
 class ValidationError(Exception):
@@ -68,8 +75,8 @@ def validate_config(config: dict[str, Any]) -> None:
             raise ValidationError(f"{cid}: bridge_kind must be {EXPECTED_BRIDGE_KIND}")
         if not candidate.get("move_id", "").startswith("agon.move."):
             raise ValidationError(f"{cid}: invalid move_id")
-        must_not = " ".join(candidate.get("must_not", []))
-        for forbidden in ("lawful move vocabulary", "proof verdict", "scars", "arena"):
+        must_not = " ".join(candidate.get("must_not", [])).lower()
+        for forbidden in REQUIRED_MUST_NOT_BOUNDARIES:
             if forbidden not in must_not:
                 raise ValidationError(f"{cid}: must_not must preserve {forbidden!r} boundary")
 

--- a/tests/test_agon_technique_binding_candidates.py
+++ b/tests/test_agon_technique_binding_candidates.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_builder():
+    path = ROOT / "scripts" / "build_agon_technique_binding_candidates.py"
+    spec = importlib.util.spec_from_file_location("agon_technique_binding_builder_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_agon_technique_binding_candidates_current() -> None:
@@ -24,3 +36,13 @@ def test_agon_technique_binding_candidate_shape() -> None:
     assert data["wave"] == "IV"
     assert data["total_candidates"] == 12
     assert all(c["bridge_kind"] == "practice_candidate" for c in data["candidates"])
+
+
+def test_builder_rejects_candidates_without_skill_workflow_stop_line() -> None:
+    builder = load_builder()
+    config = json.loads((ROOT / "config" / "agon_technique_binding_candidates.seed.json").read_text(encoding="utf-8"))
+    config["candidates"][0]["must_not"] = [
+        item for item in config["candidates"][0]["must_not"] if "skill workflow" not in item
+    ]
+    with pytest.raises(builder.ValidationError, match="create skill workflow"):
+        builder.validate_config(config)

--- a/tests/test_agon_technique_binding_candidates.py
+++ b/tests/test_agon_technique_binding_candidates.py
@@ -4,9 +4,8 @@ import importlib.util
 import json
 import subprocess
 import sys
+import unittest
 from pathlib import Path
-
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -44,5 +43,6 @@ def test_builder_rejects_candidates_without_skill_workflow_stop_line() -> None:
     config["candidates"][0]["must_not"] = [
         item for item in config["candidates"][0]["must_not"] if "skill workflow" not in item
     ]
-    with pytest.raises(builder.ValidationError, match="create skill workflow"):
+    case = unittest.TestCase()
+    with case.assertRaisesRegex(builder.ValidationError, "create skill workflow"):
         builder.validate_config(config)


### PR DESCRIPTION
## Summary
- require the skill-workflow prohibition in Agon technique candidate must_not boundaries
- align recurrence beacons and hook phrase matching with signals and wording the repo actually emits

## Validation
- python scripts/build_agon_technique_binding_candidates.py --check
- python scripts/validate_agon_technique_binding_candidates.py
- python -m pytest -q tests/test_agon_technique_binding_candidates.py