### PR TITLE
[codex] Add wave3 technique adoption contracts

### DIFF
--- a/docs/TECHNIQUE_ADOPTION_BOUNDARIES.md
+++ b/docs/TECHNIQUE_ADOPTION_BOUNDARIES.md
@@ -1,0 +1,41 @@
+# TECHNIQUE ADOPTION BOUNDARIES
+
+Version: v0.7
+Owner surface: `aoa-techniques`
+Seed family: Experience Adoption Forge
+
+## Purpose
+
+Technique-level boundaries and no-policy-overreach rule.
+
+## Core law
+
+- Adoption must be explicit.
+- Local owner consent is required.
+- Durable behavior change needs evidence, rollback and retention.
+
+## Lifecycle hooks
+
+- request
+- readiness
+- shadow
+- decision
+- activation
+- retention
+
+## Outputs
+
+- technique_adoption_boundaries
+
+## Stop lines
+
+- No hidden assistant self-adoption.
+- No adoption without local owner consent.
+- No direct Tree-of-Sophia runtime write or runtime adoption.
+- No KAG forced adoption into source repos.
+- No routing layer authorship of meaning.
+- No persistent change without rollback or explicit quarantine fallback.
+
+## Notes
+
+This document belongs to the v0.7 downstream adoption wave. It assumes the v0.6 federation harvest has already approved a shared pattern, but it refuses to treat approval as automatic adoption. Adoption is a second sovereign act: local owner consent, compatibility, shadow proof, rollback path, retention watch, and kind-safe projection are required.

--- a/docs/TECHNIQUE_OBSOLESCENCE.md
+++ b/docs/TECHNIQUE_OBSOLESCENCE.md
@@ -1,0 +1,41 @@
+# TECHNIQUE OBSOLESCENCE
+
+Version: v0.7
+Owner surface: `aoa-techniques`
+Seed family: Experience Adoption Forge
+
+## Purpose
+
+Obsolescence and supersession of adopted techniques.
+
+## Core law
+
+- Adoption must be explicit.
+- Local owner consent is required.
+- Durable behavior change needs evidence, rollback and retention.
+
+## Lifecycle hooks
+
+- request
+- readiness
+- shadow
+- decision
+- activation
+- retention
+
+## Outputs
+
+- technique_obsolescence
+
+## Stop lines
+
+- No hidden assistant self-adoption.
+- No adoption without local owner consent.
+- No direct Tree-of-Sophia runtime write or runtime adoption.
+- No KAG forced adoption into source repos.
+- No routing layer authorship of meaning.
+- No persistent change without rollback or explicit quarantine fallback.
+
+## Notes
+
+This document belongs to the v0.7 downstream adoption wave. It assumes the v0.6 federation harvest has already approved a shared pattern, but it refuses to treat approval as automatic adoption. Adoption is a second sovereign act: local owner consent, compatibility, shadow proof, rollback path, retention watch, and kind-safe projection are required.

--- a/docs/TECHNIQUE_PATTERN_ADOPTION.md
+++ b/docs/TECHNIQUE_PATTERN_ADOPTION.md
@@ -1,0 +1,41 @@
+# TECHNIQUE PATTERN ADOPTION
+
+Version: v0.7
+Owner surface: `aoa-techniques`
+Seed family: Experience Adoption Forge
+
+## Purpose
+
+How shared patterns become reusable techniques.
+
+## Core law
+
+- Adoption must be explicit.
+- Local owner consent is required.
+- Durable behavior change needs evidence, rollback and retention.
+
+## Lifecycle hooks
+
+- request
+- readiness
+- shadow
+- decision
+- activation
+- retention
+
+## Outputs
+
+- technique_pattern_adoption
+
+## Stop lines
+
+- No hidden assistant self-adoption.
+- No adoption without local owner consent.
+- No direct Tree-of-Sophia runtime write or runtime adoption.
+- No KAG forced adoption into source repos.
+- No routing layer authorship of meaning.
+- No persistent change without rollback or explicit quarantine fallback.
+
+## Notes
+
+This document belongs to the v0.7 downstream adoption wave. It assumes the v0.6 federation harvest has already approved a shared pattern, but it refuses to treat approval as automatic adoption. Adoption is a second sovereign act: local owner consent, compatibility, shadow proof, rollback path, retention watch, and kind-safe projection are required.

--- a/docs/TECHNIQUE_RETENTION_CHECKS.md
+++ b/docs/TECHNIQUE_RETENTION_CHECKS.md
@@ -1,0 +1,41 @@
+# TECHNIQUE RETENTION CHECKS
+
+Version: v0.7
+Owner surface: `aoa-techniques`
+Seed family: Experience Adoption Forge
+
+## Purpose
+
+Retention checks for practice-level adoption.
+
+## Core law
+
+- Adoption must be explicit.
+- Local owner consent is required.
+- Durable behavior change needs evidence, rollback and retention.
+
+## Lifecycle hooks
+
+- request
+- readiness
+- shadow
+- decision
+- activation
+- retention
+
+## Outputs
+
+- technique_retention_checks
+
+## Stop lines
+
+- No hidden assistant self-adoption.
+- No adoption without local owner consent.
+- No direct Tree-of-Sophia runtime write or runtime adoption.
+- No KAG forced adoption into source repos.
+- No routing layer authorship of meaning.
+- No persistent change without rollback or explicit quarantine fallback.
+
+## Notes
+
+This document belongs to the v0.7 downstream adoption wave. It assumes the v0.6 federation harvest has already approved a shared pattern, but it refuses to treat approval as automatic adoption. Adoption is a second sovereign act: local owner consent, compatibility, shadow proof, rollback path, retention watch, and kind-safe projection are required.

--- a/docs/TECHNIQUE_TO_SKILL_HANDOFF.md
+++ b/docs/TECHNIQUE_TO_SKILL_HANDOFF.md
@@ -1,0 +1,41 @@
+# TECHNIQUE TO SKILL HANDOFF
+
+Version: v0.7
+Owner surface: `aoa-techniques`
+Seed family: Experience Adoption Forge
+
+## Purpose
+
+When technique adoption should generate a skill proposal.
+
+## Core law
+
+- Adoption must be explicit.
+- Local owner consent is required.
+- Durable behavior change needs evidence, rollback and retention.
+
+## Lifecycle hooks
+
+- request
+- readiness
+- shadow
+- decision
+- activation
+- retention
+
+## Outputs
+
+- technique_to_skill_handoff
+
+## Stop lines
+
+- No hidden assistant self-adoption.
+- No adoption without local owner consent.
+- No direct Tree-of-Sophia runtime write or runtime adoption.
+- No KAG forced adoption into source repos.
+- No routing layer authorship of meaning.
+- No persistent change without rollback or explicit quarantine fallback.
+
+## Notes
+
+This document belongs to the v0.7 downstream adoption wave. It assumes the v0.6 federation harvest has already approved a shared pattern, but it refuses to treat approval as automatic adoption. Adoption is a second sovereign act: local owner consent, compatibility, shadow proof, rollback path, retention watch, and kind-safe projection are required.

--- a/examples/technique_adoption_boundary_check.example.json
+++ b/examples/technique_adoption_boundary_check.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_id": "technique_adoption_boundary_check_v1",
+  "kind": "technique_adoption_boundary_check",
+  "version": "1.0",
+  "status": "proposed",
+  "summary": "Example technique_adoption_boundary_check object for Experience Adoption Forge v0.7.",
+  "refs": {
+    "source": "experience.shared_pattern_registry",
+    "owner": "aoa-techniques",
+    "related": [
+      "experience.v0.6.federation_harvest",
+      "experience.v0.7.adoption_forge"
+    ]
+  },
+  "payload": {
+    "wave": "v0.7",
+    "repo": "aoa-techniques",
+    "pattern_ref": "pattern.shared.wrong_surface_to_owner_landing.v1",
+    "owner_surface": "aoa-techniques",
+    "requires_owner_consent": true,
+    "rollback_required": true,
+    "retention_cycles": 3,
+    "technique_contract": "practice_pattern",
+    "may_generate_skill_proposal": true
+  }
+}

--- a/examples/technique_obsolescence_notice.example.json
+++ b/examples/technique_obsolescence_notice.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_id": "technique_obsolescence_notice_v1",
+  "kind": "technique_obsolescence_notice",
+  "version": "1.0",
+  "status": "proposed",
+  "summary": "Example technique_obsolescence_notice object for Experience Adoption Forge v0.7.",
+  "refs": {
+    "source": "experience.shared_pattern_registry",
+    "owner": "aoa-techniques",
+    "related": [
+      "experience.v0.6.federation_harvest",
+      "experience.v0.7.adoption_forge"
+    ]
+  },
+  "payload": {
+    "wave": "v0.7",
+    "repo": "aoa-techniques",
+    "pattern_ref": "pattern.shared.wrong_surface_to_owner_landing.v1",
+    "owner_surface": "aoa-techniques",
+    "requires_owner_consent": true,
+    "rollback_required": true,
+    "retention_cycles": 3,
+    "technique_contract": "practice_pattern",
+    "may_generate_skill_proposal": true
+  }
+}

--- a/examples/technique_pattern_adoption_note.example.json
+++ b/examples/technique_pattern_adoption_note.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_id": "technique_pattern_adoption_note_v1",
+  "kind": "technique_pattern_adoption_note",
+  "version": "1.0",
+  "status": "proposed",
+  "summary": "Example technique_pattern_adoption_note object for Experience Adoption Forge v0.7.",
+  "refs": {
+    "source": "experience.shared_pattern_registry",
+    "owner": "aoa-techniques",
+    "related": [
+      "experience.v0.6.federation_harvest",
+      "experience.v0.7.adoption_forge"
+    ]
+  },
+  "payload": {
+    "wave": "v0.7",
+    "repo": "aoa-techniques",
+    "pattern_ref": "pattern.shared.wrong_surface_to_owner_landing.v1",
+    "owner_surface": "aoa-techniques",
+    "requires_owner_consent": true,
+    "rollback_required": true,
+    "retention_cycles": 3,
+    "technique_contract": "practice_pattern",
+    "may_generate_skill_proposal": true
+  }
+}

--- a/examples/technique_retention_probe.example.json
+++ b/examples/technique_retention_probe.example.json
@@ -1,0 +1,28 @@
+{
+  "schema_id": "technique_retention_probe_v1",
+  "kind": "technique_retention_probe",
+  "version": "1.0",
+  "status": "proposed",
+  "summary": "Example technique_retention_probe object for Experience Adoption Forge v0.7.",
+  "refs": {
+    "source": "experience.shared_pattern_registry",
+    "owner": "aoa-techniques",
+    "related": [
+      "experience.v0.6.federation_harvest",
+      "experience.v0.7.adoption_forge"
+    ]
+  },
+  "payload": {
+    "wave": "v0.7",
+    "repo": "aoa-techniques",
+    "pattern_ref": "pattern.shared.wrong_surface_to_owner_landing.v1",
+    "owner_surface": "aoa-techniques",
+    "requires_owner_consent": true,
+    "rollback_required": true,
+    "retention_cycles": 3,
+    "technique_contract": "practice_pattern",
+    "may_generate_skill_proposal": true,
+    "retention_probe": "repeat_after_3_cycles",
+    "held_threshold": 0.8
+  }
+}

--- a/examples/technique_to_skill_handoff.example.json
+++ b/examples/technique_to_skill_handoff.example.json
@@ -1,0 +1,28 @@
+{
+  "schema_id": "technique_to_skill_handoff_v1",
+  "kind": "technique_to_skill_handoff",
+  "version": "1.0",
+  "status": "proposed",
+  "summary": "Example technique_to_skill_handoff object for Experience Adoption Forge v0.7.",
+  "refs": {
+    "source": "experience.shared_pattern_registry",
+    "owner": "aoa-techniques",
+    "related": [
+      "experience.v0.6.federation_harvest",
+      "experience.v0.7.adoption_forge"
+    ]
+  },
+  "payload": {
+    "wave": "v0.7",
+    "repo": "aoa-techniques",
+    "pattern_ref": "pattern.shared.wrong_surface_to_owner_landing.v1",
+    "owner_surface": "aoa-techniques",
+    "requires_owner_consent": true,
+    "rollback_required": true,
+    "retention_cycles": 3,
+    "skill_contract": "bounded_workflow",
+    "regression_required": true,
+    "technique_contract": "practice_pattern",
+    "may_generate_skill_proposal": true
+  }
+}

--- a/schemas/technique_adoption_boundary_check_v1.json
+++ b/schemas/technique_adoption_boundary_check_v1.json
@@ -63,7 +63,8 @@
         "related": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/technique_adoption_boundary_check_v1.json
+++ b/schemas/technique_adoption_boundary_check_v1.json
@@ -105,7 +105,7 @@
         },
         "retention_cycles": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 1
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_adoption_boundary_check_v1.json
+++ b/schemas/technique_adoption_boundary_check_v1.json
@@ -96,13 +96,16 @@
           "type": "string"
         },
         "requires_owner_consent": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "rollback_required": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "retention_cycles": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_adoption_boundary_check_v1.json
+++ b/schemas/technique_adoption_boundary_check_v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_adoption_boundary_check_v1.json",
+  "title": "technique_adoption_boundary_check v1",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "kind",
+    "version",
+    "status",
+    "summary",
+    "refs",
+    "payload"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "technique_adoption_boundary_check_v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "technique_adoption_boundary_check"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "proposed",
+        "approved",
+        "blocked",
+        "passed",
+        "failed",
+        "active",
+        "retired",
+        "shadow",
+        "quarantined"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 4
+    },
+    "refs": {
+      "type": "object",
+      "required": [
+        "source",
+        "owner",
+        "related"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "wave",
+        "repo",
+        "pattern_ref",
+        "owner_surface",
+        "requires_owner_consent",
+        "rollback_required",
+        "retention_cycles",
+        "technique_contract",
+        "may_generate_skill_proposal"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "pattern_ref": {
+          "type": "string"
+        },
+        "owner_surface": {
+          "type": "string"
+        },
+        "requires_owner_consent": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "retention_cycles": {
+          "type": "integer"
+        },
+        "technique_contract": {
+          "type": "string"
+        },
+        "may_generate_skill_proposal": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/technique_obsolescence_notice_v1.json
+++ b/schemas/technique_obsolescence_notice_v1.json
@@ -63,7 +63,8 @@
         "related": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/technique_obsolescence_notice_v1.json
+++ b/schemas/technique_obsolescence_notice_v1.json
@@ -105,7 +105,7 @@
         },
         "retention_cycles": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 1
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_obsolescence_notice_v1.json
+++ b/schemas/technique_obsolescence_notice_v1.json
@@ -96,13 +96,16 @@
           "type": "string"
         },
         "requires_owner_consent": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "rollback_required": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "retention_cycles": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_obsolescence_notice_v1.json
+++ b/schemas/technique_obsolescence_notice_v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_obsolescence_notice_v1.json",
+  "title": "technique_obsolescence_notice v1",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "kind",
+    "version",
+    "status",
+    "summary",
+    "refs",
+    "payload"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "technique_obsolescence_notice_v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "technique_obsolescence_notice"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "proposed",
+        "approved",
+        "blocked",
+        "passed",
+        "failed",
+        "active",
+        "retired",
+        "shadow",
+        "quarantined"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 4
+    },
+    "refs": {
+      "type": "object",
+      "required": [
+        "source",
+        "owner",
+        "related"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "wave",
+        "repo",
+        "pattern_ref",
+        "owner_surface",
+        "requires_owner_consent",
+        "rollback_required",
+        "retention_cycles",
+        "technique_contract",
+        "may_generate_skill_proposal"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "pattern_ref": {
+          "type": "string"
+        },
+        "owner_surface": {
+          "type": "string"
+        },
+        "requires_owner_consent": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "retention_cycles": {
+          "type": "integer"
+        },
+        "technique_contract": {
+          "type": "string"
+        },
+        "may_generate_skill_proposal": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/technique_pattern_adoption_note_v1.json
+++ b/schemas/technique_pattern_adoption_note_v1.json
@@ -63,7 +63,8 @@
         "related": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/technique_pattern_adoption_note_v1.json
+++ b/schemas/technique_pattern_adoption_note_v1.json
@@ -105,7 +105,7 @@
         },
         "retention_cycles": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 1
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_pattern_adoption_note_v1.json
+++ b/schemas/technique_pattern_adoption_note_v1.json
@@ -96,13 +96,16 @@
           "type": "string"
         },
         "requires_owner_consent": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "rollback_required": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "retention_cycles": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_pattern_adoption_note_v1.json
+++ b/schemas/technique_pattern_adoption_note_v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_pattern_adoption_note_v1.json",
+  "title": "technique_pattern_adoption_note v1",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "kind",
+    "version",
+    "status",
+    "summary",
+    "refs",
+    "payload"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "technique_pattern_adoption_note_v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "technique_pattern_adoption_note"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "proposed",
+        "approved",
+        "blocked",
+        "passed",
+        "failed",
+        "active",
+        "retired",
+        "shadow",
+        "quarantined"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 4
+    },
+    "refs": {
+      "type": "object",
+      "required": [
+        "source",
+        "owner",
+        "related"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "wave",
+        "repo",
+        "pattern_ref",
+        "owner_surface",
+        "requires_owner_consent",
+        "rollback_required",
+        "retention_cycles",
+        "technique_contract",
+        "may_generate_skill_proposal"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "pattern_ref": {
+          "type": "string"
+        },
+        "owner_surface": {
+          "type": "string"
+        },
+        "requires_owner_consent": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "retention_cycles": {
+          "type": "integer"
+        },
+        "technique_contract": {
+          "type": "string"
+        },
+        "may_generate_skill_proposal": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/technique_retention_probe_v1.json
+++ b/schemas/technique_retention_probe_v1.json
@@ -63,7 +63,8 @@
         "related": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/technique_retention_probe_v1.json
+++ b/schemas/technique_retention_probe_v1.json
@@ -98,13 +98,16 @@
           "type": "string"
         },
         "requires_owner_consent": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "rollback_required": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "retention_cycles": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         },
         "technique_contract": {
           "type": "string"
@@ -116,7 +119,9 @@
           "type": "string"
         },
         "held_threshold": {
-          "type": "number"
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
         }
       }
     }

--- a/schemas/technique_retention_probe_v1.json
+++ b/schemas/technique_retention_probe_v1.json
@@ -107,7 +107,7 @@
         },
         "retention_cycles": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 1
         },
         "technique_contract": {
           "type": "string"

--- a/schemas/technique_retention_probe_v1.json
+++ b/schemas/technique_retention_probe_v1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_retention_probe_v1.json",
+  "title": "technique_retention_probe v1",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "kind",
+    "version",
+    "status",
+    "summary",
+    "refs",
+    "payload"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "technique_retention_probe_v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "technique_retention_probe"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "proposed",
+        "approved",
+        "blocked",
+        "passed",
+        "failed",
+        "active",
+        "retired",
+        "shadow",
+        "quarantined"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 4
+    },
+    "refs": {
+      "type": "object",
+      "required": [
+        "source",
+        "owner",
+        "related"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "wave",
+        "repo",
+        "pattern_ref",
+        "owner_surface",
+        "requires_owner_consent",
+        "rollback_required",
+        "retention_cycles",
+        "technique_contract",
+        "may_generate_skill_proposal",
+        "retention_probe",
+        "held_threshold"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "pattern_ref": {
+          "type": "string"
+        },
+        "owner_surface": {
+          "type": "string"
+        },
+        "requires_owner_consent": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "retention_cycles": {
+          "type": "integer"
+        },
+        "technique_contract": {
+          "type": "string"
+        },
+        "may_generate_skill_proposal": {
+          "type": "boolean"
+        },
+        "retention_probe": {
+          "type": "string"
+        },
+        "held_threshold": {
+          "type": "number"
+        }
+      }
+    }
+  }
+}

--- a/schemas/technique_to_skill_handoff_v1.json
+++ b/schemas/technique_to_skill_handoff_v1.json
@@ -63,7 +63,8 @@
         "related": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       }

--- a/schemas/technique_to_skill_handoff_v1.json
+++ b/schemas/technique_to_skill_handoff_v1.json
@@ -98,13 +98,16 @@
           "type": "string"
         },
         "requires_owner_consent": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "rollback_required": {
-          "type": "boolean"
+          "type": "boolean",
+          "const": true
         },
         "retention_cycles": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         },
         "skill_contract": {
           "type": "string"

--- a/schemas/technique_to_skill_handoff_v1.json
+++ b/schemas/technique_to_skill_handoff_v1.json
@@ -107,7 +107,7 @@
         },
         "retention_cycles": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 1
         },
         "skill_contract": {
           "type": "string"

--- a/schemas/technique_to_skill_handoff_v1.json
+++ b/schemas/technique_to_skill_handoff_v1.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_to_skill_handoff_v1.json",
+  "title": "technique_to_skill_handoff v1",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "kind",
+    "version",
+    "status",
+    "summary",
+    "refs",
+    "payload"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "technique_to_skill_handoff_v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "technique_to_skill_handoff"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "proposed",
+        "approved",
+        "blocked",
+        "passed",
+        "failed",
+        "active",
+        "retired",
+        "shadow",
+        "quarantined"
+      ]
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 4
+    },
+    "refs": {
+      "type": "object",
+      "required": [
+        "source",
+        "owner",
+        "related"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "related": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "wave",
+        "repo",
+        "pattern_ref",
+        "owner_surface",
+        "requires_owner_consent",
+        "rollback_required",
+        "retention_cycles",
+        "skill_contract",
+        "regression_required",
+        "technique_contract",
+        "may_generate_skill_proposal"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "pattern_ref": {
+          "type": "string"
+        },
+        "owner_surface": {
+          "type": "string"
+        },
+        "requires_owner_consent": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "retention_cycles": {
+          "type": "integer"
+        },
+        "skill_contract": {
+          "type": "string"
+        },
+        "regression_required": {
+          "type": "boolean"
+        },
+        "technique_contract": {
+          "type": "string"
+        },
+        "may_generate_skill_proposal": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -70,17 +70,17 @@ def wrong_type_value(value: object) -> object:
     return "not-null"
 
 
-def payload_schema_properties(schema: dict[str, object]) -> dict[str, object]:
+def schema_properties(schema: dict[str, object]) -> dict[str, object]:
     properties = schema.get("properties")
-    if not isinstance(properties, dict):
-        return {}
-    payload = properties.get("payload")
+    return properties if isinstance(properties, dict) else {}
+
+
+def payload_schema_properties(schema: dict[str, object]) -> dict[str, object]:
+    payload = schema_properties(schema).get("payload")
     if not isinstance(payload, dict):
         return {}
     payload_properties = payload.get("properties")
-    if not isinstance(payload_properties, dict):
-        return {}
-    return payload_properties
+    return payload_properties if isinstance(payload_properties, dict) else {}
 
 
 def array_field_targets(example: dict[str, object]) -> list[tuple[str, str]]:
@@ -224,20 +224,31 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                     self.assert_invalid(schema, mutated, f"{stem} empty {section}.{key} item")
         self.assertGreater(exercised, 0, "no wave3 array fields were exercised")
 
-    def test_experience_wave3_schemas_reject_payload_enum_escape_values(self) -> None:
+    def test_experience_wave3_schemas_reject_enum_escape_values(self) -> None:
+        exercised = 0
         for stem in WAVE3_STEMS:
             schema, example = load_contract(stem)
+            for key, prop in schema_properties(schema).items():
+                if not isinstance(prop, dict) or "enum" not in prop or key not in example:
+                    continue
+                exercised += 1
+                with self.subTest(stem=stem, section="top", key=key):
+                    mutated = copy.deepcopy(example)
+                    mutated[key] = ENUM_ESCAPE_VALUE
+                    self.assert_invalid(schema, mutated, f"{stem} enum escape {key}")
             payload = example.get("payload")
             if not isinstance(payload, dict):
                 continue
             for key, prop in payload_schema_properties(schema).items():
                 if not isinstance(prop, dict) or "enum" not in prop or key not in payload:
                     continue
-                with self.subTest(stem=stem, key=key):
+                exercised += 1
+                with self.subTest(stem=stem, section="payload", key=key):
                     mutated = copy.deepcopy(example)
                     self.assertIsInstance(mutated["payload"], dict)
                     mutated["payload"][key] = ENUM_ESCAPE_VALUE
-                    self.assert_invalid(schema, mutated, f"{stem} enum escape {key}")
+                    self.assert_invalid(schema, mutated, f"{stem} enum escape payload.{key}")
+        self.assertGreater(exercised, 0, "no wave3 enum fields were exercised")
 
 
 if __name__ == "__main__":

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
+import unittest
 
 from jsonschema import Draft202012Validator
 
@@ -29,11 +30,6 @@ def validation_errors(schema: dict[str, object], value: dict[str, object]) -> li
     return sorted(Draft202012Validator(schema).iter_errors(value), key=lambda error: list(error.path))
 
 
-def assert_invalid(schema: dict[str, object], value: dict[str, object], label: str) -> None:
-    errors = validation_errors(schema, value)
-    assert errors, f"{label} unexpectedly validated"
-
-
 def wrong_type_value(value: object) -> object:
     if isinstance(value, bool):
         return "not-a-boolean"
@@ -50,51 +46,61 @@ def wrong_type_value(value: object) -> object:
     return "not-null"
 
 
-def test_experience_wave3_examples_match_schemas() -> None:
-    missing_pairs: list[str] = []
-    for stem in WAVE3_STEMS:
-        schema_path = ROOT / "schemas" / f"{stem}_v1.json"
-        example_path = ROOT / "examples" / f"{stem}.example.json"
-        if not schema_path.exists():
-            missing_pairs.append(f"{example_path.relative_to(ROOT)} -> {schema_path.relative_to(ROOT)}")
-        if not example_path.exists():
-            missing_pairs.append(f"{schema_path.relative_to(ROOT)} -> {example_path.relative_to(ROOT)}")
-    assert not missing_pairs, "missing wave3 contract pair(s): " + ", ".join(missing_pairs)
+class ExperienceWave3SeedContractTests(unittest.TestCase):
+    def assert_invalid(self, schema: dict[str, object], value: dict[str, object], label: str) -> None:
+        errors = validation_errors(schema, value)
+        self.assertTrue(errors, f"{label} unexpectedly validated")
 
-    assert WAVE3_STEMS
-    for stem in WAVE3_STEMS:
-        schema, example = load_contract(stem)
-        Draft202012Validator.check_schema(schema)
-        errors = validation_errors(schema, example)
-        assert not errors, f"{stem}: {errors[0].message}" if errors else stem
+    def test_experience_wave3_examples_match_schemas(self) -> None:
+        missing_pairs: list[str] = []
+        for stem in WAVE3_STEMS:
+            schema_path = ROOT / "schemas" / f"{stem}_v1.json"
+            example_path = ROOT / "examples" / f"{stem}.example.json"
+            if not schema_path.exists():
+                missing_pairs.append(f"{example_path.relative_to(ROOT)} -> {schema_path.relative_to(ROOT)}")
+            if not example_path.exists():
+                missing_pairs.append(f"{schema_path.relative_to(ROOT)} -> {example_path.relative_to(ROOT)}")
+        self.assertFalse(missing_pairs, "missing wave3 contract pair(s): " + ", ".join(missing_pairs))
+
+        self.assertTrue(WAVE3_STEMS)
+        for stem in WAVE3_STEMS:
+            with self.subTest(stem=stem):
+                schema, example = load_contract(stem)
+                Draft202012Validator.check_schema(schema)
+                errors = validation_errors(schema, example)
+                self.assertFalse(errors, f"{stem}: {errors[0].message}" if errors else stem)
+
+    def test_experience_wave3_schemas_reject_escape_hatches(self) -> None:
+        self.assertTrue(WAVE3_STEMS)
+        for stem in WAVE3_STEMS:
+            with self.subTest(stem=stem):
+                schema, example = load_contract(stem)
+
+                with_unknown_top = copy.deepcopy(example)
+                with_unknown_top["contract_escape"] = True
+                self.assert_invalid(schema, with_unknown_top, f"{stem} unknown top-level field")
+
+                refs = example.get("refs")
+                if isinstance(refs, dict):
+                    with_unknown_ref = copy.deepcopy(example)
+                    self.assertIsInstance(with_unknown_ref["refs"], dict)
+                    with_unknown_ref["refs"]["contract_escape"] = "loose-ref"
+                    self.assert_invalid(schema, with_unknown_ref, f"{stem} unknown refs field")
+
+                payload = example.get("payload")
+                if isinstance(payload, dict):
+                    with_unknown_payload = copy.deepcopy(example)
+                    self.assertIsInstance(with_unknown_payload["payload"], dict)
+                    with_unknown_payload["payload"]["contract_escape"] = "loose-payload"
+                    self.assert_invalid(schema, with_unknown_payload, f"{stem} unknown payload field")
+
+                    if payload:
+                        key = next(iter(payload))
+                        with_wrong_payload_type = copy.deepcopy(example)
+                        self.assertIsInstance(with_wrong_payload_type["payload"], dict)
+                        with_wrong_payload_type["payload"][key] = wrong_type_value(payload[key])
+                        self.assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong payload type")
 
 
-def test_experience_wave3_schemas_reject_escape_hatches() -> None:
-    assert WAVE3_STEMS
-    for stem in WAVE3_STEMS:
-        schema, example = load_contract(stem)
-
-        with_unknown_top = copy.deepcopy(example)
-        with_unknown_top["contract_escape"] = True
-        assert_invalid(schema, with_unknown_top, f"{stem} unknown top-level field")
-
-        refs = example.get("refs")
-        if isinstance(refs, dict):
-            with_unknown_ref = copy.deepcopy(example)
-            assert isinstance(with_unknown_ref["refs"], dict)
-            with_unknown_ref["refs"]["contract_escape"] = "loose-ref"
-            assert_invalid(schema, with_unknown_ref, f"{stem} unknown refs field")
-
-        payload = example.get("payload")
-        if isinstance(payload, dict):
-            with_unknown_payload = copy.deepcopy(example)
-            assert isinstance(with_unknown_payload["payload"], dict)
-            with_unknown_payload["payload"]["contract_escape"] = "loose-payload"
-            assert_invalid(schema, with_unknown_payload, f"{stem} unknown payload field")
-
-            if payload:
-                key = next(iter(payload))
-                with_wrong_payload_type = copy.deepcopy(example)
-                assert isinstance(with_wrong_payload_type["payload"], dict)
-                with_wrong_payload_type["payload"][key] = wrong_type_value(payload[key])
-                assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong payload type")
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -29,10 +29,12 @@ GUARDRAIL_BOOLEAN_FIELDS = {
     "kag_may_propose",
     "lineage_indexed",
     "meaning_authority",
+    "release_required",
     "required_trial",
     "requires_eval_verdict",
     "requires_owner_consent",
     "rollback_required",
+    "scar_required",
     "source_theft",
     "submit_only",
 }
@@ -79,6 +81,34 @@ def payload_schema_properties(schema: dict[str, object]) -> dict[str, object]:
     if not isinstance(payload_properties, dict):
         return {}
     return payload_properties
+
+
+def array_field_targets(example: dict[str, object]) -> list[tuple[str, str]]:
+    targets: list[tuple[str, str]] = []
+    for key, value in example.items():
+        if isinstance(value, list):
+            targets.append(("top", key))
+    refs = example.get("refs")
+    if isinstance(refs, dict):
+        for key, value in refs.items():
+            if isinstance(value, list):
+                targets.append(("refs", key))
+    payload = example.get("payload")
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if isinstance(value, list):
+                targets.append(("payload", key))
+    return targets
+
+
+def set_section_value(value: dict[str, object], section: str, key: str, replacement: object) -> None:
+    if section == "top":
+        value[key] = replacement
+        return
+    nested = value[section]
+    if not isinstance(nested, dict):
+        raise AssertionError(f"{section} is not an object")
+    nested[key] = replacement
 
 
 class ExperienceWave3SeedContractTests(unittest.TestCase):
@@ -179,19 +209,20 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                         self.assert_invalid(schema, mutated, f"{stem} out-of-range {key}")
 
     def test_experience_wave3_schemas_reject_non_string_array_items(self) -> None:
+        exercised = 0
         for stem in WAVE3_STEMS:
             schema, example = load_contract(stem)
-            payload = example.get("payload")
-            if not isinstance(payload, dict):
-                continue
-            for key, value in payload.items():
-                if not isinstance(value, list):
-                    continue
-                with self.subTest(stem=stem, key=key):
+            for section, key in array_field_targets(example):
+                exercised += 1
+                with self.subTest(stem=stem, section=section, key=key, case="non-string"):
                     mutated = copy.deepcopy(example)
-                    self.assertIsInstance(mutated["payload"], dict)
-                    mutated["payload"][key] = [12345]
-                    self.assert_invalid(schema, mutated, f"{stem} non-string {key} item")
+                    set_section_value(mutated, section, key, [12345])
+                    self.assert_invalid(schema, mutated, f"{stem} non-string {section}.{key} item")
+                with self.subTest(stem=stem, section=section, key=key, case="empty-string"):
+                    mutated = copy.deepcopy(example)
+                    set_section_value(mutated, section, key, [""])
+                    self.assert_invalid(schema, mutated, f"{stem} empty {section}.{key} item")
+        self.assertGreater(exercised, 0, "no wave3 array fields were exercised")
 
     def test_experience_wave3_schemas_reject_payload_enum_escape_values(self) -> None:
         for stem in WAVE3_STEMS:

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -37,6 +37,7 @@ GUARDRAIL_BOOLEAN_FIELDS = {
     "submit_only",
 }
 RATIO_FIELD_HINTS = ("rate", "threshold")
+ENUM_ESCAPE_VALUE = "__wave3_not_allowed__"
 
 
 def load_contract(stem: str) -> tuple[dict[str, object], dict[str, object]]:
@@ -65,6 +66,19 @@ def wrong_type_value(value: object) -> object:
     if isinstance(value, dict):
         return "not-an-object"
     return "not-null"
+
+
+def payload_schema_properties(schema: dict[str, object]) -> dict[str, object]:
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+    payload = properties.get("payload")
+    if not isinstance(payload, dict):
+        return {}
+    payload_properties = payload.get("properties")
+    if not isinstance(payload_properties, dict):
+        return {}
+    return payload_properties
 
 
 class ExperienceWave3SeedContractTests(unittest.TestCase):
@@ -115,12 +129,12 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                     with_unknown_payload["payload"]["contract_escape"] = "loose-payload"
                     self.assert_invalid(schema, with_unknown_payload, f"{stem} unknown payload field")
 
-                    if payload:
-                        key = next(iter(payload))
-                        with_wrong_payload_type = copy.deepcopy(example)
-                        self.assertIsInstance(with_wrong_payload_type["payload"], dict)
-                        with_wrong_payload_type["payload"][key] = wrong_type_value(payload[key])
-                        self.assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong payload type")
+                    for key, value in payload.items():
+                        with self.subTest(stem=stem, key=key, case="wrong-type"):
+                            with_wrong_payload_type = copy.deepcopy(example)
+                            self.assertIsInstance(with_wrong_payload_type["payload"], dict)
+                            with_wrong_payload_type["payload"][key] = wrong_type_value(value)
+                            self.assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong {key} type")
 
     def test_experience_wave3_schemas_reject_guardrail_boolean_inversions(self) -> None:
         for stem in WAVE3_STEMS:
@@ -151,6 +165,12 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                     self.assertIsInstance(mutated["payload"], dict)
                     mutated["payload"][key] = -1
                     self.assert_invalid(schema, mutated, f"{stem} negative {key}")
+                if key == "retention_cycles":
+                    with self.subTest(stem=stem, key=key, case="zero"):
+                        mutated = copy.deepcopy(example)
+                        self.assertIsInstance(mutated["payload"], dict)
+                        mutated["payload"][key] = 0
+                        self.assert_invalid(schema, mutated, f"{stem} zero {key}")
                 if key == "value" or any(hint in key for hint in RATIO_FIELD_HINTS):
                     with self.subTest(stem=stem, key=key, case="above-one"):
                         mutated = copy.deepcopy(example)
@@ -172,6 +192,21 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                     self.assertIsInstance(mutated["payload"], dict)
                     mutated["payload"][key] = [12345]
                     self.assert_invalid(schema, mutated, f"{stem} non-string {key} item")
+
+    def test_experience_wave3_schemas_reject_payload_enum_escape_values(self) -> None:
+        for stem in WAVE3_STEMS:
+            schema, example = load_contract(stem)
+            payload = example.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            for key, prop in payload_schema_properties(schema).items():
+                if not isinstance(prop, dict) or "enum" not in prop or key not in payload:
+                    continue
+                with self.subTest(stem=stem, key=key):
+                    mutated = copy.deepcopy(example)
+                    self.assertIsInstance(mutated["payload"], dict)
+                    mutated["payload"][key] = ENUM_ESCAPE_VALUE
+                    self.assert_invalid(schema, mutated, f"{stem} enum escape {key}")
 
 
 if __name__ == "__main__":

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WAVE3_STEMS = (
+    "technique_adoption_boundary_check",
+    "technique_obsolescence_notice",
+    "technique_pattern_adoption_note",
+    "technique_retention_probe",
+    "technique_to_skill_handoff",
+)
+
+
+def load_contract(stem: str) -> tuple[dict[str, object], dict[str, object]]:
+    schema_path = ROOT / "schemas" / f"{stem}_v1.json"
+    example_path = ROOT / "examples" / f"{stem}.example.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    return schema, example
+
+
+def validation_errors(schema: dict[str, object], value: dict[str, object]) -> list[object]:
+    return sorted(Draft202012Validator(schema).iter_errors(value), key=lambda error: list(error.path))
+
+
+def assert_invalid(schema: dict[str, object], value: dict[str, object], label: str) -> None:
+    errors = validation_errors(schema, value)
+    assert errors, f"{label} unexpectedly validated"
+
+
+def wrong_type_value(value: object) -> object:
+    if isinstance(value, bool):
+        return "not-a-boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "not-an-integer"
+    if isinstance(value, float):
+        return "not-a-number"
+    if isinstance(value, str):
+        return 12345
+    if isinstance(value, list):
+        return {"not": "an array"}
+    if isinstance(value, dict):
+        return "not-an-object"
+    return "not-null"
+
+
+def test_experience_wave3_examples_match_schemas() -> None:
+    missing_pairs: list[str] = []
+    for stem in WAVE3_STEMS:
+        schema_path = ROOT / "schemas" / f"{stem}_v1.json"
+        example_path = ROOT / "examples" / f"{stem}.example.json"
+        if not schema_path.exists():
+            missing_pairs.append(f"{example_path.relative_to(ROOT)} -> {schema_path.relative_to(ROOT)}")
+        if not example_path.exists():
+            missing_pairs.append(f"{schema_path.relative_to(ROOT)} -> {example_path.relative_to(ROOT)}")
+    assert not missing_pairs, "missing wave3 contract pair(s): " + ", ".join(missing_pairs)
+
+    assert WAVE3_STEMS
+    for stem in WAVE3_STEMS:
+        schema, example = load_contract(stem)
+        Draft202012Validator.check_schema(schema)
+        errors = validation_errors(schema, example)
+        assert not errors, f"{stem}: {errors[0].message}" if errors else stem
+
+
+def test_experience_wave3_schemas_reject_escape_hatches() -> None:
+    assert WAVE3_STEMS
+    for stem in WAVE3_STEMS:
+        schema, example = load_contract(stem)
+
+        with_unknown_top = copy.deepcopy(example)
+        with_unknown_top["contract_escape"] = True
+        assert_invalid(schema, with_unknown_top, f"{stem} unknown top-level field")
+
+        refs = example.get("refs")
+        if isinstance(refs, dict):
+            with_unknown_ref = copy.deepcopy(example)
+            assert isinstance(with_unknown_ref["refs"], dict)
+            with_unknown_ref["refs"]["contract_escape"] = "loose-ref"
+            assert_invalid(schema, with_unknown_ref, f"{stem} unknown refs field")
+
+        payload = example.get("payload")
+        if isinstance(payload, dict):
+            with_unknown_payload = copy.deepcopy(example)
+            assert isinstance(with_unknown_payload["payload"], dict)
+            with_unknown_payload["payload"]["contract_escape"] = "loose-payload"
+            assert_invalid(schema, with_unknown_payload, f"{stem} unknown payload field")
+
+            if payload:
+                key = next(iter(payload))
+                with_wrong_payload_type = copy.deepcopy(example)
+                assert isinstance(with_wrong_payload_type["payload"], dict)
+                with_wrong_payload_type["payload"][key] = wrong_type_value(payload[key])
+                assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong payload type")

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -83,6 +83,16 @@ def payload_schema_properties(schema: dict[str, object]) -> dict[str, object]:
     return payload_properties if isinstance(payload_properties, dict) else {}
 
 
+def required_payload_fields(schema: dict[str, object]) -> list[str]:
+    payload = schema_properties(schema).get("payload")
+    if not isinstance(payload, dict):
+        return []
+    required = payload.get("required")
+    if not isinstance(required, list):
+        return []
+    return [field for field in required if isinstance(field, str)]
+
+
 def array_field_targets(example: dict[str, object]) -> list[tuple[str, str]]:
     targets: list[tuple[str, str]] = []
     for key, value in example.items():
@@ -180,6 +190,24 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                     self.assertIsInstance(mutated["payload"], dict)
                     mutated["payload"][key] = not value
                     self.assert_invalid(schema, mutated, f"{stem} inverted {key}")
+
+    def test_experience_wave3_schemas_reject_missing_required_payload_fields(self) -> None:
+        exercised = 0
+        for stem in WAVE3_STEMS:
+            schema, example = load_contract(stem)
+            payload = example.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            for key in required_payload_fields(schema):
+                if key not in payload:
+                    continue
+                exercised += 1
+                with self.subTest(stem=stem, key=key):
+                    mutated = copy.deepcopy(example)
+                    self.assertIsInstance(mutated["payload"], dict)
+                    del mutated["payload"][key]
+                    self.assert_invalid(schema, mutated, f"{stem} missing required payload.{key}")
+        self.assertGreater(exercised, 0, "no required wave3 payload fields were exercised")
 
     def test_experience_wave3_schemas_reject_invalid_numeric_ranges(self) -> None:
         for stem in WAVE3_STEMS:

--- a/tests/test_experience_wave3_seed_contracts.py
+++ b/tests/test_experience_wave3_seed_contracts.py
@@ -16,6 +16,27 @@ WAVE3_STEMS = (
     "technique_retention_probe",
     "technique_to_skill_handoff",
 )
+GUARDRAIL_BOOLEAN_FIELDS = {
+    "authority_required",
+    "derived_only",
+    "direct_tos_write",
+    "direct_write",
+    "direct_write_allowed",
+    "direct_write_blocked",
+    "dossier_allowed",
+    "drill_required",
+    "kag_may_force_uptake",
+    "kag_may_propose",
+    "lineage_indexed",
+    "meaning_authority",
+    "required_trial",
+    "requires_eval_verdict",
+    "requires_owner_consent",
+    "rollback_required",
+    "source_theft",
+    "submit_only",
+}
+RATIO_FIELD_HINTS = ("rate", "threshold")
 
 
 def load_contract(stem: str) -> tuple[dict[str, object], dict[str, object]]:
@@ -100,6 +121,57 @@ class ExperienceWave3SeedContractTests(unittest.TestCase):
                         self.assertIsInstance(with_wrong_payload_type["payload"], dict)
                         with_wrong_payload_type["payload"][key] = wrong_type_value(payload[key])
                         self.assert_invalid(schema, with_wrong_payload_type, f"{stem} wrong payload type")
+
+    def test_experience_wave3_schemas_reject_guardrail_boolean_inversions(self) -> None:
+        for stem in WAVE3_STEMS:
+            schema, example = load_contract(stem)
+            payload = example.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            for key, value in payload.items():
+                if key not in GUARDRAIL_BOOLEAN_FIELDS or not isinstance(value, bool):
+                    continue
+                with self.subTest(stem=stem, key=key):
+                    mutated = copy.deepcopy(example)
+                    self.assertIsInstance(mutated["payload"], dict)
+                    mutated["payload"][key] = not value
+                    self.assert_invalid(schema, mutated, f"{stem} inverted {key}")
+
+    def test_experience_wave3_schemas_reject_invalid_numeric_ranges(self) -> None:
+        for stem in WAVE3_STEMS:
+            schema, example = load_contract(stem)
+            payload = example.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            for key, value in payload.items():
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
+                with self.subTest(stem=stem, key=key, case="negative"):
+                    mutated = copy.deepcopy(example)
+                    self.assertIsInstance(mutated["payload"], dict)
+                    mutated["payload"][key] = -1
+                    self.assert_invalid(schema, mutated, f"{stem} negative {key}")
+                if key == "value" or any(hint in key for hint in RATIO_FIELD_HINTS):
+                    with self.subTest(stem=stem, key=key, case="above-one"):
+                        mutated = copy.deepcopy(example)
+                        self.assertIsInstance(mutated["payload"], dict)
+                        mutated["payload"][key] = 1.5
+                        self.assert_invalid(schema, mutated, f"{stem} out-of-range {key}")
+
+    def test_experience_wave3_schemas_reject_non_string_array_items(self) -> None:
+        for stem in WAVE3_STEMS:
+            schema, example = load_contract(stem)
+            payload = example.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            for key, value in payload.items():
+                if not isinstance(value, list):
+                    continue
+                with self.subTest(stem=stem, key=key):
+                    mutated = copy.deepcopy(example)
+                    self.assertIsInstance(mutated["payload"], dict)
+                    mutated["payload"][key] = [12345]
+                    self.assert_invalid(schema, mutated, f"{stem} non-string {key} item")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Plant Experience Wave 3 from the v0.6 federation harvest and v0.7 adoption forge seeds into this owner repo.
- Add owner-local docs, strict schema/example pairs, and contract tests that reject unknown fields and wrong payload types.
- Preserve the Wave 3 stop-lines: no Codex harvest approval, no forced adoption, no hidden assistant self-rewrite, no direct ToS write, and no runtime activation from seed landing.

## Validation

- `python scripts/release_check.py`
- Wave 3 targeted schema/example contract tests
- staged `git diff --cached --check`
- staged secret-pattern scan
- checkpoint review-note completed for `582a7c3`
