### PR TITLE
Soften mechanics boundary wording

### DIFF
--- a/docs/decisions/2026-05-01-distillation-cross-layer-candidate-registry.md
+++ b/docs/decisions/2026-05-01-distillation-cross-layer-candidate-registry.md
@@ -27,7 +27,7 @@ The registry records each candidate with:
 - inherited external placement status when the candidate belongs to the
   external candidate ledger
 - atom/topology fields for possible future technique shape
-- law/local/bridge fields for source law, local route, and stop line
+- boundary fields for source owner, local route, and stop line
 - nearest overlap, wave, and next move
 
 The generated compact index is validation evidence only. The active part README

--- a/docs/decisions/2026-05-01-distillation-external-candidate-registry.md
+++ b/docs/decisions/2026-05-01-distillation-external-candidate-registry.md
@@ -11,9 +11,10 @@ route readable, but the current `13` candidate states still lived mostly as
 tables and prose.
 
 The project direction now requires each mechanics surface to preserve the
-difference between higher law, local implementation, and bridge stop lines.
-`aoa-techniques` also needs technique candidates to stay portable outside OS
-Abyss while still participating in AoA provenance and review.
+difference between source ownership, local handling, and stop lines where that
+distinction affects candidate movement. `aoa-techniques` also needs technique
+candidates to stay portable outside OS Abyss while still participating in AoA
+provenance and review.
 
 ## Decision
 
@@ -24,7 +25,7 @@ The registry records each remaining external candidate with:
 
 - the existing ledger status and gate status
 - atom/topology fields for the possible future technique shape
-- law/local/bridge fields for source law, local route, and stop line
+- boundary fields for source owner, local route, and stop line
 - nearest overlap and next move
 
 The generated compact index is validation evidence only. The active part README

--- a/docs/decisions/2026-05-01-distillation-gate-alignment.md
+++ b/docs/decisions/2026-05-01-distillation-gate-alignment.md
@@ -14,8 +14,8 @@ mini-skills.
 That left one workflow risk: donor refinery, external import, and candidate
 ledger reopen rules could each ask for similar information in different words.
 Future agents might therefore draft a bundle before the candidate has a clear
-atom/topology shape or before source law, local route, and bridge stop line are
-separated.
+atom/topology shape or before owner boundary, local route, and stop line are
+clear.
 
 ## Options
 
@@ -35,8 +35,8 @@ The packet has two sides:
 - atom/topology: atomic move, current atomic status, likely `domain`, primary
   `kind`, family posture, capability class, substrate, execution profile, risk
   posture, and nearest relation or overlap
-- law/local/bridge: higher law, local route, bridge stop line, portable core,
-  AoA-only context, and donor exclusions
+- boundary/portability: source owner or boundary, local route, stop line,
+  portable core, AoA-only context, and donor exclusions
 
 Candidates that cannot name the packet stay in their ledger, overlap,
 incubation, or not-yet-technique-shaped lane. The generated registries remain
@@ -48,7 +48,6 @@ This adds a small amount of intake friction before the next import wave, but it
 keeps future work honest: a candidate has to be one portable move before it can
 become a technique bundle.
 
-The gate also preserves the law/local/bridge split needed for standalone use of
-`aoa-techniques`. External users can adopt a technique without deploying OS
-Abyss, while OS Abyss can still keep local integration context around the same
-candidate.
+The gate also preserves standalone use of `aoa-techniques`. External users can
+adopt a technique without deploying OS Abyss, while OS Abyss can still keep
+local integration context around the same candidate.

--- a/docs/decisions/2026-05-01-mechanics-boundary-language-correction.md
+++ b/docs/decisions/2026-05-01-mechanics-boundary-language-correction.md
@@ -1,0 +1,42 @@
+# Mechanics Boundary Language Correction
+
+Status: accepted
+Date: 2026-05-01
+
+## Context
+
+The previous mechanics pass correctly noticed a real boundary problem:
+`aoa-techniques` needs to remain portable as a public technique library while
+also participating in OS Abyss and AoA mechanics. The implementation overdid
+that insight by turning the boundary concern into repeated
+`Law/Local/Bridge` prose blocks.
+
+That shape was too heavy for this repository. `Agents-of-Abyss` keeps many of
+these boundaries legible through concise owner split, route cards, part maps,
+provenance surfaces, and stop-lines; it does not force every active section to
+restate the same three-part formula.
+
+## Decision
+
+Remove the universal `Law/Local/Bridge` prose pattern from active mechanics
+route surfaces. Keep the actual boundary intent in lighter language:
+
+- name the stronger owner when a mechanics surface depends on external
+  authority
+- keep AoA-only context out of the portable technique core
+- preserve provenance and stop-lines where candidate movement needs them
+- do not let registry metadata become a required README section shape
+
+Distillation registries may keep compact boundary fields for now because they
+validate candidate movement and do not by themselves publish technique canon.
+Those fields are route metadata, not an instruction to copy the same block into
+every mechanic.
+
+## Consequences
+
+The active mechanics pages become shorter and more natural. Future mechanics
+work should preserve the idea through owner routing, provenance, and candidate
+gates instead of by inserting a named block wherever a boundary exists.
+
+This does not weaken portability or owner separation. It makes the separation
+less theatrical and easier to read.

--- a/docs/decisions/2026-05-01-mechanics-law-local-bridge-alignment.md
+++ b/docs/decisions/2026-05-01-mechanics-law-local-bridge-alignment.md
@@ -1,6 +1,6 @@
-# Mechanics Law, Local Implementation, And Bridge Alignment
+# Mechanics Boundary Posture Alignment
 
-Status: accepted
+Status: superseded by [Mechanics Boundary Language Correction](2026-05-01-mechanics-boundary-language-correction.md)
 Date: 2026-05-01
 
 ## Context
@@ -10,35 +10,26 @@ then proved the active/legacy pattern through Agon and Distillation. The
 subsequent atom and topology contracts clarified that `aoa-techniques` should
 grow toward a large corpus of small executable moves, not broad mini-skills.
 
-That still left one ambiguity: a mechanics package can mention AoA-wide law,
-local repository implementation, bridge behavior, donor evidence, and technique
-candidate movement in the same surface. If those layers are not separated,
-future agents can mistake local mechanics for higher law or turn a bridge into
-an overloaded doctrine bundle.
+That still left one ambiguity: a mechanics package can mention AoA-wide
+authority, local repository handling, donor evidence, and technique candidate
+movement in the same surface. If owner boundaries are invisible, future agents
+can mistake local mechanics for source authority or turn a handoff note into an
+overloaded doctrine bundle.
 
 ## Decision
 
-Add a mechanics-wide reading rule: larger mechanics should separate higher law,
-local implementation, and bridges whenever that distinction helps the project.
+This record originally chose an explicit mechanics-wide split. The corrected
+decision is narrower: mechanics surfaces should keep owner boundaries legible
+without requiring a repeated named block in every README.
 
-- Higher law belongs to the owning AoA source that defines meaning, authority,
-  and stop-lines.
-- Local implementation belongs to the `aoa-techniques` mechanics package that
-  explains how candidate movement, intake, review, registries, ledgers, or
-  package shape work here.
-- Bridges must stay narrow, provenance-linked, and explicit about both sides,
-  input/output shape, and stop line.
-
-Tie that split to the technique atom and topology contracts before any mechanics
-candidate becomes a technique bundle.
+Tie that boundary posture to the technique atom and topology contracts before
+any mechanics candidate becomes a technique bundle.
 
 ## Consequences
 
-Mechanics entrypoints now carry a stronger gate for future work without forcing
-an immediate schema migration or a bulk rewrite of every package. Distillation
-names this as the next alignment pass before structured registries, while Agon
-records the split in its tracked package entrypoint before any promotion work.
-
-The tradeoff is another explicit review layer. It is worth it because the
-project needs many mechanics to connect across repos without confusing source
-law, owner-local execution, and candidate bridges.
+Mechanics entrypoints should stay light, closer to the current
+`Agents-of-Abyss` style: concise route cards, owner split where needed, and
+provenance surfaces for deeper history. Distillation may still keep compact
+registry fields for source owner, local route, stop line, portable core, and
+AoA-only context because those fields protect candidate movement, but they are
+not a prose template for every mechanic.

--- a/docs/decisions/2026-05-01-standalone-portable-technique-posture.md
+++ b/docs/decisions/2026-05-01-standalone-portable-technique-posture.md
@@ -24,7 +24,7 @@ Record a dual posture for `aoa-techniques`:
   provenance, review posture, mechanics, and generated surfaces for sibling
   repos
 
-AoA references may explain source law, provenance, owner boundaries, and
+AoA references may explain source ownership, provenance, owner boundaries, and
 integration routes. They should not be required for the core technique to be
 executed by an external agent system after that system supplies its own local
 context and orchestration.
@@ -32,9 +32,9 @@ context and orchestration.
 ## Consequences
 
 Future technique authoring and mechanics work should keep portable practice
-distinct from AoA-only integration detail. Mechanics bridges should name whether
-a sibling reference is higher law, provenance, optional integration context, or
-a required owner handoff.
+distinct from AoA-only integration detail. Mechanics references should make
+clear whether sibling material is provenance, optional integration context, or a
+required owner handoff.
 
 This does not weaken AoA ownership. It keeps the authored practice useful both
 inside OS Abyss and outside it.

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -56,11 +56,9 @@ It does not own:
   silently promote candidates into canon.
 - Every cross-repo handoff must name the owner and stop-line rather than
   importing that owner's authority into this repo.
-- Larger mechanics should distinguish higher law, local implementation, and
-  bridge surfaces when that split helps the project stay legible. Higher law
-  belongs to the source owner; local implementation belongs to this repo's
-  mechanics package; bridges must stay narrow, provenance-linked, and explicit
-  about both sides.
+- When a mechanics surface points to another AoA owner, name the owner route
+  and stop-line only as much as the current surface needs. Do not import sibling
+  authority or turn boundary notes into a local doctrine block.
 - Before a mechanics candidate becomes a technique bundle, the active surface
   should be able to name the atomic move, likely `domain`, likely `kind`,
   likely family or reason no family is stable yet, capability class, substrate,

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -41,27 +41,8 @@ generated-reader interpretation, or public selection guidance. Use
 
 Mechanics can prepare canon. They do not replace canon.
 
-## Law, Local Form, Bridges
-
-Larger mechanics should keep three layers separate when that separation helps
-the project stay legible:
-
-- higher law: the owning AoA source that defines meaning, authority, and
-  stop-lines for the mechanic
-- local implementation: the `aoa-techniques` route for candidate movement,
-  intake, review, registries, ledgers, or package shape
-- bridges: narrow, provenance-linked handoff surfaces that name both sides,
-  the input/output shape, and the stop line
-
-Do not let a local implementation pretend to be the higher law. Do not turn a
-bridge into an overloaded doctrine bundle. When the split is useful, make it an
-explicit block in the package README, `DIRECTION.md`, or part README instead of
-leaving future agents to infer it from old wave language.
-
-Mechanics may serve OS Abyss integration, but they should not make portable
-techniques depend on a full OS Abyss deployment. When a bridge points to an AoA
-sibling repo, name whether that link is source law, provenance, optional
-integration context, or a required owner handoff.
+Cross-repo references stay light: point to the owner, preserve provenance, and
+keep AoA-only context outside the portable technique core.
 
 ## Candidate Gate
 
@@ -74,7 +55,7 @@ and [Technique Topology Contract](../docs/TECHNIQUE_TOPOLOGY_CONTRACT.md):
 - likely family or reason no family is stable yet
 - capability class, substrate, execution profile, and risk posture
 - nearest related techniques, alternatives, or conflict points
-- source law, local implementation route, and bridge stop line
+- owner boundary, portable core, and stop line
 
 If those cannot be named, keep the material in mechanics, legacy, or a
 candidate ledger instead of drafting a broad technique bundle.

--- a/mechanics/agon/README.md
+++ b/mechanics/agon/README.md
@@ -28,14 +28,8 @@ workflows, `aoa-evals` owns proof verdicts, `aoa-routing` owns routing logic,
 `aoa-memo` owns memory writeback, and `Tree-of-Sophia` owns ToS-authored
 meaning.
 
-### Law, local route, bridge
-
-- higher law: `Agents-of-Abyss` owns Agon doctrine, lawful moves, arena law,
-  verdict retention, and rank/scar boundaries
-- local implementation: this package owns only the technique-side staging route
-  for requested practice candidates and later bundle-local review
-- bridge: part-local candidate surfaces translate center-owned move pressure
-  into public-safe technique review without importing center authority
+Part-local candidate surfaces translate center-owned move pressure into
+public-safe technique review. They do not import center authority.
 
 ### Inputs
 

--- a/mechanics/audit/DIRECTION.md
+++ b/mechanics/audit/DIRECTION.md
@@ -20,13 +20,6 @@ turning queue pressure into canonical status.
   promotion by themselves
 - Audit can name blockers and route work, but it does not silently flip
   technique status
-
-## Law, Local Route, Bridge
-
-- higher law: canonical review doctrine and bundle-local evidence notes
-- local route: this package's readiness matrix, promotion runbook, evidence
-  sprint runbook, and searched-lane ledger
-- bridge: compact references from queue surfaces back to exact bundle evidence,
-  external evidence, and generated status summaries
-
-The bridge stops before proof doctrine or final promotion authority.
+- Queue links should point back to exact bundle evidence, external evidence, or
+  generated summaries without becoming proof doctrine or final promotion
+  authority.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -73,7 +73,7 @@ Changed:
   [parts/external-candidate-ledger](parts/external-candidate-ledger/README.md)
 - kept all `13` candidate verdicts, status counts, and the
   `phase_sync_for_agents` active narrowing lane unchanged
-- made atom/topology and law/local/bridge gates explicit per candidate without
+- made atom/topology and boundary/portability gates explicit per candidate without
   promoting any candidate into a technique bundle
 
 Verification lane:
@@ -159,7 +159,7 @@ Not moved:
 
 Changed:
 
-- made the atom/topology and law/local/bridge packet explicit in the donor
+- made the atom/topology and boundary/portability packet explicit in the donor
   refinery and external import runbook
 - aligned external and cross-layer candidate-ledger reopen rules with the same
   packet before any future import wave

--- a/mechanics/distillation/README.md
+++ b/mechanics/distillation/README.md
@@ -38,9 +38,9 @@ bundle, the active part should be able to name a compact gate packet:
 - the atomic move and the likely `domain` / primary `kind`
 - the family posture, capability class, substrate, execution profile, and risk
   posture
-- `higher_law`, `local_route`, and `bridge_stop_line`
+- source owner or boundary, repo-local handling route, and stop line
 - what remains portable outside OS Abyss and what is only AoA integration
-  context, or `portable_core` and `aoa_only_context`
+  context
 
 If those cannot be named, keep the material here as a candidate, hold,
 incubation lane, or legacy receipt.

--- a/mechanics/distillation/parts/cross-layer-candidate-ledger/README.md
+++ b/mechanics/distillation/parts/cross-layer-candidate-ledger/README.md
@@ -144,9 +144,9 @@ If future work needs exact wave execution order, use the preserved raw receipt.
 - external donors continue to use the normal external-import package in the external intake surface: `TECHNIQUE.md`, `notes/external-origin.md`, `notes/external-import-review.md`, `notes/second-context-adaptation.md`, one checklist, one minimal public-safe example, and the expected generated-surface sync
 - cross-layer or internal-origin candidates here should use donor-appropriate origin and adaptation notes without forcing `external-*` note names where the donor is not actually an external-import case
 - do not reopen `hold because overlap`, `needs layer incubation before distillation here`, or `substrate or architecture pattern, not yet a technique` lanes just to fill a wave
-- do not treat a sibling repo's local implementation as higher law for
-  `aoa-techniques`; name source law, local extraction route, and bridge stop
-  line separately
+- do not treat a sibling repo's local behavior as technique authority;
+  name the source owner, extraction route, and stop line only where it changes
+  the candidate route
 - do not draft a bundle until the candidate can name its atomic move, likely
   `domain`, primary `kind`, family posture, capability class, substrate,
   execution profile, risk posture, and standalone portability note
@@ -172,14 +172,13 @@ Atom/topology gate:
 - capability class, substrate, execution profile, and risk posture
 - nearest landed technique, overlap watch, or layer-owner surface
 
-Law/local/bridge gate:
+Boundary/portability gate:
 
 - `higher_law`: the source owner or AoA layer whose authority and stop lines
-  matter
+  matter for extraction
 - `local_route`: why this row stays held, moves to incubation, enters import
   review, or remains closed as landed
-- `bridge_stop_line`: what must not cross from source layer into technique
-  canon
+- `bridge_stop_line`: what must not cross from source layer into technique canon
 - what remains portable outside OS Abyss
 - `aoa_only_context` or equivalent note for local integration context
 - source owner and generated or indexed surfaces expected to change

--- a/mechanics/distillation/parts/donor-refinery/README.md
+++ b/mechanics/distillation/parts/donor-refinery/README.md
@@ -17,21 +17,9 @@ AoA should refine external donors through this chain:
 `aoa-techniques` owns the extraction of reusable practice from that chain.
 It does not own playbook meaning or eval doctrine.
 
-## Law, Local Route, Bridge
-
-Distillation must keep three layers separate:
-
-- higher law: the source owner or AoA layer that defines authority, meaning,
-  and stop-lines
-- local route: this package's extraction, hold, overlap, incubation, or import
-  path inside `aoa-techniques`
-- bridge: a narrow handoff that names the donor input, extracted output shape,
-  owner boundary, and stop line
-
-A donor may help OS Abyss, but the extracted technique candidate must still be
-portable as a bounded practice. AoA-only law, runtime assumptions, or sibling
-repo integration details should stay as provenance or boundary context, not as
-hidden requirements for the technique.
+Donor intake stays portable: owner references and AoA context explain boundary
+and provenance. The extracted candidate still has to stand as one bounded
+practice outside OS Abyss.
 
 ## Three intake tests
 
@@ -133,20 +121,23 @@ The atom/topology side of the packet is:
 These fields classify the candidate for extraction. They do not promote future
 topology axes into current technique frontmatter authority.
 
-## Law/Local/Bridge Gate
+## Boundary And Portability Gate
 
-The law/local/bridge side of the same packet is:
+The boundary side of the same packet is:
 
 - `higher_law`: the source owner or layer whose authority and stop lines matter
+  for extraction
 - `local_route`: the `aoa-techniques` path for extraction, hold, overlap,
   incubation, import, or rejection
-- `bridge_stop_line`: what the bridge must not carry across
+- `bridge_stop_line`: what must not cross into technique canon
 - `portable_core`: what remains useful outside OS Abyss
 - `aoa_only_context`: what stays as local integration or provenance context
 - donor exclusions: what is intentionally left behind
 
-If this split cannot be named without importing the donor's whole system, keep
-the material in the relevant ledger or incubation lane.
+These registry field names are compact route metadata, not a section template
+for every mechanic. If the boundary cannot be named without importing the
+donor's whole system, keep the material in the relevant ledger or incubation
+lane.
 
 ## Gate Verdicts
 

--- a/mechanics/distillation/parts/external-candidate-ledger/README.md
+++ b/mechanics/distillation/parts/external-candidate-ledger/README.md
@@ -157,9 +157,10 @@ Atom/topology gate:
 - bounded reusable practice being extracted
 - nearest landed technique or overlap watch
 
-Law/local/bridge gate:
+Boundary/portability gate:
 
 - `higher_law`: the source owner or layer whose authority and stop lines matter
+  for extraction
 - `local_route`: why this row should stay held, move to incubation, or enter
   import review
 - `bridge_stop_line`: what must not cross from donor into technique canon

--- a/mechanics/distillation/parts/external-import-runbook/README.md
+++ b/mechanics/distillation/parts/external-import-runbook/README.md
@@ -23,7 +23,7 @@ Open this runbook only when all of the following are already true:
 - the candidate is not blocked by an unresolved overlap with an existing technique
 - the candidate can name one atomic move, likely `domain`, primary `kind`, and
   nearest relation or conflict points
-- the candidate can separate source law, local extraction route, and bridge stop
+- the candidate can name source owner or boundary, extraction route, and stop
   line without making OS Abyss a hidden dependency for portable use
 
 If those checks still fail, stop and record the result in the candidate or review surface instead of drafting a bundle.
@@ -45,7 +45,7 @@ Atom/Topology fields:
 - `risk_posture`
 - nearest landed technique, alternative, or conflict point
 
-Law/Local/Bridge fields:
+Boundary/portability fields:
 
 - `higher_law`
 - `local_route`
@@ -64,7 +64,7 @@ dependency, return the candidate to the ledger or incubation lane.
    - name the reusable object being extracted
    - name the gate packet's atomic move and likely topology posture
    - name the nearest existing technique or overlap watch
-   - name the source law, local extraction route, and bridge stop line
+   - name the source owner or boundary, extraction route, and stop line
    - state what stays out of the donor
 2. Confirm canonical-home fit.
    - keep technique meaning here
@@ -111,7 +111,7 @@ For every import issue or PR, name these explicitly:
 - likely `domain` and primary `kind`
 - likely family or reason no family is stable yet
 - capability class, substrate, execution profile, and risk posture
-- `higher_law`, `local_route`, and `bridge_stop_line`
+- boundary fields: `higher_law`, `local_route`, and `bridge_stop_line`
 - standalone portability note, or `portable_core`, for readers outside OS Abyss
 - `aoa_only_context` that must not become a hidden dependency
 - what stays out of the donor

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -301,7 +301,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         for text in (donor_refinery, external_runbook):
             with self.subTest(surface=text.splitlines()[0]):
                 self.assertIn("Atom/Topology", text)
-                self.assertIn("Law/Local/Bridge", text)
+                self.assertIn("Boundary", text)
                 self.assertIn("atomic_move_note", text)
                 self.assertIn("atomic_move_status", text)
                 self.assertIn("capability_class", text)
@@ -343,7 +343,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             with self.subTest(surface=text.splitlines()[0]):
                 self.assertIn("## Reopen Gate", text)
                 self.assertIn("Atom/topology gate", text)
-                self.assertIn("Law/local/bridge gate", text)
+                self.assertIn("Boundary/portability gate", text)
                 self.assertIn("atomic_move_note", text)
                 self.assertIn("atomic_move_status", text)
                 self.assertIn("higher_law", text)
@@ -365,9 +365,33 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Distillation Gate Alignment", decision)
         self.assertIn("gate packet", decision)
         self.assertIn("atom/topology", decision)
-        self.assertIn("law/local/bridge", decision)
+        self.assertIn("boundary/portability", decision)
         self.assertIn("generated registries remain", decision)
         self.assertIn("evidence only", decision)
+
+    def test_mechanics_boundary_language_correction_is_discoverable(self) -> None:
+        decision = (
+            REPO_ROOT
+            / "docs"
+            / "decisions"
+            / "2026-05-01-mechanics-boundary-language-correction.md"
+        ).read_text(encoding="utf-8")
+
+        mechanics_readme = (REPO_ROOT / "mechanics" / "README.md").read_text(
+            encoding="utf-8"
+        )
+        agon_readme = (
+            REPO_ROOT / "mechanics" / "agon" / "README.md"
+        ).read_text(encoding="utf-8")
+        audit_direction = (
+            REPO_ROOT / "mechanics" / "audit" / "DIRECTION.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Mechanics Boundary Language Correction", decision)
+        self.assertIn("not an instruction to copy", decision)
+        self.assertNotIn("## Law, Local Form, Bridges", mechanics_readme)
+        self.assertNotIn("### Law, local route, bridge", agon_readme)
+        self.assertNotIn("## Law, Local Route, Bridge", audit_direction)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -1189,7 +1189,7 @@ class TechniqueContentSmokeTests(unittest.TestCase):
             "bounded-specialist-generation",
             "## Reopen Gate",
             "Atom/topology gate",
-            "Law/local/bridge gate",
+            "Boundary/portability gate",
         ):
             self.assertIn(target, candidates)
 


### PR DESCRIPTION
## Summary
- remove the over-formalized Law/Local/Bridge prose blocks from active mechanics route surfaces
- keep the owner-boundary and portability intent in lighter language
- add a decision correction and update topology tests around the new wording

## Validation
- python -m unittest tests.test_distillation_mechanics_topology tests.test_validate_repo
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py
- public-share hygiene scan over origin/main..HEAD before publishing

## Notes
This PR carries the reviewed commit 76ab986 from local main. Candidate statuses and generated authority surfaces were not changed.