### PR TITLE
[codex] Define technique atom and topology contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,16 @@ Root route card for `aoa-techniques`.
 `aoa-techniques` is the public practice canon of AoA.
 It stores reusable, sanitized, bounded, reviewable engineering techniques that can later be lifted into skills, evals, routing, KAG exports, or other derived artifacts.
 A technique is a portable unit of method, not a skill bundle, proof surface, questline, or agent identity.
+The primary unit is an atomic executable move: one compact technique should be small enough to classify, template, and hand to a small agent after orchestration supplies the right context.
+Technique classification is faceted: `domain` and `kind` are current frontmatter truth, while family, capability, substrate, execution profile, risk posture, and relation topology should stay explicit design axes instead of being collapsed into tags.
 
 ## Owner lane
 
 This repository owns:
 
 - technique bundle meaning, IDs, intent, contracts, and adaptation notes
-- public-safe technique wording and kind/domain selection
+- public-safe technique wording and topology selection, including current
+  domain/kind truth and future family/capability/substrate/risk axes
 - owner-local participation in AoA cross-mechanics around reusable practice movement
 - generated technique catalogs, capsules, feat-card reader surfaces, and source-lift surfaces
 
@@ -27,13 +30,15 @@ It does not own:
 1. `README.md`
 2. `ROADMAP.md`
 3. `docs/START_HERE.md`
-4. `mechanics/README.md` when the change touches AoA mechanics or practice movement around canon
-5. `WALKTHROUGH.md`
-6. `docs/TECHNIQUE_SELECTION.md`
-7. `docs/TECHNIQUE_KIND_GUIDE.md`
-8. the target `techniques/**/TECHNIQUE.md`
-9. affected generated catalogs, capsules, feat cards, or source-lift outputs
-10. `docs/AGENTS_ROOT_REFERENCE.md` for preserved full root branches
+4. `docs/TECHNIQUE_ATOM_CONTRACT.md`
+5. `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
+6. `mechanics/README.md` when the change touches AoA mechanics or practice movement around canon
+7. `WALKTHROUGH.md`
+8. `docs/TECHNIQUE_SELECTION.md`
+9. `docs/TECHNIQUE_KIND_GUIDE.md`
+10. the target `techniques/**/TECHNIQUE.md`
+11. affected generated catalogs, capsules, feat cards, or source-lift outputs
+12. `docs/AGENTS_ROOT_REFERENCE.md` for preserved full root branches
 
 
 ## AGENTS stack law
@@ -48,6 +53,7 @@ It does not own:
 ## Route away when
 
 - the object is an executable workflow, not a reusable practice
+- the object needs a chain of several independent moves instead of one atomic technique
 - the change is proof, routing, memory, role, playbook, KAG, or stats meaning
 - the idea is vague philosophy without an operational method
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Public library of reusable techniques for coding agents and humans.
 
-`aoa-techniques` is the public practice canon of AoA. It is not a snippet dump and not an “awesome list”. A technique here is a minimal reproducible unit of engineering practice: a workflow, validation pattern, safety protocol, documentation layout, evaluation loop, or transfer method that can travel cleanly across projects.
+`aoa-techniques` is the public practice canon of AoA. It is not a snippet dump
+and not an "awesome list". A technique here is an atomic executable move: one
+minimal reproducible unit of engineering practice that can be classified,
+templated, verified, and handed to a small agent after orchestration supplies the
+right context.
 
 > Current release: `v0.4.2`. See [CHANGELOG](CHANGELOG.md) for release notes.
 
@@ -11,6 +15,8 @@ Public library of reusable techniques for coding agents and humans.
 Use the shortest route by need:
 
 - repo-owned entrypoint: `docs/START_HERE.md`
+- atomic technique contract: `docs/TECHNIQUE_ATOM_CONTRACT.md`
+- classification topology contract: `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
 - one full bundle end to end: `techniques/agent-workflows/plan-diff-apply-verify-report/TECHNIQUE.md`
 - current technique map: `TECHNIQUE_INDEX.md`
 - current direction and hardening waves: `docs/START_HERE.md` and `ROADMAP.md`
@@ -26,7 +32,8 @@ Use the shortest route by need:
 - repo layer position and neighboring repos: `docs/ECOSYSTEM_CONTEXT.md`
 - current technique map, docs map, and generated catalog: `TECHNIQUE_INDEX.md`, `docs/README.md`, and `generated/technique_catalog.min.json`
 - via negativa pruning checklist: `docs/VIA_NEGATIVA_CHECKLIST.md`
-- frontmatter routing axes and kind doctrine: `docs/DOMAIN_MAP.md`, `docs/TECHNIQUE_KIND_GUIDE.md`, `docs/TECHNIQUE_KIND_HANDOFF_PACK.md`, `generated/technique_kind_manifest.min.json`, `config/technique_kind_registry.yaml`, `data/technique_kind_wave1.yaml`, `reports/wave1_kind_counts.md`, and `docs/TECHNIQUE_KINDS_SEED.md`
+- frontmatter routing axes, topology, and kind doctrine: `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`, `docs/DOMAIN_MAP.md`, `docs/TECHNIQUE_KIND_GUIDE.md`, `docs/TECHNIQUE_KIND_HANDOFF_PACK.md`, `generated/technique_kind_manifest.min.json`, `config/technique_kind_registry.yaml`, `config/technique_family_seed.yaml`, `data/technique_kind_wave1.yaml`, `reports/technique_family_scout.md`, `reports/wave1_kind_counts.md`, and `docs/TECHNIQUE_KINDS_SEED.md`
+- atomicity and small-agent authoring contract: `docs/TECHNIQUE_ATOM_CONTRACT.md`
 - feat-reader and runtime-card surfaces: `mechanics/growth-cycle/TECHNIQUE_FEAT_MODEL.md`, `generated/technique_feat_cards.min.example.json`, `docs/TECHNIQUE_CAPSULES.md`, and `generated/technique_capsules.min.json`
 - status, review, and promotion posture: `docs/CANONICAL_RUBRIC.md`, `docs/CANONICAL_REVIEW_GUIDE.md`, `mechanics/audit/PROMOTION_READINESS_MATRIX.md`, `generated/technique_promotion_readiness.min.json`, and `docs/RELEASING.md`
 - Agon practice-candidate bridge: `mechanics/agon/parts/move-technique-bridge/README.md`, `mechanics/agon/LANDING_LOG.md`, `mechanics/agon/PROVENANCE.md`, `mechanics/agon/parts/move-technique-bridge/generated/agon_technique_binding_candidates.min.json`, `python mechanics/agon/parts/move-technique-bridge/scripts/build_agon_technique_binding_candidates.py --check`, `python mechanics/agon/parts/move-technique-bridge/scripts/validate_agon_technique_binding_candidates.py`, and `python -m pytest -q mechanics/agon/parts/move-technique-bridge/tests/test_agon_technique_binding_candidates.py`
@@ -72,6 +79,8 @@ Bad candidates:
 ## Core principles
 
 - public-safe reusable practice over project-local residue
+- atomic executable moves over chains disguised as techniques
+- faceted topology over overloaded buckets or one giant category tree
 - bounded, reviewable contracts over vague lore
 - source-linked promotion over raw copying
 - linked docs and generated surfaces over oversized root inventories
@@ -104,6 +113,8 @@ full intake history.
 A strong technique should include:
 
 - clear intent and usage boundaries
+- one atomic move that can be executed from a compact runtime card
+- topology fit across `domain`, `kind`, and any reviewed future axes
 - explicit inputs, outputs, and risks
 - validation method
 - adaptation notes when portability needs them
@@ -112,9 +123,9 @@ A strong technique should include:
 ## Contribution model
 
 `aoa-techniques` owns practice meaning, while neighboring repos own execution,
-proof, routing, role, and scenario composition. If a reusable contract can be
-extracted cleanly from a neighboring layer, it belongs here once it becomes
-public-safe, bounded, and portable.
+proof, routing, role, and scenario composition. If one atomic reusable contract
+can be extracted cleanly from a neighboring layer, it belongs here once it
+becomes public-safe, bounded, and portable.
 
 The current runtime path for public technique use remains:
 

--- a/config/technique_family_seed.yaml
+++ b/config/technique_family_seed.yaml
@@ -1,10 +1,12 @@
 schema_version: 1
 axis_name: technique_family
-status: optional-wave1-seed
+status: scout-foundation
 cardinality: zero-or-one-secondary-family
-purpose: Optional second semantic axis for stable corpus clusters. Not required to land wave1 `kind`.
+purpose: Optional semantic shelf axis for stable corpus clusters. Not authoritative frontmatter yet;
+  use the topology contract before promoting family into schema or validators.
 core_rules:
 - Keep family narrower than domain and more cluster-like than kind.
+- Use family as a library shelf that may span domains, kinds, substrates, and risk postures.
 - A family may contain multiple kinds when one stable cluster spans workflows, guardrails, and evidence
   surfaces.
 - Do not block wave1 on family if bulk frontmatter migration becomes noisy.

--- a/docs/AGENTS_ROOT_REFERENCE.md
+++ b/docs/AGENTS_ROOT_REFERENCE.md
@@ -76,6 +76,11 @@ widening the axis.
 ## Growth posture
 
 This repository captures reusable method, not agent destiny.
+The primary technique unit is one atomic executable move, not a chained skill or
+scenario object.
+Classification is faceted: `domain` and `kind` are current frontmatter truth,
+while family, capability, substrate, execution profile, risk posture, and
+relation topology stay explicit design axes until promoted.
 
 Higher layers may later package these techniques into bounded workflows,
 portable proofs, routing hints, continuity support, or longer-horizon
@@ -89,12 +94,14 @@ Before making changes, read in this order:
 1. `README.md`
 2. `ROADMAP.md`
 3. `docs/START_HERE.md`
-4. `mechanics/README.md` when movement surfaces are involved
-5. `WALKTHROUGH.md`
-6. `docs/TECHNIQUE_SELECTION.md`
-7. `docs/TECHNIQUE_KIND_GUIDE.md`
-8. the target `techniques/**/TECHNIQUE.md`
-9. any generated catalogs, capsules, feat-card surfaces, or source-lift outputs affected by the change
+4. `docs/TECHNIQUE_ATOM_CONTRACT.md`
+5. `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
+6. `mechanics/README.md` when movement surfaces are involved
+7. `WALKTHROUGH.md`
+8. `docs/TECHNIQUE_SELECTION.md`
+9. `docs/TECHNIQUE_KIND_GUIDE.md`
+10. the target `techniques/**/TECHNIQUE.md`
+11. any generated catalogs, capsules, feat-card surfaces, or source-lift outputs affected by the change
 
 Then branch by task:
 

--- a/docs/DOMAIN_MAP.md
+++ b/docs/DOMAIN_MAP.md
@@ -1,6 +1,11 @@
 # Domain Map
 
-This document anchors the bounded meaning of the current `domain` values in technique frontmatter.
+This document anchors the bounded meaning of the current `domain` values in
+technique frontmatter.
+
+For the wider classification system, see
+[Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md). `domain` is the
+first owner and review route, not the whole category system.
 
 ## Current domains
 
@@ -18,6 +23,8 @@ This document anchors the bounded meaning of the current `domain` values in tech
 - Pick the domain that best matches the technique's primary reusable contract, not every place it may be used.
 - Do not create a new domain just to fit one project-shaped bundle.
 - If a technique spans multiple areas, choose the domain that should own the default review vocabulary for that technique.
+- Do not force substrate, capability class, family, or risk posture into
+  `domain`; those are separate topology questions.
 - `system-recovery` owns reusable degraded/reground/recover posture only; it does not own live runtime contracts, repair automation, or source-owned failure meaning.
 - `validation-patterns` owns evidence-led analysis patterns only; it does not replace `aoa-evals`, repo-local receipts, or project-specific remediation policy.
 - `history` owns session or transcript artifact discipline only; memory objects, retrieval semantics, and recall surfaces still belong outside this repo's current ownership boundary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Choose the path that matches your question:
   - [Start Here](START_HERE.md)
   - [Ecosystem Context](ECOSYSTEM_CONTEXT.md)
 - I need to pick a technique now:
+  - [Technique Atom Contract](TECHNIQUE_ATOM_CONTRACT.md)
+  - [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md)
   - [Technique Selection Guide](TECHNIQUE_SELECTION_GUIDE.md)
   - [Technique Kind Guide](TECHNIQUE_KIND_GUIDE.md)
   - [Technique Kind Handoff Pack](TECHNIQUE_KIND_HANDOFF_PACK.md)
@@ -185,6 +187,8 @@ These are human-authored guides that define bounded review, metadata, and docume
 
 - [Start Here](START_HERE.md)
 - [Ecosystem Context](ECOSYSTEM_CONTEXT.md)
+- [Technique Atom Contract](TECHNIQUE_ATOM_CONTRACT.md)
+- [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md)
 - [Canonical Rubric](CANONICAL_RUBRIC.md)
 - [Canonical Review Guide](CANONICAL_REVIEW_GUIDE.md)
 - [Mechanics](../mechanics/README.md)
@@ -321,6 +325,8 @@ These are outside `docs/` but matter when navigating the repo:
 ## Notes
 
 - Prefer [Start Here](START_HERE.md) when the question is "where should I begin inside this repo before choosing a deeper surface?"
+- Prefer [Technique Atom Contract](TECHNIQUE_ATOM_CONTRACT.md) when the question is "what counts as one technique instead of a skill, playbook, or chain?"
+- Prefer [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md) when the question is "which classes, families, categories, or axes should organize a large technique corpus?"
 - Prefer generated reader surfaces when the question is "what should I inspect next?"
 - Prefer `TECHNIQUE_SECTIONS.md` when the question is "which published techniques expose this lifted section heading?"
 - Prefer `../generated/technique_sections.full.json` when the question is "which exact technique section should I expand next?"

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -8,13 +8,18 @@ Use it when you want one bounded answer to what to open next without guessing be
 
 - the public practice canon of AoA
 - the source of truth for technique meaning, IDs, bounded contracts, adaptation notes, and generated technique surfaces built from those authored sources
+- the home for atomic executable moves: one technique should be compact enough to classify, template, verify, and hand to a small agent after orchestration supplies the right context
+- the owner of the technique topology contract: `domain` and `kind` are current frontmatter truth, while family, capability, substrate, execution profile, risk posture, and relation topology are explicit design axes for future scale
 - a repository for reusable techniques, not for bounded execution workflows, verdict logic, routing policy, or private project operations
 - the technique-layer home inside the AoA ontology spine; open [Ecosystem Context](ECOSYSTEM_CONTEXT.md) when the question is why this layer exists separately from skills, playbooks, evals, or runtime repos
 
 ## If You Need One Technique Now
 
+- open [Technique Atom Contract](TECHNIQUE_ATOM_CONTRACT.md) when the question is whether a candidate is one atomic technique or a skill/playbook/chain wearing technique clothing
+- open [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md) when the question is how a technique should be classified beyond the first `domain` and `kind`
 - open [`plan-diff-apply-verify-report`](../techniques/agent-workflows/plan-diff-apply-verify-report/TECHNIQUE.md) when you want one concrete canonical bundle before any chooser or generated surface
 - open [Technique Selection Guide](TECHNIQUE_SELECTION_GUIDE.md) when the question is how the selection family stays bounded before you trust any chooser surface
+- open [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md) before proposing new classes, families, categories, or schema axes
 - open [Technique Kind Guide](TECHNIQUE_KIND_GUIDE.md) when the second selector axis or a kind tie-break matters
 - open [Technique Kind Handoff Pack](TECHNIQUE_KIND_HANDOFF_PACK.md) when a neighboring AoA repo needs the bounded `domain + kind` handoff
 - open [Technique Selection](TECHNIQUE_SELECTION.md) for one bounded pick by domain and current defaults
@@ -54,6 +59,7 @@ Use it when you want one bounded answer to what to open next without guessing be
 - current corpus posture is generated from `../generated/technique_catalog.min.json` and the selection surfaces, not hand-maintained here
 - open `TECHNIQUE_SELECTION.md` for the live domain/kind/status split before you trust any snapshot count
 - use `../generated/technique_catalog.min.json` when you need the current machine-readable corpus view
+- the intended growth shape is `1000+` compact, well-classified, template-backed techniques as an early target, with a faceted topology that can grow beyond that without turning `agent-workflows` or `docs` into junk drawers
 - the current repo-wide operating shape is still `pick -> inspect -> expand -> object use`
 
 ## Repo-Only Operating Contract
@@ -61,7 +67,7 @@ Use it when you want one bounded answer to what to open next without guessing be
 - `pick`: choose one route from this page, `TECHNIQUE_SELECTION.md`, or `REPO_DOC_SURFACES.md`
 - `inspect`: open one `TECHNIQUE.md`, one guide, or one review surface
 - `expand`: only then open a generated manifest or full markdown section/body
-- `object use`: use the technique meaning or derived routing surface from this repo before jumping to execution or routing repos
+- `object use`: use one atomic technique meaning or derived routing surface from this repo before jumping to execution or routing repos
 
 ## When To Leave This Repo
 

--- a/docs/TECHNIQUE_ATOM_CONTRACT.md
+++ b/docs/TECHNIQUE_ATOM_CONTRACT.md
@@ -1,0 +1,135 @@
+# Technique Atom Contract
+
+This guide defines what `aoa-techniques` means by one technique.
+
+Use it when authoring, reviewing, distilling, selecting, or templating a
+candidate and the real question is whether the object is one reusable technique
+or a larger workflow object that belongs in another AoA layer.
+
+Use [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md) next when the
+question is where the atomic technique belongs in the larger classification
+map.
+
+## Core Contract
+
+A technique is one atomic executable move.
+
+It should be:
+
+- compact enough to explain in one sentence
+- narrow enough to classify with one `domain` and one primary `kind`
+- concrete enough to execute from a template or capsule
+- bounded enough to verify with one local check, smoke, example, or review cue
+- portable enough to reuse outside the origin project after public-safe
+  sanitization
+
+A technique may have several steps, but those steps must serve one move. If the
+candidate needs several independent outcomes, a persistent role, long-running
+state, orchestration policy, or scenario composition, it is no longer one
+technique.
+
+## Small-Agent Target
+
+The target shape is not only human readability. A well-shaped technique should
+be usable by a small agent after a larger orchestrator has selected the
+technique and supplied the relevant local context.
+
+As a design target, a 2-4B model should be able to execute the technique when it
+receives:
+
+- the compact technique card or relevant `TECHNIQUE.md` section
+- the local task frame
+- the required inputs
+- the expected output shape
+- the stop line and validation signal
+
+This does not mean every small model can autonomously choose the right
+technique. Selection, routing, context packing, and multi-technique composition
+may belong to larger agents, skills, playbooks, or routing layers. The technique
+itself must still stay small enough to execute once selected.
+
+## Scale Target
+
+The repository should be able to grow toward `1000+` techniques without turning
+into a pile of broad mini-skills.
+
+That requires:
+
+- one atomic move per bundle
+- `domain` as the first routing axis
+- one primary `kind` as the second routing axis
+- topology axes that keep family, capability, substrate, execution profile,
+  risk posture, and relations distinct instead of overloading `domain`
+- tags only for nuance
+- concise summaries that work in generated catalogs
+- capsules that preserve the smallest runtime card shape
+- examples and checks that prove the move without smuggling in a whole workflow
+
+If a future classification scheme cannot handle many hundreds of techniques,
+the scheme is too weak. If one technique needs many pages of orchestration
+before it can be used, the technique is too large.
+
+## Not A Skill
+
+A skill can orchestrate. A technique should not.
+
+Route away from `aoa-techniques` when the candidate is mainly:
+
+- a multi-step execution workflow with state, retries, or tool orchestration:
+  use `aoa-skills`
+- verdict doctrine, benchmark proof, or claim scoring: use `aoa-evals`
+- dispatch policy, selector logic, or recommendation behavior: use
+  `aoa-routing`
+- scenario composition, campaign shape, or recurring play: use `aoa-playbooks`
+- role identity, handoff posture, or agent contract: use `aoa-agents`
+- memory, recall, KAG substrate, runtime, or infrastructure ownership: use the
+  owning layer
+- candidate movement, donor intake, promotion readiness, or cross-mechanic
+  process: keep it in `mechanics/` until one atomic practice can be extracted
+
+## Authoring Checks
+
+Before drafting or accepting a technique, answer these checks:
+
+- Can the technique name one move without using "and then" as the center?
+- Can a reader identify the inputs and outputs without reading origin lore?
+- Does the core procedure stay subordinate to that one move?
+- Does the validation section name one smallest honest check?
+- Does the risk section name how this move fails or gets misused?
+- Can generated capsules compress it without losing the executable center?
+- Would a small agent still know when to stop, return, or ask for help?
+
+If the answer is no, narrow the candidate before promotion.
+
+## Distillation Rule
+
+Donor material should be reduced to one reusable move before it becomes a
+technique bundle.
+
+Preserve donor lineage, origin notes, and excluded doctrine, but do not import
+the donor's whole system. If the donor contains several good moves, split them
+into separate candidates and let `mechanics/distillation/` keep the accounting
+until each one is ready.
+
+## Template And Capsule Implication
+
+The template should force the author to name the atomic move, the smallest
+successful procedure, the inputs, the outputs, the contracts, the risks, and the
+minimal validation signal.
+
+Capsules should preserve that executable center for local runtime lookup. They
+are not a replacement for the bundle, but they are a core pressure test: if the
+capsule cannot carry the move, the bundle is probably too broad or too vague.
+
+## Review Outcome
+
+When a candidate fails this contract, do not patch around the failure with more
+prose. Choose one of these outcomes:
+
+- split the candidate into multiple techniques
+- narrow it to the smallest reusable move
+- keep it in a mechanic as a candidate
+- route it to the owning repo as a skill, eval, routing object, playbook, role,
+  memory object, KAG object, or runtime object
+
+The repo can grow large only if each technique stays small.

--- a/docs/TECHNIQUE_CAPSULE_GUIDE.md
+++ b/docs/TECHNIQUE_CAPSULE_GUIDE.md
@@ -6,6 +6,8 @@ Capsules are derived lookup cards for local runtime use. They are not KAG/source
 
 See also:
 - [Start Here](START_HERE.md)
+- [Technique Atom Contract](TECHNIQUE_ATOM_CONTRACT.md)
+- [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md)
 - [Technique Capsules](TECHNIQUE_CAPSULES.md)
 - [`../generated/technique_capsules.json`](../generated/technique_capsules.json)
 - [`../generated/technique_capsules.min.json`](../generated/technique_capsules.min.json)
@@ -69,6 +71,11 @@ The runtime card fields are intentionally narrow:
   - the main failure or misuse seam to watch
 - `validation_short`
   - the smallest validation reminder that still routes back to the bundle
+
+The future `execution_profile` topology axis should be tested against capsule
+quality: a `tiny-card` or `small-agent` technique must preserve its executable
+center in this card family, while `orchestration-required` techniques may need
+an outer workflow even though the technique itself remains atomic.
 
 ## Boundaries
 

--- a/docs/TECHNIQUE_KIND_GUIDE.md
+++ b/docs/TECHNIQUE_KIND_GUIDE.md
@@ -7,6 +7,7 @@ Use it when you are writing, reviewing, or selecting a technique and need the bo
 See also:
 
 - [Technique Selection Guide](TECHNIQUE_SELECTION_GUIDE.md)
+- [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md)
 - [Technique Selection](TECHNIQUE_SELECTION.md)
 - [Technique Kinds Seed](TECHNIQUE_KINDS_SEED.md)
 - [`../config/technique_kind_registry.yaml`](../config/technique_kind_registry.yaml)
@@ -18,6 +19,8 @@ See also:
 
 - `domain` stays the ownership and first-routing axis.
 - `kind` is the bounded second selector axis inside that owner layer.
+- `kind` names the atomic move shape; it is not the family, substrate,
+  capability class, or risk posture.
 - Each technique chooses exactly one primary `kind`.
 - Use `tags` for extra nuance instead of widening `kind`.
 - Keep `family` scout-only and non-authoritative in this wave.

--- a/docs/TECHNIQUE_SELECTION_GUIDE.md
+++ b/docs/TECHNIQUE_SELECTION_GUIDE.md
@@ -6,6 +6,7 @@ Use it when the question is not which one technique to choose, but how the repo'
 
 See also:
 - [Start Here](START_HERE.md)
+- [Technique Topology Contract](TECHNIQUE_TOPOLOGY_CONTRACT.md)
 - [Technique Selection](TECHNIQUE_SELECTION.md)
 - [Selection Patterns](SELECTION_PATTERNS.md)
 - [`../generated/technique_catalog.json`](../generated/technique_catalog.json)
@@ -48,6 +49,9 @@ The selection family stays bounded to shallow bundle-routing knowledge:
 The family is allowed to help a reader choose one next technique or one nearby cluster.
 It is not allowed to replace `TECHNIQUE.md`, semantic review docs, or bundle-local notes as the source of meaning.
 `domain` stays the first routing cut, while `kind` is the bounded second cut inside that owner layer.
+The wider topology contract may add future axes such as family, capability
+class, substrate, execution profile, and risk posture, but this selection
+family only uses axes that are current source or validator truth.
 
 If a domain has no canonical default yet, the validator-backed domain-start specs may point to one bounded `promoted` starter for that domain.
 That is a temporary route aid, not a silent promotion.

--- a/docs/TECHNIQUE_TOPOLOGY_CONTRACT.md
+++ b/docs/TECHNIQUE_TOPOLOGY_CONTRACT.md
@@ -1,0 +1,285 @@
+# Technique Topology Contract
+
+This guide defines the classification topology for `aoa-techniques`.
+
+Use it when the question is not only whether a candidate is one atomic
+technique, but where that technique should live in a corpus that must scale
+beyond hundreds or thousands of entries.
+
+## Purpose
+
+The technique corpus should become a large, navigable library of small agentic
+moves, not a flat list and not five overloaded buckets.
+
+The topology must support:
+
+- coding, documentation, validation, recovery, history, media, tool use,
+  dialogue, planning, observation, and other agent-capability surfaces
+- `1000+` techniques as an early scale target, not a ceiling
+- small-agent execution after orchestration has selected and packed context
+- future cross-repo consumers in skills, evals, routing, playbooks, memory, KAG,
+  agents, runtime, and stats without moving technique meaning out of this repo
+
+## Topology Law
+
+Classification is faceted, not a single tree.
+
+No one axis should carry all meaning. A technique is routed through several
+orthogonal questions:
+
+- What owner/review lane should read it first?
+- What atomic move shape does it perform?
+- Which stable semantic family does it belong to?
+- What agent capability does it exercise?
+- What substrate or object does it operate on?
+- What execution profile can use it?
+- What risk posture does it carry?
+- What relations make it compose, conflict, or sequence with other techniques?
+
+The first two axes are current frontmatter truth. Other axes are design
+contracts and scout surfaces until they are intentionally promoted into schema,
+generated catalogs, and validators.
+
+## Axis Stack
+
+| axis | current status | role | current or future source |
+|---|---|---|---|
+| `domain` | authoritative frontmatter | first owner and review route | `docs/DOMAIN_MAP.md`, schema, validators |
+| `kind` | authoritative frontmatter | atomic move shape | `docs/TECHNIQUE_KIND_GUIDE.md`, `config/technique_kind_registry.yaml`, schema, validators |
+| `family` | scout-only | stable semantic shelf spanning domains or kinds | `config/technique_family_seed.yaml`, `reports/technique_family_scout.md` |
+| `capability_class` | design axis | what agent capability the move exercises | future config and generated catalog field |
+| `substrate` | design axis | what object or medium the move operates on | future config and generated catalog field |
+| `execution_profile` | design axis | what size or orchestration level can execute it | future capsule/catalog field |
+| `risk_posture` | design axis | mutation, public-share, safety, reversibility, and approval posture | future review/catalog field |
+| `relations` | current bounded frontmatter plus future strengthening | direct composition, conflict, sequence, prerequisite, or alternative hints | current `relations` plus future typed relation guidance |
+
+## Current Axes
+
+### Domain
+
+`domain` is not the whole category system. It is the first owner and review
+route for a technique.
+
+The current domains are intentionally narrow:
+
+- `agent-workflows`
+- `docs`
+- `evaluation`
+- `system-recovery`
+- `validation-patterns`
+- `history`
+
+Do not treat these six domains as a complete map of everything agents can do.
+They are the current public corpus lanes. Future growth may need new domains or
+subdomains, but adding one must happen through schema, template, validator, and
+docs updates in the same wave.
+
+### Kind
+
+`kind` names the atomic move shape.
+
+The current kinds are:
+
+- `workflow`
+- `guardrail`
+- `validation`
+- `composition`
+- `distribution`
+- `artifact`
+- `lift`
+- `discovery`
+- `handoff`
+- `ingest`
+- `assessment`
+- `recovery`
+
+The `kind` axis should stay singular. If one technique seems to need several
+kinds, narrow the atomic move or split the candidate.
+
+### Family
+
+`family` is the future shelf layer.
+
+A family groups nearby techniques that may cross domains or kinds but belong to
+one durable semantic neighborhood. The current family seed is scout-only because
+the corpus is still small and forcing frontmatter migration too early would
+create false precision.
+
+The existing seed already points toward real shelves such as:
+
+- `instruction-surface`
+- `kag-source-lift`
+- `history-artifacts`
+- `runtime-truth-lifecycle`
+- `handoff-continuation`
+- `media-ingest`
+- `decision-routing`
+- `diagnosis-repair`
+- `automation-governance`
+- `antifragility-recovery`
+
+Future promotion of `family` should make it a stable optional frontmatter field
+only after the family registry has clear ownership, examples, and tie-break
+rules.
+
+## Future Axes
+
+### Capability Class
+
+`capability_class` should answer what the agent is doing at the capability
+level.
+
+Likely classes include:
+
+- observe
+- read
+- interpret
+- plan
+- choose
+- transform
+- write
+- mutate
+- validate
+- compare
+- summarize
+- compress
+- handoff
+- recover
+- coordinate
+- communicate
+- learn-from-artifact
+
+This axis is broader than `kind`. For example, a technique can be a `guardrail`
+kind while exercising the `choose` capability, or a `lift` kind while exercising
+the `compress` capability.
+
+### Substrate
+
+`substrate` should answer what the technique acts on.
+
+Likely substrates include:
+
+- code
+- tests
+- docs
+- instructions
+- config
+- shell
+- APIs
+- data
+- media
+- UI
+- conversation
+- history
+- memory-adjacent artifacts
+- graph-adjacent artifacts
+- tool surfaces
+- runtime state
+- human approval surfaces
+
+This axis prevents `docs` and `agent-workflows` from becoming overloaded
+catch-all domains.
+
+### Execution Profile
+
+`execution_profile` should answer what kind of agent can execute the technique
+after selection.
+
+Likely profiles include:
+
+- `tiny-card`: executable from a capsule or one short section with obvious
+  inputs
+- `small-agent`: suitable for 2-4B models when the orchestrator supplies the
+  local frame, facts, stop line, and output shape
+- `medium-agent`: requires more local reasoning, comparison, or multi-file
+  awareness but still stays one technique
+- `orchestration-required`: the technique is atomic, but safe use requires an
+  outer workflow, approval gate, or tool choreography
+
+This is not a quality score. It describes the execution envelope.
+
+### Risk Posture
+
+`risk_posture` should answer what can go wrong operationally.
+
+Likely values include:
+
+- read-only
+- mutating
+- public-share
+- security-sensitive
+- irreversible
+- approval-required
+- degraded-mode
+- external-evidence
+
+This axis should route safety expectations without moving proof doctrine into
+this repo.
+
+## Relation Topology
+
+Direct `relations` already exist in frontmatter. They should remain bounded
+links, not graph inference.
+
+Future relation guidance should distinguish at least:
+
+- prerequisite
+- follows
+- alternative
+- conflicts-with
+- strengthens
+- narrows
+- generalizes
+- consumes-output-of
+- produces-input-for
+
+Relations should help an orchestrator compose techniques while preserving the
+fact that each technique remains one atomic move.
+
+## Growth Rules
+
+- Add new topology axes as config and generated projections before requiring
+  them in every technique bundle.
+- Keep authored bundle meaning stronger than generated classifications.
+- Use scout reports for exploration, then promote axes only after repeated
+  review shows stable value.
+- Do not let one domain become a junk drawer for many substrates.
+- Do not use tags as a substitute for missing topology forever.
+- Do not let family become a hidden status or quality score.
+- Treat topology changes as public contract changes that need tests and
+  decision notes.
+
+## Mechanics Interface
+
+Mechanics should use this topology while distilling candidates.
+
+Before a candidate becomes a technique bundle, mechanics should be able to name:
+
+- the atomic move
+- the likely domain
+- the likely kind
+- the likely family or reason no family is stable yet
+- the capability class being exercised
+- the substrate being acted on
+- the execution profile target
+- the risk posture
+- nearest related techniques or conflict seams
+
+If those cannot be named, keep the candidate in mechanics instead of promoting
+it into canon.
+
+## Next Honest Build Path
+
+The next topology wave should not rewrite all existing bundles at once.
+
+A bounded path is:
+
+1. keep `domain` and `kind` authoritative
+2. strengthen `family` from scout-only into a reviewed optional axis
+3. add non-required generated projections for `capability_class`, `substrate`,
+   `execution_profile`, and `risk_posture`
+4. test the axes against distillation and mechanics candidates
+5. promote only the axes that survive repeated review into schema/frontmatter
+
+The goal is a corpus that can grow very large while staying navigable by both
+large orchestrators and small executors.

--- a/docs/decisions/2026-05-01-technique-atom-contract.md
+++ b/docs/decisions/2026-05-01-technique-atom-contract.md
@@ -1,0 +1,54 @@
+# Technique Atom Contract
+
+Date: 2026-05-01
+
+## Status
+
+Accepted
+
+## Context
+
+The repository already described techniques as reusable, bounded, and portable,
+and it already separated techniques from skills, evals, routing, roles, and
+playbooks. That was enough for the first hardening stage, where the main risk
+was public safety, reviewability, generated-surface parity, and corpus hygiene.
+
+As the corpus grows, that wording is not specific enough. A broad "minimal
+reproducible unit" can still drift into a mini-skill, a workflow chain, or a
+large method document. The project direction now needs `aoa-techniques` to scale
+toward many hundreds or thousands of compact practices that can be classified,
+selected, templated, and handed to small agents after orchestration supplies the
+right context.
+
+## Options
+
+- Keep the existing wording and rely on reviewers to infer atomicity from
+  "bounded" and "portable".
+- Turn techniques into richer skill-like workflows so each bundle carries more
+  context and more execution chain.
+- Add an explicit atom contract while keeping skills, playbooks, routing, evals,
+  memory, KAG, and runtime behavior in their owning repositories.
+
+## Decision
+
+Add a repo-owned Technique Atom Contract and wire it into the root route card,
+root README, Start Here, docs map, and technique template.
+
+The contract defines one technique as one atomic executable move: compact enough
+to classify, template, verify, and execute from a small runtime card once the
+right context has been supplied.
+
+## Consequences
+
+Future technique candidates should be narrowed before promotion if they need
+several independent moves, long-running state, orchestration policy, scenario
+composition, role identity, proof verdicts, or routing behavior.
+
+The template now asks authors to name the atomic move and small-agent execution
+shape explicitly. This adds a little authoring friction, but it gives the corpus
+a clearer path toward `1000+` techniques without turning the repository into a
+pile of broad mini-skills.
+
+Existing bundles are not rewritten by this decision. They can be audited
+gradually through normal review, distillation, promotion, capsule, and selection
+surfaces.

--- a/docs/decisions/2026-05-01-technique-topology-contract.md
+++ b/docs/decisions/2026-05-01-technique-topology-contract.md
@@ -1,0 +1,53 @@
+# Technique Topology Contract
+
+Date: 2026-05-01
+
+## Status
+
+Accepted
+
+## Context
+
+The repo now explicitly defines a technique as one atomic executable move. That
+solves the size and execution-shape problem, but it does not by itself solve the
+classification problem.
+
+The current corpus uses `domain` and `kind` as authoritative frontmatter axes
+and has a scout-only `family` seed. That was enough for the first public corpus,
+but a corpus aiming toward `1000+` techniques and then beyond cannot rely on a
+small set of broad domains. Agent techniques will cover coding, documentation,
+tool use, media, dialogue, planning, observation, recovery, history, and many
+other capability surfaces.
+
+## Options
+
+- Keep the current `domain + kind + tags` scheme and let categories evolve
+  locally as the corpus grows.
+- Immediately migrate schema and all bundles to a large new taxonomy.
+- Record a topology contract now, keep current authoritative axes stable, and
+  mark future axes as design contracts until they are proven through mechanics,
+  distillation, generated reports, and validators.
+
+## Decision
+
+Add `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md` as the repo-owned topology guide.
+
+The contract defines classification as faceted rather than a single tree:
+`domain`, `kind`, `family`, `capability_class`, `substrate`,
+`execution_profile`, `risk_posture`, and typed `relations` each answer a
+different routing question.
+
+Only `domain` and `kind` remain current authoritative frontmatter. `family`
+remains scout-only. The other axes are design axes for the next classification
+wave, not immediate schema requirements.
+
+## Consequences
+
+Future mechanics and distillation passes can classify candidates against the
+intended topology without pretending the schema migration has already happened.
+
+This creates a stronger path toward a large corpus while avoiding a premature
+all-bundle migration. The tradeoff is that contributors now need to distinguish
+current truth from design axes: generated scout surfaces and topology notes can
+guide future work, but authored technique bundles and current validators still
+own present corpus truth.

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -1636,8 +1636,8 @@ def validate_family_seed_alignment(repo_root: Path) -> None:
         fail(f"{seed_path}: schema_version must be 1")
     if seed.get("axis_name") != "technique_family":
         fail(f"{seed_path}: axis_name must stay 'technique_family'")
-    if seed.get("status") != "optional-wave1-seed":
-        fail(f"{seed_path}: status must stay 'optional-wave1-seed'")
+    if seed.get("status") != "scout-foundation":
+        fail(f"{seed_path}: status must stay 'scout-foundation'")
     family_seed_entries_by_id(seed, seed_path)
 
 

--- a/templates/TECHNIQUE.template.md
+++ b/templates/TECHNIQUE.template.md
@@ -36,6 +36,28 @@ evidence:
 
 What problem this technique solves.
 
+## Atomic move
+
+Name the one move this technique performs. If the answer needs several
+independent verbs, split the candidate or route it to a skill, playbook, eval,
+or mechanic instead.
+
+## Topology fit
+
+Name the current and likely future classification fit:
+
+- domain:
+- kind:
+- likely family or no stable family yet:
+- likely capability class:
+- likely substrate:
+- execution profile:
+- risk posture:
+
+Only `domain` and `kind` are current frontmatter truth. Treat the remaining
+axes as review notes until the topology contract promotes them into schema,
+generated catalogs, or validators.
+
 ## When to use
 
 - case 1
@@ -59,7 +81,18 @@ What problem this technique solves.
 
 ## Core procedure
 
-Describe the technique step by step.
+Describe the smallest successful application of the technique step by step.
+Keep every step subordinate to the one atomic move above.
+
+## Small-agent execution shape
+
+Describe what a small model should see after orchestration supplies context:
+
+- compact task frame
+- required local facts
+- exact action to take
+- visible stop line
+- minimal verification signal
 
 ## Contracts
 

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -1618,6 +1618,126 @@ class TechniqueContentSmokeTests(unittest.TestCase):
         self.assertIn("generated/technique_kind_manifest.json", releasing)
         self.assertIn("generated/technique_kind_manifest.min.json", releasing)
 
+    def test_technique_atom_contract_is_discoverable_and_template_backed(self) -> None:
+        atom_contract = (REPO_ROOT / "docs" / "TECHNIQUE_ATOM_CONTRACT.md").read_text(
+            encoding="utf-8"
+        )
+        decision = (
+            REPO_ROOT
+            / "docs"
+            / "decisions"
+            / "2026-05-01-technique-atom-contract.md"
+        ).read_text(encoding="utf-8")
+        template = (REPO_ROOT / "templates" / "TECHNIQUE.template.md").read_text(
+            encoding="utf-8"
+        )
+        agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        start_here = (REPO_ROOT / "docs" / "START_HERE.md").read_text(
+            encoding="utf-8"
+        )
+        docs_readme = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+
+        for target in (
+            "one atomic executable move",
+            "2-4B model",
+            "`1000+` techniques",
+            "A skill can orchestrate. A technique should not.",
+            "small enough to execute once selected",
+            "Capsules should preserve that executable center",
+        ):
+            self.assertIn(target, atom_contract)
+
+        for surface_name, surface in (
+            ("AGENTS.md", agents),
+            ("README.md", readme),
+            ("docs/START_HERE.md", start_here),
+            ("docs/README.md", docs_readme),
+        ):
+            with self.subTest(surface=surface_name):
+                self.assertIn("TECHNIQUE_ATOM_CONTRACT.md", surface)
+
+        self.assertIn("## Atomic move", template)
+        self.assertIn("## Small-agent execution shape", template)
+        self.assertIn("one atomic executable move", decision)
+        self.assertIn("broad mini-skills", decision)
+
+    def test_technique_topology_contract_defines_faceted_classification(self) -> None:
+        topology = (REPO_ROOT / "docs" / "TECHNIQUE_TOPOLOGY_CONTRACT.md").read_text(
+            encoding="utf-8"
+        )
+        decision = (
+            REPO_ROOT
+            / "docs"
+            / "decisions"
+            / "2026-05-01-technique-topology-contract.md"
+        ).read_text(encoding="utf-8")
+        atom_contract = (REPO_ROOT / "docs" / "TECHNIQUE_ATOM_CONTRACT.md").read_text(
+            encoding="utf-8"
+        )
+        domain_map = (REPO_ROOT / "docs" / "DOMAIN_MAP.md").read_text(encoding="utf-8")
+        kind_guide = (REPO_ROOT / "docs" / "TECHNIQUE_KIND_GUIDE.md").read_text(
+            encoding="utf-8"
+        )
+        selection_guide = (
+            REPO_ROOT / "docs" / "TECHNIQUE_SELECTION_GUIDE.md"
+        ).read_text(encoding="utf-8")
+        capsule_guide = (REPO_ROOT / "docs" / "TECHNIQUE_CAPSULE_GUIDE.md").read_text(
+            encoding="utf-8"
+        )
+        template = (REPO_ROOT / "templates" / "TECHNIQUE.template.md").read_text(
+            encoding="utf-8"
+        )
+        agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        start_here = (REPO_ROOT / "docs" / "START_HERE.md").read_text(
+            encoding="utf-8"
+        )
+        docs_readme = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+        family_seed = validate_repo.read_yaml(
+            REPO_ROOT / "config" / "technique_family_seed.yaml"
+        )
+
+        for target in (
+            "Classification is faceted, not a single tree.",
+            "`domain` | authoritative frontmatter",
+            "`kind` | authoritative frontmatter",
+            "`family` | scout-only",
+            "`capability_class` | design axis",
+            "`substrate` | design axis",
+            "`execution_profile` | design axis",
+            "`risk_posture` | design axis",
+            "coding, documentation, validation, recovery, history, media, tool use",
+            "The goal is a corpus that can grow very large",
+        ):
+            self.assertIn(target, topology)
+
+        for surface in (
+            atom_contract,
+            domain_map,
+            kind_guide,
+            selection_guide,
+            capsule_guide,
+        ):
+            self.assertIn("TECHNIQUE_TOPOLOGY_CONTRACT.md", surface)
+
+        for surface_name, surface in (
+            ("AGENTS.md", agents),
+            ("README.md", readme),
+            ("docs/START_HERE.md", start_here),
+            ("docs/README.md", docs_readme),
+        ):
+            with self.subTest(surface=surface_name):
+                self.assertIn("TECHNIQUE_TOPOLOGY_CONTRACT.md", surface)
+
+        self.assertIn("## Topology fit", template)
+        self.assertEqual("scout-foundation", family_seed["status"])
+        self.assertIn(
+            "Use family as a library shelf",
+            "\n".join(family_seed["core_rules"]),
+        )
+        self.assertIn("faceted rather than a single tree", decision)
+
     def test_selection_and_semantic_review_guides_are_discoverable_and_validator_backed(self) -> None:
         docs_readme = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
         selection = (REPO_ROOT / "docs" / "TECHNIQUE_SELECTION.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add the Technique Atom Contract to define a technique as one atomic executable move rather than a mini-skill or chain
- add the Technique Topology Contract to define faceted classification across domain, kind, family, capability class, substrate, execution profile, risk posture, and relation topology
- wire the contracts into repo entrypoints, existing classification guides, the technique template, family seed validation, and regression tests

## Validation

- `python -m unittest tests.test_validate_repo.TechniqueContentSmokeTests.test_technique_atom_contract_is_discoverable_and_template_backed tests.test_validate_repo.TechniqueContentSmokeTests.test_technique_topology_contract_defines_faceted_classification`
- `python scripts/validate_repo.py`
- `python -m unittest discover -s tests`
- `python scripts/validate_nested_agents.py`
- `python scripts/release_check.py`
- `git diff --check`