### PR TITLE
Document recurrence owner observation boundaries

### DIFF
--- a/docs/RECURRENCE_LIVE_OBSERVATION_PRODUCERS.md
+++ b/docs/RECURRENCE_LIVE_OBSERVATION_PRODUCERS.md
@@ -1,0 +1,3 @@
+# Live observation producer notes for techniques
+
+Producer inputs: `docs/CROSS_LAYER_TECHNIQUE_CANDIDATES.md`, `docs/PROMOTION_READINESS_MATRIX.md`, and `generated/technique_promotion_readiness.min.json`. Signals remain advisory: no candidate or canonical status changes happen here.

--- a/docs/RECURRENCE_REVIEW_DECISION_CLOSURE.md
+++ b/docs/RECURRENCE_REVIEW_DECISION_CLOSURE.md
@@ -1,0 +1,5 @@
+# Recurrence review decision closure for techniques
+
+Technique beacons may point at candidate intake, overlap holds, or canonical-pressure surfaces. A decision packet may record `accept`, `reject`, `defer`, `reanchor`, `split`, `merge`, or `suppress`, but it does not change technique status by itself.
+
+For `canonical_pressure`, use the decision to point at the owner review note or readiness-matrix followthrough. For `new_technique_candidate`, keep SDK lineage provisional until `aoa-techniques` assigns a candidate or landed technique ref.


### PR DESCRIPTION
Publishes recurrence live observation and review decision closure owner-boundary docs for techniques. Local verification before publish covered cross-repo diff checks and recurrence contract validation.