### PR TITLE
[codex] Add checkpoint candidate mechanic

### DIFF
--- a/docs/decisions/2026-05-03-checkpoint-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-checkpoint-candidate-mechanic.md
@@ -1,0 +1,76 @@
+# Checkpoint Candidate Mechanic
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+`Agents-of-Abyss` now has a landed Checkpoint mechanic that owns checkpoint law,
+vocabulary, owner map, stop-lines, and cross-owner route grammar. The center
+owner map routes implementation controls to `aoa-sdk`, protocol and closeout
+bridge behavior to `aoa-skills`, actor posture to `aoa-agents`, memory and
+relaunch surfaces to `aoa-memo`, proof to `aoa-evals`, routing hints to
+`aoa-routing`, derived visibility to `aoa-stats`, runtime exports to
+`abyss-stack`, and reviewed seed lineage to `Dionysus`.
+
+`aoa-techniques` already carries checkpoint-adjacent practice: structured
+handoff before compaction, receipt-confirmed handoff packets, episode-bounded
+loops, checkpoint-bound self-repair, session capture, witness traces, and the
+live `phase_sync_for_agents` to `phase-synchronized-agent-handoff` candidate
+lane in distillation.
+
+The current AoA queue has no direct `ORQ-CHECKPOINT-TECHNIQUES-*` request, so
+this repo should not present checkpoint work as center request acceptance.
+
+## Decision
+
+Add a local `mechanics/checkpoint/` package as candidate-only practice
+pressure.
+
+Create active package route files:
+
+- `AGENTS.md`
+- `README.md`
+- `DIRECTION.md`
+- `PARTS.md`
+- `PROVENANCE.md`
+- `LANDING_LOG.md`
+- `ROADMAP.md`
+- `parts/AGENTS.md`
+- `parts/README.md`
+
+Create two active parts:
+
+- `parts/phase-handoff-candidate/README.md`
+- `parts/technique-anchors/README.md`
+
+Do not create `legacy/raw/` in this pass because no local pre-split checkpoint
+wave receipt or raw source packet is being moved.
+
+Add Checkpoint to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ Center
+Pressure, with `candidate-only` posture.
+
+## Consequences
+
+- Checkpoint pressure becomes discoverable in the mechanics map without
+  importing AoA center law as local implementation authority.
+- The phase handoff candidate stays staged until evidence shows a standalone
+  atomic move with phase boundary, handoff packet, continuation permission, and
+  stop/return/escalation rule.
+- Existing checkpoint-adjacent technique bundles remain canonical only through
+  their `techniques/**/TECHNIQUE.md` homes.
+- Checkpoint controls, note protocol, closeout bridge execution, actor
+  posture, memory writeback, proof verdicts, runtime activation, route
+  authority, stats truth, owner acceptance, hidden scheduler behavior,
+  autonomous self-repair, and technique promotion stay outside this package.
+
+## Verification
+
+Verify with:
+
+```bash
+python -m unittest tests.test_checkpoint_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -7,7 +7,7 @@ Route card for the `aoa-techniques/mechanics/` surface.
 `mechanics/` owns reusable practice-motion surfaces for `aoa-techniques`.
 These files describe how practice moves through the repo by participating in
 cross-project AoA mechanics: method-growth, distillation, audit, growth-cycle,
-Agon, recurrence, experience, release-support, and antifragility.
+Agon, recurrence, experience, release-support, antifragility, and checkpoint.
 
 Mechanics are not canonical technique bundles. They shape the route into or
 around canon, while `techniques/` owns published technique content and
@@ -20,7 +20,7 @@ This surface owns:
 - owner-local movement grammar for candidate-to-technique flow inside the AoA
   mechanics vocabulary
 - bounded intake, promotion, adoption, mastery, recurrence, release-support,
-  experience, and antifragility routes
+  experience, antifragility, and checkpoint routes
 - public-safe stop-lines for deciding when a surface must hand off to another
   AoA repo
 - reusable precedent notes that are too procedural for general `docs/` but not

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -34,6 +34,9 @@ receipt route, not a copy of the AoA request queue and not proof of acceptance.
   release support surfaces that remain bounded by owner consent.
 - [antifragility](antifragility/README.md): stress, chaos, degraded-mode, and
   recovery-oriented practice routes.
+- [checkpoint](checkpoint/README.md): phase handoff, handoff packet,
+  compaction, re-entry, and checkpoint-bound repair pressure that stays
+  candidate-only until a technique bundle owns the atomic move.
 
 ## Boundary
 

--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -128,6 +128,18 @@ or candidate lanes without a direct AoA owner-request ID targeting
   technique promotion. Existing antifragility-recovery technique bundles remain
   canonical only through their `techniques/**/TECHNIQUE.md` homes.
 
+### [checkpoint](checkpoint/README.md)
+
+- Current status: `candidate-only`
+- Why it stays separate: the current AoA Checkpoint owner-request queue has no
+  direct `ORQ-CHECKPOINT-TECHNIQUES-*` request. Local Checkpoint surfaces
+  preserve phase handoff, handoff packet, compaction/re-entry, and
+  checkpoint-bound repair pressure without claiming checkpoint implementation
+  authority, memory canon, proof verdicts, runtime activation, owner
+  acceptance, hidden scheduler behavior, autonomous self-repair, or automatic
+  technique promotion. Existing checkpoint-related technique bundles remain
+  canonical only through their `techniques/**/TECHNIQUE.md` homes.
+
 ### [growth-cycle](growth-cycle/README.md)
 
 - Current status: `candidate-only`

--- a/mechanics/checkpoint/AGENTS.md
+++ b/mechanics/checkpoint/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+Route card for `mechanics/checkpoint/`.
+
+## Purpose
+
+This package owns the `aoa-techniques` side of Checkpoint: local practice
+pressure around phase handoff, handoff packets, compaction/re-entry,
+checkpoint-bound repair, and candidate narrowing that may feed future technique
+canon.
+
+It does not own AoA checkpoint law, checkpoint controls, checkpoint-note
+protocol, memory writeback, proof verdicts, runtime activation, route
+authority, stats truth, owner acceptance, hidden scheduling, autonomous
+self-repair, or technique status changes.
+
+## Start here
+
+1. Root `AGENTS.md`.
+2. `mechanics/AGENTS.md`.
+3. `mechanics/checkpoint/README.md`.
+4. `DIRECTION.md`, `PARTS.md`, `PROVENANCE.md`, and the touched part README.
+5. `mechanics/REQUEST_RECEIPTS.md` only when naming AoA center-side pressure.
+
+## Local law
+
+- Keep checkpoint here technique-layered: reusable practice pressure, not
+  checkpoint implementation authority.
+- Do not import `Agents-of-Abyss` checkpoint law as local implementation
+  authority.
+- Do not treat checkpoint notes, session artifacts, handoff packets, receipts,
+  or repair posture as memory canon, proof verdicts, runtime truth, owner
+  acceptance, or route authority.
+- Keep sibling owner truth with its owner: controls in `aoa-sdk`, protocol in
+  `aoa-skills`, actor posture in `aoa-agents`, memory/relaunch in `aoa-memo`,
+  proof in `aoa-evals`, routing in `aoa-routing`, stats in `aoa-stats`, runtime
+  exports in `abyss-stack`, and center law in `Agents-of-Abyss`.
+- If a stable reusable practice emerges, route it into `techniques/` through
+  the normal technique review path.
+
+## Verify
+
+Use the root validation path after changes:
+
+```bash
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/checkpoint/DIRECTION.md
+++ b/mechanics/checkpoint/DIRECTION.md
@@ -1,0 +1,49 @@
+# Checkpoint Direction
+
+Checkpoint in `aoa-techniques` keeps continuation-shaped practice portable
+without pretending that local practice notes implement the full checkpoint
+stack.
+
+This file owns the local direction only. AoA center owns checkpoint law,
+vocabulary, owner map, stop-lines, and cross-owner route grammar.
+
+## Source-of-truth Split
+
+- `README.md`: package entry card and shortest route.
+- `DIRECTION.md`: current local direction.
+- `PARTS.md`: active part map.
+- `parts/`: concise local mechanics surfaces.
+- `PROVENANCE.md`: bridge from AoA checkpoint, local candidate ledgers, and
+  existing technique bundles to active parts.
+- `LANDING_LOG.md`: dated structural accounting.
+- `ROADMAP.md`: future contour, not a historical ledger.
+
+## Local Contour
+
+This package can name:
+
+- active narrowing pressure for `phase_sync_for_agents` and
+  `phase-synchronized-agent-handoff`
+- existing handoff, compaction, receipt, episode, history, witness, and
+  checkpoint-bound repair technique anchors
+- the boundary between candidate mechanics and technique canon
+- the owner route to stronger checkpoint surfaces when local practice is not
+  the real owner
+
+It cannot name:
+
+- AoA checkpoint law or checkpoint implementation authority
+- checkpoint-note protocol or closeout bridge skill behavior
+- memory canon, recall truth, proof verdicts, runtime activation, stats truth,
+  route authority, or owner acceptance
+- hidden scheduler behavior or autonomous self-repair
+- automatic technique promotion
+
+## Growth Rule
+
+Add detail only when repeated checkpoint-shaped work needs a clearer route into
+portable technique practice, owner-local handoff, or future bundle review.
+
+If the output needs controls, protocol, actor posture, memory, proof, routing,
+stats, runtime export, seed lineage, or owner acceptance, route to the owner
+repository instead of expanding local prose.

--- a/mechanics/checkpoint/LANDING_LOG.md
+++ b/mechanics/checkpoint/LANDING_LOG.md
@@ -1,0 +1,29 @@
+# Checkpoint Landing Log
+
+This ledger records structural landings for `mechanics/checkpoint/`. It is not
+a roadmap and not a technique status source.
+
+## 2026-05-03
+
+- Added the local Checkpoint mechanic package as candidate-only practice
+  pressure.
+- Created active route files: `AGENTS.md`, `README.md`, `DIRECTION.md`,
+  `PARTS.md`, `PROVENANCE.md`, `LANDING_LOG.md`, and `ROADMAP.md`.
+- Created active parts:
+  - `parts/phase-handoff-candidate/README.md`
+  - `parts/technique-anchors/README.md`
+- Updated `mechanics/README.md`, `mechanics/AGENTS.md`, and
+  `mechanics/REQUEST_RECEIPTS.md` so checkpoint is discoverable without
+  claiming a direct `ORQ-CHECKPOINT-TECHNIQUES-*` lane.
+- Added topology tests and a decision note for the candidate-only checkpoint
+  landing.
+
+## Verification Route
+
+Use:
+
+```bash
+python -m unittest tests.test_checkpoint_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/checkpoint/PARTS.md
+++ b/mechanics/checkpoint/PARTS.md
@@ -1,0 +1,16 @@
+# Checkpoint Parts
+
+This file maps current checkpoint pressure to active `aoa-techniques` parts.
+It is not the AoA center checkpoint part map and not a raw source inventory.
+
+| Part | Current role | Active source | Provenance |
+|---|---|---|---|
+| `phase-handoff-candidate` | Keeps the active `phase_sync_for_agents` narrowing lane visible without creating a premature `phase-synchronized-agent-handoff` bundle. | [parts/phase-handoff-candidate](parts/phase-handoff-candidate/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `technique-anchors` | Maps existing checkpoint-adjacent technique bundles and their limits without changing technique status. | [parts/technique-anchors](parts/technique-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+
+## Part Rule
+
+If a part starts carrying a stable reusable practice with inputs, outputs,
+risks, examples, and validation, route the practice bundle into `techniques/`.
+Leave this package as the mechanics layer that explains how checkpoint pressure
+moved.

--- a/mechanics/checkpoint/PROVENANCE.md
+++ b/mechanics/checkpoint/PROVENANCE.md
@@ -1,0 +1,57 @@
+# Checkpoint Provenance
+
+This file preserves the active-first bridge from AoA checkpoint law, local
+candidate ledgers, and existing checkpoint-adjacent technique bundles to the
+current local parts.
+
+This pass does not create `legacy/raw/` because no local pre-split checkpoint
+wave receipt or raw source packet is being moved. The package is a new local
+mechanic built from active center guidance and already-landed local surfaces.
+
+## Active Landing Map
+
+| Source pressure | Current active home | Preservation note |
+|---|---|---|
+| `phase_sync_for_agents` in the external candidate ledger | [parts/phase-handoff-candidate](parts/phase-handoff-candidate/README.md) | The candidate stays `future_import_here` until public evidence exposes a standalone phase boundary, handoff packet, continuation permission, and stop/return/escalation rule. |
+| `phase-synchronized-agent-handoff` in the cross-layer candidate ledger | [parts/phase-handoff-candidate](parts/phase-handoff-candidate/README.md) | The lane stays staged instead of becoming a broad orchestration import. |
+| Existing checkpoint-adjacent technique bundles | [parts/technique-anchors](parts/technique-anchors/README.md) | Technique status remains owned by each `techniques/**/TECHNIQUE.md` bundle. |
+
+## AoA Center Relation
+
+`Agents-of-Abyss` owns checkpoint law, vocabulary, owner map, stop-lines, and
+cross-owner route grammar. Its Checkpoint package names stronger owner routes
+for `aoa-sdk`, `aoa-skills`, `aoa-agents`, `aoa-memo`, `aoa-playbooks`,
+`aoa-evals`, `aoa-routing`, `aoa-stats`, `Dionysus`, and `abyss-stack`.
+
+There is no direct `ORQ-CHECKPOINT-TECHNIQUES-*` request in the current AoA
+owner-request queue. Checkpoint pressure here is therefore local
+candidate-only practice pressure, not direct owner-request acceptance.
+
+## Source Bridge
+
+Relevant center-side sources consulted for this landing:
+
+- `Agents-of-Abyss:mechanics/checkpoint/README.md`
+- `Agents-of-Abyss:mechanics/checkpoint/DIRECTION.md`
+- `Agents-of-Abyss:mechanics/checkpoint/PARTS.md`
+- `Agents-of-Abyss:mechanics/checkpoint/OWNER_MAP.md`
+- `Agents-of-Abyss:mechanics/checkpoint/PROVENANCE.md`
+- `Agents-of-Abyss:mechanics/checkpoint/docs/CHECKPOINT_LAW.md`
+- `Agents-of-Abyss:mechanics/checkpoint/docs/CHECKPOINT_OWNER_BOUNDARY.md`
+- `Agents-of-Abyss:mechanics/checkpoint/parts/session-carry/README.md`
+- `Agents-of-Abyss:mechanics/checkpoint/parts/review-gate/README.md`
+- `Agents-of-Abyss:mechanics/checkpoint/parts/return-reentry/README.md`
+- `Agents-of-Abyss:mechanics/checkpoint/parts/closeout-bridge/README.md`
+- `Agents-of-Abyss:mechanics/checkpoint/parts/owner-handoff/README.md`
+
+Relevant local candidate and technique surfaces:
+
+- [External Candidate Ledger](../distillation/parts/external-candidate-ledger/README.md)
+- [Cross-Layer Candidate Ledger](../distillation/parts/cross-layer-candidate-ledger/README.md)
+- [Promotion Readiness Matrix](../audit/parts/promotion-readiness-matrix/README.md)
+- [structured-handoff-before-compaction](../../techniques/agent-workflows/structured-handoff-before-compaction/TECHNIQUE.md)
+- [receipt-confirmed-handoff-packet](../../techniques/agent-workflows/receipt-confirmed-handoff-packet/TECHNIQUE.md)
+- [episode-bounded-agent-loop](../../techniques/agent-workflows/episode-bounded-agent-loop/TECHNIQUE.md)
+- [checkpoint-bound-self-repair](../../techniques/agent-workflows/checkpoint-bound-self-repair/TECHNIQUE.md)
+- [session-capture-as-repo-artifact](../../techniques/history/session-capture-as-repo-artifact/TECHNIQUE.md)
+- [witness-trace-as-reviewable-artifact](../../techniques/history/witness-trace-as-reviewable-artifact/TECHNIQUE.md)

--- a/mechanics/checkpoint/README.md
+++ b/mechanics/checkpoint/README.md
@@ -1,0 +1,43 @@
+# Checkpoint
+
+This package owns the `aoa-techniques` side of Checkpoint: phase handoff,
+handoff packet, compaction/re-entry, and checkpoint-bound repair pressure that
+is not yet a new technique bundle.
+
+Checkpoint here is thinner than the center mechanic in `Agents-of-Abyss`.
+The center owns checkpoint law, vocabulary, owner map, stop-lines, and
+cross-owner route grammar. This repo only owns reusable practice-shaped
+pressure that may later distill into `techniques/**/TECHNIQUE.md`.
+
+## Active route
+
+- [Direction](DIRECTION.md)
+- [Parts](PARTS.md)
+- [Provenance](PROVENANCE.md)
+- [Landing Log](LANDING_LOG.md)
+- [Roadmap](ROADMAP.md)
+
+## Functioning parts
+
+- [Phase Handoff Candidate](parts/phase-handoff-candidate/README.md): keeps
+  `phase_sync_for_agents` and `phase-synchronized-agent-handoff` visible as an
+  active narrowing lane without drafting a premature bundle.
+- [Technique Anchors](parts/technique-anchors/README.md): maps current
+  checkpoint-adjacent technique bundles without changing their status.
+
+## Boundary
+
+Checkpoint can prepare and document technique-layer practice. It does not
+define checkpoint implementation authority, memory canon, proof verdicts,
+runtime activation, owner acceptance, hidden scheduler behavior, autonomous
+self-repair, route authority, stats truth, or automatic technique promotion.
+
+Stable reusable checkpoint practices may later become technique bundles, but
+only through the normal `techniques/**/TECHNIQUE.md` review path.
+
+## AoA relation
+
+`Agents-of-Abyss` owns the center Checkpoint mechanic and current owner map.
+The current center queue has no direct `ORQ-CHECKPOINT-TECHNIQUES-*` request,
+so local checkpoint pressure is recorded as candidate-only practice pressure in
+[Owner Request Receipts](../REQUEST_RECEIPTS.md).

--- a/mechanics/checkpoint/ROADMAP.md
+++ b/mechanics/checkpoint/ROADMAP.md
@@ -1,0 +1,41 @@
+# Checkpoint Roadmap
+
+This roadmap records future contour for the `aoa-techniques` checkpoint
+package. It does not change technique status, generated contracts, checkpoint
+law, or validator behavior by itself.
+
+## Current State
+
+- `phase-handoff-candidate` is the local home for the active
+  `phase_sync_for_agents` to `phase-synchronized-agent-handoff` narrowing lane.
+- `technique-anchors` maps current checkpoint-adjacent technique bundles
+  without changing their canonical or promoted status.
+- Checkpoint pressure is currently non-ORQ candidate-only pressure in this
+  repo, not a direct AoA owner-request landing.
+
+## Next Honest Moves
+
+- Reopen the phase handoff candidate only when public evidence exposes a
+  standalone phase boundary, handoff packet, continuation permission, and
+  stop/return/escalation rule.
+- Keep checkpoint-related references pointed at technique bundle homes when
+  the bundle already exists.
+- Add a new part only if repeated technique-layer checkpoint signals no longer
+  fit phase handoff candidate pressure or existing technique anchors.
+- Promote a reusable checkpoint practice into `techniques/` only after it can
+  name one atomic move, likely domain, likely kind, family posture, capability,
+  substrate, execution profile, risk posture, relations, and validation.
+
+## Stop-lines
+
+- Do not claim checkpoint implementation authority from this package.
+- Do not treat checkpoint notes, handoff packets, receipts, or session
+  artifacts as memory canon, route authority, proof verdicts, runtime
+  activation, stats truth, or owner acceptance.
+- Do not use checkpoint language to hide hidden scheduler behavior or
+  autonomous self-repair.
+- Do not allow automatic technique promotion or promote checkpoint-shaped
+  pressure into technique canon without a bundle-local review path.
+- Do not import AoA checkpoint law, checkpoint controls, closeout bridge
+  protocol, actor posture, memory writeback, proof, routing, stats, runtime
+  export, seed lineage, or owner acceptance into this package.

--- a/mechanics/checkpoint/parts/AGENTS.md
+++ b/mechanics/checkpoint/parts/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+Route card for `mechanics/checkpoint/parts/`.
+
+## Purpose
+
+Each part owns one bounded local checkpoint route for `aoa-techniques`. Parts
+describe movement around technique canon; they do not become canonical
+technique bundles or checkpoint implementation authority.
+
+## Local law
+
+- Keep part docs concise and owner-bounded.
+- Preserve links to `PROVENANCE.md` when moving, staging, or compacting source
+  material.
+- Keep controls, protocol, actor posture, memory, proof, runtime, routing,
+  stats, seed lineage, and owner acceptance with their owning repositories.
+- Promote into `techniques/` only when the reusable practice can stand as an
+  atomic technique with validation.
+
+## Verify
+
+Use the package and root tests after part changes:
+
+```bash
+python -m unittest tests.test_checkpoint_mechanics_topology
+python scripts/validate_repo.py
+```

--- a/mechanics/checkpoint/parts/README.md
+++ b/mechanics/checkpoint/parts/README.md
@@ -1,0 +1,12 @@
+# Checkpoint Parts
+
+Active local parts:
+
+- [Phase Handoff Candidate](phase-handoff-candidate/README.md)
+- [Technique Anchors](technique-anchors/README.md)
+
+These parts keep technique-layer checkpoint pressure legible. They do not own
+AoA checkpoint law, checkpoint controls, checkpoint-note protocol, memory
+canon, proof verdicts, runtime activation, route authority, stats truth, owner
+acceptance, hidden scheduler behavior, autonomous self-repair, or technique
+status changes.

--- a/mechanics/checkpoint/parts/phase-handoff-candidate/README.md
+++ b/mechanics/checkpoint/parts/phase-handoff-candidate/README.md
@@ -1,0 +1,46 @@
+# Phase Handoff Candidate
+
+This part keeps the active `phase_sync_for_agents` narrowing lane visible for
+future technique review.
+
+It does not draft `phase-synchronized-agent-handoff` as a technique bundle yet.
+
+## Current Role
+
+The candidate is still narrower than a donor orchestration stack but broader
+than the already-landed handoff siblings. It should remain staged until the
+reusable object can be named as one atomic move instead of a bundle of phase
+governance, mailbox transport, handoff authoring, receipt acceptance, and
+runtime orchestration.
+
+## Gate
+
+Reopen for bundle drafting only when evidence exposes all of these as one
+standalone practice:
+
+- phase boundary
+- handoff packet
+- continuation permission
+- stop/return/escalation rule
+
+Until then, keep the lane in mechanics and candidate ledgers.
+
+## Active Anchors
+
+- [External Candidate Ledger](../../../distillation/parts/external-candidate-ledger/README.md):
+  `phase_sync_for_agents` remains the active narrowing lane with
+  `future_import_here` posture.
+- [Cross-Layer Candidate Ledger](../../../distillation/parts/cross-layer-candidate-ledger/README.md):
+  `phase-synchronized-agent-handoff` remains staged elsewhere and should be
+  reopened only if a cleaner phase-checkpoint contract emerges.
+- [Promotion Readiness Matrix](../../../audit/parts/promotion-readiness-matrix/README.md):
+  existing handoff siblings are tracked as narrower promoted bundles.
+
+## Stop-lines
+
+- Do not import the donor orchestration stack.
+- Do not collapse existing handoff packet, receipt, mailbox, episode, or repair
+  techniques into one broad phase doctrine.
+- Do not use this candidate to claim checkpoint implementation authority,
+  memory canon, proof verdicts, runtime activation, owner acceptance, hidden
+  scheduler behavior, autonomous self-repair, or automatic technique promotion.

--- a/mechanics/checkpoint/parts/technique-anchors/README.md
+++ b/mechanics/checkpoint/parts/technique-anchors/README.md
@@ -1,0 +1,34 @@
+# Technique Anchors
+
+This part maps current checkpoint-adjacent technique bundles so future
+checkpoint work starts from the existing canon instead of redrafting it inside
+mechanics.
+
+It does not change technique status. The canonical or promoted meaning remains
+inside each `techniques/**/TECHNIQUE.md` file.
+
+## Anchor Map
+
+| Technique | Checkpoint-side relevance | Boundary |
+|---|---|---|
+| [AOA-T-0057 structured-handoff-before-compaction](../../../../techniques/agent-workflows/structured-handoff-before-compaction/TECHNIQUE.md) | Writes one continuation packet before compaction or session rollover. | Does not decide continuation permission, stop, return, or escalation rules across a general phase system. |
+| [AOA-T-0058 receipt-confirmed-handoff-packet](../../../../techniques/agent-workflows/receipt-confirmed-handoff-packet/TECHNIQUE.md) | Requires visible receipt before the receiver continues from a handoff packet. | Does not author the packet, own transport, or define broader rejection and phase-control policy. |
+| [AOA-T-0062 episode-bounded-agent-loop](../../../../techniques/agent-workflows/episode-bounded-agent-loop/TECHNIQUE.md) | Breaks longer work into checkpointed episodes with explicit continue, stop, or escalate decisions. | Does not define the handoff artifact shape, startup ritual, budgets, scheduler, or full autonomous platform. |
+| [AOA-T-0083 checkpoint-bound-self-repair](../../../../techniques/agent-workflows/checkpoint-bound-self-repair/TECHNIQUE.md) | Keeps self-repair behind approval, rollback, health-check, iteration-limit, and improvement-log posture. | Does not choose the repair shape or authorize autonomous self-modification. |
+| [AOA-T-0026 session-capture-as-repo-artifact](../../../../techniques/history/session-capture-as-repo-artifact/TECHNIQUE.md) | Preserves session history as project-scoped artifacts that can later support review or handoff. | Does not create memory recall semantics, policy authority, or checkpoint implementation truth. |
+| [AOA-T-0045 witness-trace-as-reviewable-artifact](../../../../techniques/history/witness-trace-as-reviewable-artifact/TECHNIQUE.md) | Preserves a bounded run trace before writeback, compost promotion, or canon lift. | Does not own runtime witness generation, memory writeback, proof, or promotion policy. |
+
+## Use
+
+Use this map when a checkpoint-shaped request appears and the smaller existing
+technique may already answer it.
+
+If the request needs a new atomic move, send it back through candidate review
+instead of editing these anchors into a larger checkpoint doctrine.
+
+## Stop-lines
+
+- Do not treat this map as a generated catalog or technique index replacement.
+- Do not change bundle status from this part.
+- Do not let checkpoint language override bundle-local contracts, risks,
+  validation, or adjacent-technique boundaries.

--- a/tests/test_checkpoint_mechanics_topology.py
+++ b/tests/test_checkpoint_mechanics_topology.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_CHECKPOINT_SURFACES = (
+    "mechanics/checkpoint/AGENTS.md",
+    "mechanics/checkpoint/README.md",
+    "mechanics/checkpoint/DIRECTION.md",
+    "mechanics/checkpoint/PARTS.md",
+    "mechanics/checkpoint/PROVENANCE.md",
+    "mechanics/checkpoint/LANDING_LOG.md",
+    "mechanics/checkpoint/ROADMAP.md",
+    "mechanics/checkpoint/parts/AGENTS.md",
+    "mechanics/checkpoint/parts/README.md",
+)
+
+PART_LOCAL_CHECKPOINT_READMES = (
+    "mechanics/checkpoint/parts/phase-handoff-candidate/README.md",
+    "mechanics/checkpoint/parts/technique-anchors/README.md",
+)
+
+
+class CheckpointMechanicsTopologyTestCase(unittest.TestCase):
+    def test_checkpoint_active_surfaces_are_discoverable(self) -> None:
+        for relative_path in ACTIVE_CHECKPOINT_SURFACES + PART_LOCAL_CHECKPOINT_READMES:
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).is_file())
+
+    def test_checkpoint_part_map_names_all_current_parts(self) -> None:
+        parts = (REPO_ROOT / "mechanics" / "checkpoint" / "PARTS.md").read_text(
+            encoding="utf-8"
+        )
+        provenance = (
+            REPO_ROOT / "mechanics" / "checkpoint" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        for part_name in ("phase-handoff-candidate", "technique-anchors"):
+            with self.subTest(part_name=part_name):
+                self.assertIn(part_name, parts)
+                self.assertIn(part_name, provenance)
+
+    def test_checkpoint_stays_outside_direct_orq_lane(self) -> None:
+        receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
+            encoding="utf-8"
+        )
+        direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
+        non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+
+        self.assertNotIn("ORQ-CHECKPOINT-TECHNIQUES", direct_section)
+        self.assertIn("### [checkpoint](checkpoint/README.md)", non_orq_section)
+        self.assertIn("Current status: `candidate-only`", non_orq_section)
+        self.assertIn(
+            "direct `ORQ-CHECKPOINT-TECHNIQUES-*` request",
+            non_orq_section,
+        )
+        for phrase in (
+            "checkpoint implementation\n  authority",
+            "memory canon",
+            "proof verdicts",
+            "runtime activation",
+            "owner\n  acceptance",
+            "hidden scheduler behavior",
+            "autonomous self-repair",
+            "automatic\n  technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, non_orq_section)
+
+    def test_phase_handoff_candidate_preserves_gate(self) -> None:
+        candidate = (
+            REPO_ROOT
+            / "mechanics"
+            / "checkpoint"
+            / "parts"
+            / "phase-handoff-candidate"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for phrase in (
+            "phase_sync_for_agents",
+            "phase-synchronized-agent-handoff",
+            "future_import_here",
+            "phase boundary",
+            "handoff packet",
+            "continuation permission",
+            "stop/return/escalation rule",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, candidate)
+
+    def test_technique_anchors_point_to_bundle_local_homes(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "checkpoint"
+            / "parts"
+            / "technique-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for technique_id in (
+            "AOA-T-0057",
+            "AOA-T-0058",
+            "AOA-T-0062",
+            "AOA-T-0083",
+            "AOA-T-0026",
+            "AOA-T-0045",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, anchors)
+
+        self.assertIn("does not change technique status", anchors)
+        self.assertIn("techniques/**/TECHNIQUE.md", anchors)
+
+    def test_checkpoint_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+        provenance = (
+            REPO_ROOT / "mechanics" / "checkpoint" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertFalse((REPO_ROOT / "mechanics" / "checkpoint" / "legacy").exists())
+        self.assertIn("does not create `legacy/raw/`", provenance)
+        self.assertIn("no local pre-split checkpoint", provenance)
+
+    def test_checkpoint_stop_lines_remain_explicit(self) -> None:
+        direction = (
+            REPO_ROOT / "mechanics" / "checkpoint" / "DIRECTION.md"
+        ).read_text(encoding="utf-8")
+        roadmap = (REPO_ROOT / "mechanics" / "checkpoint" / "ROADMAP.md").read_text(
+            encoding="utf-8"
+        )
+        compact_direction = " ".join(direction.split())
+        compact_roadmap = " ".join(roadmap.split())
+
+        for phrase in (
+            "checkpoint implementation authority",
+            "memory canon",
+            "proof verdicts",
+            "runtime activation",
+            "owner acceptance",
+            "hidden scheduler",
+            "autonomous self-repair",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_direction)
+                self.assertIn(phrase, compact_roadmap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `mechanics/checkpoint/` as a candidate-only local mechanic for checkpoint-shaped technique pressure
- map phase handoff and checkpoint-adjacent technique anchors without claiming AoA checkpoint authority
- add request receipt coverage, a decision note, and topology tests

## Validation

- `python -m unittest tests.test_checkpoint_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo`
- `python scripts/validate_repo.py`
- `python -m unittest discover -s tests`
- `git diff --check`