### PR TITLE
[codex] Add semantic AGENTS validation

### DIFF
--- a/.agents/skills/AGENTS.md
+++ b/.agents/skills/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Guidance for `.agents/skills/`
+
+`.agents/skills/` is a generated or exported agent-facing companion surface for technique use.
+
+It may help a coding agent find reusable practice quickly, but the source-authored technique canon remains in `techniques/*/*/TECHNIQUE.md` and related bundle files.
+
+Do not turn a technique export into a new skill bundle. Skills belong in `aoa-skills`; this layer should describe practice primitives, validation patterns, docs layouts, and transfer methods.
+
+Do not hand-edit exported files as the first move. Change the source technique, export configuration, or builder, then regenerate and review the diff.
+
+Keep descriptions short, public-safe, and bounded. Avoid hidden project assumptions, private paths, or capability claims stronger than the source technique.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `config/`
+
+`config/` holds policy, export, and build inputs for the technique canon.
+
+Use config to tune publication and generation behavior, not to author technique meaning. Technique meaning belongs in `TECHNIQUE.md`, checks, examples, notes, and source-owned docs.
+
+Keep config explicit and reviewable. Avoid hidden environment assumptions, private paths, and policy that only one local machine understands.
+
+When config changes generated surfaces, rebuild the affected catalogs and inspect the diff for meaning drift.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `data/`
+
+`data/` holds source-supporting or build-supporting data used by the technique canon.
+
+Treat data changes as contract-adjacent. They may alter catalogs, reports, grouping, or downstream projections even when no Markdown changed.
+
+Keep data public-safe and reproducible. Do not add private transcripts, personal data, secret-bearing payloads, or local-only paths.
+
+If data is derived, document the source and rebuild path. If data is authored, keep ownership clear and avoid making generated files the source of truth.
+
+Verify with the nearest builder or validator, then:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `examples/`
+
+`examples/` demonstrates technique use without becoming the technique canon.
+
+Examples should remain minimal, public-safe, and tied to a source technique, schema, or docs surface. They are allowed to teach, not to invent new doctrine.
+
+When an example shows an adaptation, keep the adaptation boundary explicit. Put promotion, maturity, or portability claims back into the owning technique docs.
+
+No secrets, real credentials, private repositories, or unreduced session transcripts.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/incoming/AGENTS.md
+++ b/incoming/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Guidance for `incoming/`
+
+`incoming/` is a quarantine and staging area for candidate technique material.
+
+Nothing here is canonical merely because it exists. A candidate must be reviewed, normalized, linked to source evidence, and promoted through the documented technique shape before it can speak as canon.
+
+Preserve provenance, uncertainty, and review status. Do not erase rough edges by turning partial notes into polished doctrine too early.
+
+Do not put secrets, private transcripts, or unreduced project dumps here. If material is not public-safe, keep it out of this repository.
+
+Promotion should end in a source-authored technique bundle, not a generated or staging-only artifact.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/reports/AGENTS.md
+++ b/reports/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `reports/`
+
+`reports/` contains readouts about technique coverage, drift, validation, or publication posture.
+
+Reports are diagnostic surfaces. They may point to evidence and gaps, but they do not own technique meaning and must not outrank source-authored bundles.
+
+Keep report language bounded: say what was measured, what was not measured, and what command or source produced the readout.
+
+Do not convert a report into a proof claim that belongs in `aoa-evals` or a workflow claim that belongs in `aoa-skills`.
+
+Verify with the report generator when present, then:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/schemas/AGENTS.md
+++ b/schemas/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `schemas/`
+
+`schemas/` holds machine-readable contracts for technique surfaces, reports, manifests, examples, or downstream exports.
+
+Schema edits are contract edits. Preserve `$schema`, stable identifier posture, required fields, enums, and descriptions that keep techniques reproducible.
+
+Do not loosen a schema only to pass a broken generated file. Fix the source, update paired examples, or document the contract change.
+
+When a schema affects routing, KAG lift, or skill composition, re-check the downstream consumer surface and name the owner repo in the report.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `scripts/`
+
+`scripts/` contains deterministic builders, validators, promotion helpers, and report tools for the technique canon.
+
+Keep scripts repo-relative and reproducible. Avoid hidden network calls, private paths, and ambient credentials unless the command explicitly documents them.
+
+When editing builders, preserve the distinction between authored technique bundles and generated summaries. Generated files summarize; they do not become the canon.
+
+When editing validators, prefer precise failures that name the file, field, and owner surface. Do not weaken validation to make a bad corpus pass.
+
+Verify with:
+
+```bash
+python scripts/validate_repo.py
+python scripts/validate_semantic_agents.py
+```

--- a/scripts/validate_semantic_agents.py
+++ b/scripts/validate_semantic_agents.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate Pack 4 semantic-layer AGENTS.md guidance for aoa-techniques."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class AgentsDocSpec:
+    path: Path
+    required_snippets: tuple[str, ...]
+
+
+REQUIRED_DOCS: tuple[AgentsDocSpec, ...] = (
+    AgentsDocSpec(
+        Path('.agents/skills/AGENTS.md'),
+        (
+            'agent-facing companion surface',
+            'TECHNIQUE.md',
+            'aoa-skills',
+            'public-safe',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('config/AGENTS.md'),
+        (
+            'policy',
+            'export',
+            'TECHNIQUE.md',
+            'generated surfaces',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('data/AGENTS.md'),
+        (
+            'contract-adjacent',
+            'public-safe',
+            'derived',
+            'source of truth',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('examples/AGENTS.md'),
+        (
+            'technique canon',
+            'public-safe',
+            'adaptation boundary',
+            'No secrets',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('incoming/AGENTS.md'),
+        (
+            'quarantine',
+            'candidate',
+            'provenance',
+            'public-safe',
+            'Promotion',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('reports/AGENTS.md'),
+        (
+            'diagnostic surfaces',
+            'source-authored bundles',
+            'bounded',
+            'aoa-evals',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('schemas/AGENTS.md'),
+        (
+            'Schema edits are contract edits',
+            '$schema',
+            'paired examples',
+            'downstream consumer',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('scripts/AGENTS.md'),
+        (
+            'deterministic builders',
+            'repo-relative',
+            'generated summaries',
+            'validators',
+            'validate_repo.py',
+        ),
+    ),
+    AgentsDocSpec(
+        Path('tests/AGENTS.md'),
+        (
+            'technique contracts',
+            'generated parity',
+            'public-safe',
+            'python -m unittest discover -s tests',
+            'validate_semantic_agents.py',
+        ),
+    ),
+)
+
+
+def _display(path: Path, repo_root: Path) -> str:
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def validate(repo_root: Path = REPO_ROOT) -> list[str]:
+    issues: list[str] = []
+    for spec in REQUIRED_DOCS:
+        path = repo_root / spec.path
+        if not path.is_file():
+            issues.append(f"{spec.path.as_posix()}: file is missing")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if not text.strip().startswith("# AGENTS.md"):
+            issues.append(f"{spec.path.as_posix()}: must start with '# AGENTS.md'")
+        for snippet in spec.required_snippets:
+            if snippet not in text:
+                issues.append(
+                    f"{spec.path.as_posix()}: missing required snippet {snippet!r}"
+                )
+    return issues
+
+
+def main() -> int:
+    issues = validate(REPO_ROOT)
+    if issues:
+        print("Pack 4 semantic AGENTS validation failed.", file=sys.stderr)
+        for issue in issues:
+            print(f"- {issue}", file=sys.stderr)
+        return 1
+    print(f"[ok] Pack 4 semantic AGENTS docs are present and shaped: {len(REQUIRED_DOCS)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Guidance for `tests/`
+
+`tests/` protects technique contracts, validators, builders, generated parity, and downstream-consumer assumptions.
+
+Tests should keep reusable practice reproducible. Prefer cases that expose invariants, boundary conditions, drift, and transfer behavior rather than incidental formatting.
+
+Do not update snapshots or expected generated surfaces without rebuilding and checking the source-authored technique or manifest that owns meaning.
+
+Keep fixtures public-safe. No secrets, private transcripts, hidden benchmark data, or machine-local paths.
+
+Verify with:
+
+```bash
+python -m unittest discover -s tests
+python scripts/validate_semantic_agents.py
+```

--- a/tests/test_validate_semantic_agents.py
+++ b/tests/test_validate_semantic_agents.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_semantic_agents.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_semantic_agents", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ValidateSemanticAgentsTests(unittest.TestCase):
+    def test_repository_semantic_docs_validate(self) -> None:
+        module = load_validator()
+        self.assertEqual(module.validate(REPO_ROOT), [])
+
+    def test_missing_required_doc_fails(self) -> None:
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for spec in module.REQUIRED_DOCS:
+                path = root / spec.path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# AGENTS.md\n" + "\n".join(spec.required_snippets) + "\n", encoding="utf-8")
+            missing = root / module.REQUIRED_DOCS[0].path
+            missing.unlink()
+            issues = module.validate(root)
+        self.assertTrue(any("file is missing" in issue for issue in issues))
+
+    def test_missing_required_snippet_fails(self) -> None:
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for spec in module.REQUIRED_DOCS:
+                path = root / spec.path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("# AGENTS.md\n" + "\n".join(spec.required_snippets) + "\n", encoding="utf-8")
+            target_spec = module.REQUIRED_DOCS[0]
+            target = root / target_spec.path
+            first_snippet = target_spec.required_snippets[0]
+            target.write_text("# AGENTS.md\n" + "\n".join(target_spec.required_snippets[1:]) + "\n", encoding="utf-8")
+            issues = module.validate(root)
+        self.assertTrue(any(first_snippet in issue for issue in issues))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Pack4 semantic-layer tightening surfaces: local AGENTS.md guidance for semantic subtrees plus scripts/validate_semantic_agents.py and focused unit coverage. Local validation covered semantic validator/unit tests, existing nested AGENTS validation, staged diff whitespace check, high-risk token scan, and full python -m pytest -q tests.