### PR TITLE
[codex] Add experience wave4 technique contracts

### DIFF
--- a/docs/APPEAL_REASONING_TECHNIQUES.md
+++ b/docs/APPEAL_REASONING_TECHNIQUES.md
@@ -1,0 +1,39 @@
+# Appeal Reasoning Techniques
+
+Status: seed v0.8.0  
+Repo landing: `aoa-techniques`  
+Layer: Experience Polis Governance
+
+## Purpose
+
+Reasoning techniques for appeals and overturns.
+
+v0.8 adds a polis-governance contour around the experience mechanic. Earlier seeds forged capture, distillation, certification, deployment, federation and adoption. This seed asks a harder question: **who may decide when those paths conflict?**
+
+## Local law
+
+- Local owner keeps meaning authority.
+- Governance packets must cite evidence and decision refs.
+- No direct ToS write or hidden assistant self-change.
+
+## Minimal flow
+
+1. Receive governance route signal.
+2. Validate authority and local owner consent.
+3. Apply, hold, reject or escalate according to owner law.
+4. Emit audit receipt.
+
+## Owner notes
+
+- aoa-techniques receives only bounded governance surfaces.
+- Policy precedent may inform local decisions but not force local adoption.
+
+## Invariants
+
+- Codex may collect evidence and propose packets, but may not vote, certify, veto, amend charters, or submit direct Tree-of-Sophia writes.
+- Assistant agents may request review, but may not self-recharter, self-promote, or convert service revision into agonic scar authority.
+- Agonic agents may contest, appeal and receive scars, but may not launder scars through assistant release paths.
+- Councils produce reviewable decisions, not hidden doctrine.
+- Vetoes and emergency stay orders require explicit authority and expiry.
+- Governance precedents may be harvested, but owner-local adoption still requires consent.
+- Tree-of-Sophia intake remains dossier-bound and never direct runtime governance write.

--- a/docs/AUTHORITY_RESOLUTION_TECHNIQUES.md
+++ b/docs/AUTHORITY_RESOLUTION_TECHNIQUES.md
@@ -1,0 +1,5 @@
+# AUTHORITY RESOLUTION TECHNIQUES
+
+Techniques for separating actor capability from governance authority.
+
+Runtime law remains reviewable. Owner meaning remains owner-local.

--- a/docs/GOVERNANCE_TECHNIQUE_PRECEDENT.md
+++ b/docs/GOVERNANCE_TECHNIQUE_PRECEDENT.md
@@ -1,0 +1,39 @@
+# Governance Technique Precedent
+
+Status: seed v0.8.0  
+Repo landing: `aoa-techniques`  
+Layer: Experience Polis Governance
+
+## Purpose
+
+How reusable governance techniques are documented.
+
+v0.8 adds a polis-governance contour around the experience mechanic. Earlier seeds forged capture, distillation, certification, deployment, federation and adoption. This seed asks a harder question: **who may decide when those paths conflict?**
+
+## Local law
+
+- Local owner keeps meaning authority.
+- Governance packets must cite evidence and decision refs.
+- No direct ToS write or hidden assistant self-change.
+
+## Minimal flow
+
+1. Receive governance route signal.
+2. Validate authority and local owner consent.
+3. Apply, hold, reject or escalate according to owner law.
+4. Emit audit receipt.
+
+## Owner notes
+
+- aoa-techniques receives only bounded governance surfaces.
+- Policy precedent may inform local decisions but not force local adoption.
+
+## Invariants
+
+- Codex may collect evidence and propose packets, but may not vote, certify, veto, amend charters, or submit direct Tree-of-Sophia writes.
+- Assistant agents may request review, but may not self-recharter, self-promote, or convert service revision into agonic scar authority.
+- Agonic agents may contest, appeal and receive scars, but may not launder scars through assistant release paths.
+- Councils produce reviewable decisions, not hidden doctrine.
+- Vetoes and emergency stay orders require explicit authority and expiry.
+- Governance precedents may be harvested, but owner-local adoption still requires consent.
+- Tree-of-Sophia intake remains dossier-bound and never direct runtime governance write.

--- a/docs/SEALED_DECISION_TECHNIQUES.md
+++ b/docs/SEALED_DECISION_TECHNIQUES.md
@@ -1,0 +1,5 @@
+# SEALED DECISION TECHNIQUES
+
+Techniques for commit/reveal, hash chain review and tamper detection.
+
+Runtime law remains reviewable. Owner meaning remains owner-local.

--- a/examples/appeal_reasoning_step.example.json
+++ b/examples/appeal_reasoning_step.example.json
@@ -1,0 +1,20 @@
+{
+  "authority": {
+    "actor": "operator.sovereign",
+    "mode": "reviewed"
+  },
+  "created_at": "2026-04-22T12:00:00-06:00",
+  "decision_refs": [],
+  "evidence_refs": [
+    "receipt:example:001"
+  ],
+  "id": "technique.appeal_reasoning_step.example.001",
+  "kind": "technique.appeal_reasoning_step",
+  "notes": [
+    "seed example for v0.8 polis governance"
+  ],
+  "requires_trace": true,
+  "schema_version": "v1",
+  "status": "proposed",
+  "step": "compare_omitted_evidence"
+}

--- a/examples/sealed_decision_technique_note_v1.example.json
+++ b/examples/sealed_decision_technique_note_v1.example.json
@@ -1,0 +1,5 @@
+{
+  "applies_to": "governance_vote",
+  "note_id": "tech_001",
+  "technique": "commit_reveal_hashing"
+}

--- a/examples/technique_governance_precedent.example.json
+++ b/examples/technique_governance_precedent.example.json
@@ -1,0 +1,20 @@
+{
+  "authority": {
+    "actor": "operator.sovereign",
+    "mode": "reviewed"
+  },
+  "created_at": "2026-04-22T12:00:00-06:00",
+  "decision_refs": [],
+  "evidence_refs": [
+    "receipt:example:001"
+  ],
+  "id": "technique.governance_precedent.example.001",
+  "kind": "technique.governance_precedent",
+  "notes": [
+    "seed example for v0.8 polis governance"
+  ],
+  "precedent_ref": "experience.policy_precedent.example.001",
+  "schema_version": "v1",
+  "status": "proposed",
+  "technique_ref": "technique.appeal_reasoning"
+}

--- a/schemas/appeal_reasoning_step_v1.json
+++ b/schemas/appeal_reasoning_step_v1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/appeal_reasoning_step_v1.json",
+  "title": "Appeal Reasoning Step V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authority",
+    "created_at",
+    "decision_refs",
+    "evidence_refs",
+    "id",
+    "kind",
+    "notes",
+    "requires_trace",
+    "schema_version",
+    "status",
+    "step"
+  ],
+  "properties": {
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor",
+        "mode"
+      ],
+      "properties": {
+        "actor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "reviewed"
+          ]
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1,
+      "const": "technique.appeal_reasoning_step"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "requires_trace": {
+      "type": "boolean",
+      "const": true
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1,
+      "const": "v1"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1,
+      "enum": [
+        "proposed"
+      ]
+    },
+    "step": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/schemas/sealed_decision_technique_note_v1.json
+++ b/schemas/sealed_decision_technique_note_v1.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/sealed_decision_technique_note_v1.json",
+  "title": "sealed_decision_technique_note_v1",
+  "description": "Seed schema for sealed_decision_technique_note_v1 in Experience Constitution Runtime v0.9.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "applies_to",
+    "note_id",
+    "technique"
+  ],
+  "properties": {
+    "applies_to": {
+      "type": "string",
+      "minLength": 1
+    },
+    "note_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "technique": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/schemas/technique_governance_precedent_v1.json
+++ b/schemas/technique_governance_precedent_v1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aoa.local/aoa-techniques/schemas/technique_governance_precedent_v1.json",
+  "title": "Technique Governance Precedent V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "authority",
+    "created_at",
+    "decision_refs",
+    "evidence_refs",
+    "id",
+    "kind",
+    "notes",
+    "precedent_ref",
+    "schema_version",
+    "status",
+    "technique_ref"
+  ],
+  "properties": {
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "actor",
+        "mode"
+      ],
+      "properties": {
+        "actor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1,
+          "enum": [
+            "reviewed"
+          ]
+        }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "decision_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1,
+      "const": "technique.governance_precedent"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "precedent_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1,
+      "const": "v1"
+    },
+    "status": {
+      "type": "string",
+      "minLength": 1,
+      "enum": [
+        "proposed"
+      ]
+    },
+    "technique_ref": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/tests/test_experience_wave4_seed_contracts.py
+++ b/tests/test_experience_wave4_seed_contracts.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import unittest
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENUM_ESCAPE_VALUE = "__wave4_not_allowed__"
+
+WAVE4_CONTRACTS = (
+    ('appeal_reasoning_step', 'appeal_reasoning_step_v1.json'),
+    ('technique_governance_precedent', 'technique_governance_precedent_v1.json'),
+    ('sealed_decision_technique_note_v1', 'sealed_decision_technique_note_v1.json'),
+)
+
+
+
+def load_contract(stem: str, schema_file: str) -> tuple[dict[str, object], dict[str, object]]:
+    schema_path = ROOT / "schemas" / schema_file
+    example_path = ROOT / "examples" / f"{stem}.example.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    return schema, example
+
+
+def validation_errors(schema: dict[str, object], value: dict[str, object]) -> list[object]:
+    return sorted(Draft202012Validator(schema).iter_errors(value), key=lambda error: list(error.path))
+
+
+def wrong_type_value(value: object) -> object:
+    if isinstance(value, bool):
+        return "not-a-boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "not-an-integer"
+    if isinstance(value, float):
+        return "not-a-number"
+    if isinstance(value, str):
+        return 12345
+    if isinstance(value, list):
+        return {"not": "an array"}
+    if isinstance(value, dict):
+        return "not-an-object"
+    return "not-null"
+
+
+def const_escape_value(value: object) -> object:
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value + 1
+    if isinstance(value, float):
+        return value + 1.0
+    if isinstance(value, str):
+        return f"{value}{ENUM_ESCAPE_VALUE}"
+    return ENUM_ESCAPE_VALUE
+
+
+def get_path(value: object, path: tuple[object, ...]) -> object:
+    cursor = value
+    for part in path:
+        if isinstance(part, int):
+            assert isinstance(cursor, list)
+            cursor = cursor[part]
+        else:
+            assert isinstance(cursor, dict)
+            cursor = cursor[part]
+    return cursor
+
+
+def set_path(value: object, path: tuple[object, ...], replacement: object) -> None:
+    cursor = value
+    for part in path[:-1]:
+        if isinstance(part, int):
+            assert isinstance(cursor, list)
+            cursor = cursor[part]
+        else:
+            assert isinstance(cursor, dict)
+            cursor = cursor[part]
+    last = path[-1]
+    if isinstance(last, int):
+        assert isinstance(cursor, list)
+        cursor[last] = replacement
+    else:
+        assert isinstance(cursor, dict)
+        cursor[last] = replacement
+
+
+def delete_path(value: object, path: tuple[object, ...]) -> None:
+    cursor = value
+    for part in path[:-1]:
+        if isinstance(part, int):
+            assert isinstance(cursor, list)
+            cursor = cursor[part]
+        else:
+            assert isinstance(cursor, dict)
+            cursor = cursor[part]
+    last = path[-1]
+    if isinstance(last, int):
+        assert isinstance(cursor, list)
+        del cursor[last]
+    else:
+        assert isinstance(cursor, dict)
+        del cursor[last]
+
+
+def walk_values(value: object, path: tuple[object, ...] = ()) -> list[tuple[tuple[object, ...], object]]:
+    found: list[tuple[tuple[object, ...], object]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = (*path, key)
+            found.append((child_path, child))
+            found.extend(walk_values(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            child_path = (*path, index)
+            found.append((child_path, child))
+            found.extend(walk_values(child, child_path))
+    return found
+
+
+def object_paths(value: object, path: tuple[object, ...] = ()) -> list[tuple[object, ...]]:
+    found: list[tuple[object, ...]] = []
+    if isinstance(value, dict):
+        found.append(path)
+        for key, child in value.items():
+            found.extend(object_paths(child, (*path, key)))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(object_paths(child, (*path, index)))
+    return found
+
+
+def array_paths(value: object, path: tuple[object, ...] = ()) -> list[tuple[object, ...]]:
+    found: list[tuple[object, ...]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            found.extend(array_paths(child, (*path, key)))
+    elif isinstance(value, list):
+        found.append(path)
+        for index, child in enumerate(value):
+            found.extend(array_paths(child, (*path, index)))
+    return found
+
+
+def schema_type(schema: object) -> object:
+    return schema.get("type") if isinstance(schema, dict) else None
+
+
+def schema_properties(schema: object) -> dict[str, object]:
+    if not isinstance(schema, dict):
+        return {}
+    props = schema.get("properties")
+    return props if isinstance(props, dict) else {}
+
+
+def required_paths(schema: object, example: object, path: tuple[object, ...] = ()) -> list[tuple[object, ...]]:
+    found: list[tuple[object, ...]] = []
+    if not isinstance(schema, dict):
+        return found
+    if schema_type(schema) == "object" and isinstance(example, dict):
+        required = schema.get("required")
+        properties = schema_properties(schema)
+        if isinstance(required, list):
+            for key in required:
+                if isinstance(key, str) and key in example:
+                    found.append((*path, key))
+        for key, prop in properties.items():
+            if key in example:
+                found.extend(required_paths(prop, example[key], (*path, key)))
+    if schema_type(schema) == "array" and isinstance(example, list) and example:
+        found.extend(required_paths(schema.get("items"), example[0], (*path, 0)))
+    return found
+
+
+def constrained_paths(schema: object, example: object, keyword: str, path: tuple[object, ...] = ()) -> list[tuple[tuple[object, ...], object]]:
+    found: list[tuple[tuple[object, ...], object]] = []
+    if not isinstance(schema, dict):
+        return found
+    if keyword in schema:
+        found.append((path, schema[keyword]))
+    if schema_type(schema) == "object" and isinstance(example, dict):
+        for key, prop in schema_properties(schema).items():
+            if key in example:
+                found.extend(constrained_paths(prop, example[key], keyword, (*path, key)))
+    if schema_type(schema) == "array" and isinstance(example, list) and example:
+        found.extend(constrained_paths(schema.get("items"), example[0], keyword, (*path, 0)))
+    return found
+
+
+class ExperienceWave4SeedContractTests(unittest.TestCase):
+    def assert_invalid(self, schema: dict[str, object], value: dict[str, object], label: str) -> None:
+        errors = validation_errors(schema, value)
+        self.assertTrue(errors, f"{label} unexpectedly validated")
+
+    def test_experience_wave4_examples_match_schemas(self) -> None:
+        self.assertTrue(WAVE4_CONTRACTS)
+        missing_pairs: list[str] = []
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema_path = ROOT / "schemas" / schema_file
+            example_path = ROOT / "examples" / f"{stem}.example.json"
+            if not schema_path.exists():
+                missing_pairs.append(f"{example_path.relative_to(ROOT)} -> {schema_path.relative_to(ROOT)}")
+            if not example_path.exists():
+                missing_pairs.append(f"{schema_path.relative_to(ROOT)} -> {example_path.relative_to(ROOT)}")
+        self.assertFalse(missing_pairs, "missing wave4 contract pair(s): " + ", ".join(missing_pairs))
+
+        for stem, schema_file in WAVE4_CONTRACTS:
+            with self.subTest(stem=stem):
+                schema, example = load_contract(stem, schema_file)
+                Draft202012Validator.check_schema(schema)
+                errors = validation_errors(schema, example)
+                self.assertFalse(errors, f"{stem}: {errors[0].message}" if errors else stem)
+
+    def test_experience_wave4_schemas_reject_unknown_fields(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path in object_paths(example):
+                exercised += 1
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path) or "top"):
+                    mutated = copy.deepcopy(example)
+                    target = get_path(mutated, path) if path else mutated
+                    self.assertIsInstance(target, dict)
+                    target["contract_escape"] = "loose-field"
+                    self.assert_invalid(schema, mutated, f"{stem} unknown field at {path}")
+        self.assertGreater(exercised, 0, "no wave4 object fields were exercised")
+
+    def test_experience_wave4_schemas_reject_wrong_types_for_every_field(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path, value in walk_values(example):
+                exercised += 1
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path)):
+                    mutated = copy.deepcopy(example)
+                    set_path(mutated, path, wrong_type_value(value))
+                    self.assert_invalid(schema, mutated, f"{stem} wrong type at {path}")
+        self.assertGreater(exercised, 0, "no wave4 fields were exercised")
+
+    def test_experience_wave4_schemas_reject_missing_required_fields(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path in required_paths(schema, example):
+                exercised += 1
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path)):
+                    mutated = copy.deepcopy(example)
+                    delete_path(mutated, path)
+                    self.assert_invalid(schema, mutated, f"{stem} missing required field at {path}")
+        self.assertGreater(exercised, 0, "no wave4 required fields were exercised")
+
+    def test_experience_wave4_schemas_reject_bad_array_items(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path in array_paths(example):
+                value = get_path(example, path)
+                if not isinstance(value, list):
+                    continue
+                exercised += 1
+                replacement = [wrong_type_value(value[0])] if value else [12345]
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path), case="wrong-item"):
+                    mutated = copy.deepcopy(example)
+                    set_path(mutated, path, replacement)
+                    self.assert_invalid(schema, mutated, f"{stem} wrong array item at {path}")
+                if not value or isinstance(value[0], str):
+                    with self.subTest(stem=stem, path=".".join(str(part) for part in path), case="empty-string"):
+                        mutated = copy.deepcopy(example)
+                        set_path(mutated, path, [""])
+                        self.assert_invalid(schema, mutated, f"{stem} empty string array item at {path}")
+        self.assertGreater(exercised, 0, "no wave4 array fields were exercised")
+
+    def test_experience_wave4_schemas_reject_const_escapes(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path, _const_value in constrained_paths(schema, example, "const"):
+                if not path:
+                    continue
+                exercised += 1
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path)):
+                    mutated = copy.deepcopy(example)
+                    set_path(mutated, path, const_escape_value(get_path(example, path)))
+                    self.assert_invalid(schema, mutated, f"{stem} const escape at {path}")
+        self.assertGreater(exercised, 0, "no wave4 const fields were exercised")
+
+    def test_experience_wave4_schemas_reject_enum_escapes(self) -> None:
+        exercised = 0
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path, _enum_values in constrained_paths(schema, example, "enum"):
+                if not path:
+                    continue
+                exercised += 1
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path)):
+                    mutated = copy.deepcopy(example)
+                    set_path(mutated, path, ENUM_ESCAPE_VALUE)
+                    self.assert_invalid(schema, mutated, f"{stem} enum escape at {path}")
+        self.assertGreater(exercised, 0, "no wave4 enum fields were exercised")
+
+    def test_experience_wave4_schemas_reject_invalid_numeric_ranges(self) -> None:
+        for stem, schema_file in WAVE4_CONTRACTS:
+            schema, example = load_contract(stem, schema_file)
+            for path, value in walk_values(example):
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
+                with self.subTest(stem=stem, path=".".join(str(part) for part in path), case="negative"):
+                    mutated = copy.deepcopy(example)
+                    set_path(mutated, path, -1)
+                    self.assert_invalid(schema, mutated, f"{stem} negative number at {path}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- add Wave 4 authority, appeal, and sealed-decision technique surfaces
- add hardened schema/example contracts and unittest contract coverage

Validation:
- python scripts/release_check.py