### PR TITLE
[codex] Add boundary bridge candidate mechanic

### DIFF
--- a/docs/decisions/2026-05-03-boundary-bridge-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-boundary-bridge-candidate-mechanic.md
@@ -1,0 +1,79 @@
+# Boundary Bridge Candidate Mechanic
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+`Agents-of-Abyss` has a landed Boundary Bridge mechanic that owns
+boundary-crossing doctrine, bridge modes, owner maps, non-transfer stop-lines,
+and owner-request packets. The center owner map routes ToS meaning to
+`Tree-of-Sophia`, derived projection to `aoa-kag`, route behavior to
+`aoa-routing`, memory and witness objects to `aoa-memo`, proof to `aoa-evals`,
+scenario choreography to `aoa-playbooks`, compatibility to `aoa-sdk`, runtime
+to `abyss-stack`, and public projection to the public route owner after
+evidence lands.
+
+`aoa-techniques` already carries boundary-adjacent practice: owner-layer
+triage, nearest-wrong-target rejection, bounded context mapping,
+canonical-owner mirrors, source-lift and KAG exports, direct relation lifts,
+multi-source provenance, repo-doc surface lifts, contract boundary testing,
+fail-closed evidence gates, and audit-to-closeout proof loops.
+
+The current AoA queue has no direct `ORQ-BRIDGE-TECHNIQUES-*` request, so this
+repo should not present boundary-bridge work as center request acceptance.
+
+## Decision
+
+Add a local `mechanics/boundary-bridge/` package as candidate-only practice
+pressure.
+
+Create active package route files:
+
+- `AGENTS.md`
+- `README.md`
+- `DIRECTION.md`
+- `PARTS.md`
+- `PROVENANCE.md`
+- `LANDING_LOG.md`
+- `ROADMAP.md`
+- `parts/AGENTS.md`
+- `parts/README.md`
+
+Create three active parts:
+
+- `parts/owner-boundary-anchors/README.md`
+- `parts/derived-projection-anchors/README.md`
+- `parts/proof-claim-anchors/README.md`
+
+Do not create `legacy/raw/` in this pass because no local pre-split
+boundary-bridge wave receipt or raw source packet is being moved.
+
+Add Boundary-bridge to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ
+Center Pressure, with `candidate-only` posture.
+
+## Consequences
+
+- Boundary-bridge pressure becomes discoverable in the mechanics map without
+  importing AoA center law as local implementation authority.
+- Existing boundary-adjacent technique bundles remain canonical only through
+  their `techniques/**/TECHNIQUE.md` homes.
+- Generated readers, KAG exports, repo-doc routing, relation hints, and
+  compatibility mirrors remain derived or mirrored surfaces rather than source
+  truth.
+- Owner acceptance, identity claims, ToS canon, source interpretation, routing
+  authority, SDK authority, memory authority, runtime authority, public
+  projection authority, generated companion authority, proof before
+  `aoa-evals` or source-owner evidence, and technique promotion stay outside
+  this package.
+
+## Verification
+
+Verify with:
+
+```bash
+python -m unittest tests.test_boundary_bridge_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -7,7 +7,8 @@ Route card for the `aoa-techniques/mechanics/` surface.
 `mechanics/` owns reusable practice-motion surfaces for `aoa-techniques`.
 These files describe how practice moves through the repo by participating in
 cross-project AoA mechanics: method-growth, distillation, audit, growth-cycle,
-Agon, recurrence, experience, release-support, antifragility, and checkpoint.
+Agon, recurrence, experience, release-support, antifragility, checkpoint, and
+boundary-bridge.
 
 Mechanics are not canonical technique bundles. They shape the route into or
 around canon, while `techniques/` owns published technique content and
@@ -20,7 +21,7 @@ This surface owns:
 - owner-local movement grammar for candidate-to-technique flow inside the AoA
   mechanics vocabulary
 - bounded intake, promotion, adoption, mastery, recurrence, release-support,
-  experience, antifragility, and checkpoint routes
+  experience, antifragility, checkpoint, and boundary-bridge routes
 - public-safe stop-lines for deciding when a surface must hand off to another
   AoA repo
 - reusable precedent notes that are too procedural for general `docs/` but not

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -37,6 +37,9 @@ receipt route, not a copy of the AoA request queue and not proof of acceptance.
 - [checkpoint](checkpoint/README.md): phase handoff, handoff packet,
   compaction, re-entry, and checkpoint-bound repair pressure that stays
   candidate-only until a technique bundle owns the atomic move.
+- [boundary-bridge](boundary-bridge/README.md): owner-boundary,
+  derived-projection, and proof-claim practice pressure that keeps technique
+  canon, generated surfaces, sibling owners, and public claims distinct.
 
 ## Boundary
 

--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -128,6 +128,21 @@ or candidate lanes without a direct AoA owner-request ID targeting
   technique promotion. Existing antifragility-recovery technique bundles remain
   canonical only through their `techniques/**/TECHNIQUE.md` homes.
 
+### [boundary-bridge](boundary-bridge/README.md)
+
+- Current status: `candidate-only`
+- Why it stays separate: the current AoA Boundary Bridge owner-request queue
+  has no direct `ORQ-BRIDGE-TECHNIQUES-*` request. Local Boundary-bridge
+  surfaces preserve owner-boundary, derived-projection, and proof-claim
+  practice pressure without claiming owner acceptance, identity between bridged
+  surfaces, AoA-authored Tree-of-Sophia canon, source interpretation, derived
+  projection as source truth, routing authority, SDK authority, memory
+  authority, runtime authority, public projection authority, proof before
+  `aoa-evals` or the source owner lands evidence, generated companion
+  authority, or automatic technique promotion. Existing boundary-related
+  technique bundles remain canonical only through their
+  `techniques/**/TECHNIQUE.md` homes.
+
 ### [checkpoint](checkpoint/README.md)
 
 - Current status: `candidate-only`

--- a/mechanics/boundary-bridge/AGENTS.md
+++ b/mechanics/boundary-bridge/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+Route card for `mechanics/boundary-bridge/`.
+
+## Purpose
+
+This package owns the `aoa-techniques` side of Boundary-bridge: local practice
+pressure around owner-boundary placement, non-identity, derived projection,
+proof-claim discipline, and generated or mirrored surfaces that may feed future
+technique canon.
+
+It does not own AoA boundary-bridge law, Tree-of-Sophia meaning, source
+interpretation, KAG projection truth, routing behavior, SDK compatibility
+authority, memory writeback, proof verdicts, runtime activation, public
+projection authority, owner acceptance, or technique status changes.
+
+## Start here
+
+1. Root `AGENTS.md`.
+2. `mechanics/AGENTS.md`.
+3. `mechanics/boundary-bridge/README.md`.
+4. `DIRECTION.md`, `PARTS.md`, `PROVENANCE.md`, and the touched part README.
+5. `mechanics/REQUEST_RECEIPTS.md` only when naming AoA center-side pressure.
+
+## Local law
+
+- Keep boundary-bridge here technique-layered: reusable practice pressure, not
+  cross-owner authority.
+- Do not import `Agents-of-Abyss` boundary-bridge law as local implementation
+  authority.
+- Do not treat technique anchors, generated surfaces, KAG exports, route hints,
+  proof notes, receipts, or compatibility mirrors as owner acceptance, source
+  truth, proof verdicts, runtime truth, or public authority.
+- Keep sibling owner truth with its owner: ToS meaning in `Tree-of-Sophia`,
+  derived projection in `aoa-kag`, route behavior in `aoa-routing`, memory and
+  witness objects in `aoa-memo`, proof in `aoa-evals`, scenario choreography in
+  `aoa-playbooks`, compatibility in `aoa-sdk`, runtime in `abyss-stack`, and
+  center law in `Agents-of-Abyss`.
+- If a stable reusable practice emerges, route it into `techniques/` through
+  the normal technique review path.
+
+## Verify
+
+Use the root validation path after changes:
+
+```bash
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/boundary-bridge/DIRECTION.md
+++ b/mechanics/boundary-bridge/DIRECTION.md
@@ -1,0 +1,53 @@
+# Boundary Bridge Direction
+
+Boundary-bridge in `aoa-techniques` keeps cross-owner practice portable without
+pretending that local practice notes transfer authority between owners.
+
+This file owns the local direction only. AoA center owns boundary-crossing
+doctrine, bridge modes, owner maps, non-transfer stop-lines, and owner-request
+packets.
+
+## Source-of-truth Split
+
+- `README.md`: package entry card and shortest route.
+- `DIRECTION.md`: current local direction.
+- `PARTS.md`: active part map.
+- `parts/`: concise local mechanics surfaces.
+- `PROVENANCE.md`: bridge from AoA boundary-bridge, local docs, and existing
+  technique bundles to active parts.
+- `LANDING_LOG.md`: dated structural accounting.
+- `ROADMAP.md`: future contour, not a historical ledger.
+
+## Local Contour
+
+This package can name:
+
+- local techniques that keep owner placement, nearest-wrong-target rejection,
+  bounded contexts, and validated mirrors distinct
+- local techniques and docs that keep source-lift, KAG exports, generated
+  readers, repo-doc routing, and relation hints derived from authored sources
+- local techniques that keep proof and public claims below owner evidence
+- the boundary between candidate mechanics and technique canon
+- the owner route to stronger boundary surfaces when local practice is not the
+  real owner
+
+It cannot name:
+
+- AoA boundary-bridge law or owner acceptance
+- identity between bridged surfaces
+- AoA-authored Tree-of-Sophia canon or source interpretation
+- derived projection as source truth
+- routing authority, SDK authority, memory authority, runtime authority, public
+  projection authority, or generated companion authority
+- proof before `aoa-evals` or the source owner lands evidence
+- automatic technique promotion
+
+## Growth Rule
+
+Add detail only when repeated boundary-shaped work needs a clearer route into
+portable technique practice, owner-local handoff, or future bundle review.
+
+If the output needs ToS meaning, KAG projection, route behavior, memory,
+scenario choreography, proof, compatibility, runtime export, public projection,
+or owner acceptance, route to the owner repository instead of expanding local
+prose.

--- a/mechanics/boundary-bridge/LANDING_LOG.md
+++ b/mechanics/boundary-bridge/LANDING_LOG.md
@@ -1,0 +1,30 @@
+# Boundary Bridge Landing Log
+
+This ledger records structural landings for `mechanics/boundary-bridge/`. It
+is not a roadmap and not a technique status source.
+
+## 2026-05-03
+
+- Added the local Boundary-bridge mechanic package as candidate-only practice
+  pressure.
+- Created active route files: `AGENTS.md`, `README.md`, `DIRECTION.md`,
+  `PARTS.md`, `PROVENANCE.md`, `LANDING_LOG.md`, and `ROADMAP.md`.
+- Created active parts:
+  - `parts/owner-boundary-anchors/README.md`
+  - `parts/derived-projection-anchors/README.md`
+  - `parts/proof-claim-anchors/README.md`
+- Updated `mechanics/README.md`, `mechanics/AGENTS.md`, and
+  `mechanics/REQUEST_RECEIPTS.md` so boundary-bridge is discoverable without
+  claiming a direct `ORQ-BRIDGE-TECHNIQUES-*` lane.
+- Added topology tests and a decision note for the candidate-only
+  boundary-bridge landing.
+
+## Verification Route
+
+Use:
+
+```bash
+python -m unittest tests.test_boundary_bridge_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/boundary-bridge/PARTS.md
+++ b/mechanics/boundary-bridge/PARTS.md
@@ -1,0 +1,18 @@
+# Boundary Bridge Parts
+
+This file maps current boundary-bridge pressure to active `aoa-techniques`
+parts. It is not the AoA center boundary-bridge part map and not a raw source
+inventory.
+
+| Part | Current role | Active source | Provenance |
+|---|---|---|---|
+| `owner-boundary-anchors` | Maps owner placement, nearest-wrong-target rejection, bounded context, and validated-mirror technique anchors without claiming owner acceptance. | [parts/owner-boundary-anchors](parts/owner-boundary-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `derived-projection-anchors` | Maps source-lift, KAG, relation, provenance, repo-doc, and generated reader surfaces that stay downstream of authored bundles. | [parts/derived-projection-anchors](parts/derived-projection-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `proof-claim-anchors` | Maps proof and public-claim practice anchors without issuing proof verdicts from mechanics. | [parts/proof-claim-anchors](parts/proof-claim-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+
+## Part Rule
+
+If a part starts carrying a stable reusable practice with inputs, outputs,
+risks, examples, and validation, route the practice bundle into `techniques/`.
+Leave this package as the mechanics layer that explains how boundary-bridge
+pressure moved.

--- a/mechanics/boundary-bridge/PROVENANCE.md
+++ b/mechanics/boundary-bridge/PROVENANCE.md
@@ -1,0 +1,66 @@
+# Boundary Bridge Provenance
+
+This file preserves the active-first bridge from AoA boundary-bridge law,
+local source-lift docs, and existing boundary-adjacent technique bundles to the
+current local parts.
+
+This pass does not create `legacy/raw/` because no local pre-split
+boundary-bridge wave receipt or raw source packet is being moved. The package
+is a new local mechanic built from active center guidance and already-landed
+local surfaces.
+
+## Active Landing Map
+
+| Source pressure | Current active home | Preservation note |
+|---|---|---|
+| Owner placement, non-identity, and no-transfer practice | [parts/owner-boundary-anchors](parts/owner-boundary-anchors/README.md) | Existing bundles keep owner placement and nearest-wrong-target rejection in technique canon rather than mechanics prose. |
+| Source-lift and generated reader pressure | [parts/derived-projection-anchors](parts/derived-projection-anchors/README.md) | Generated surfaces stay derived from authored technique bundles and docs; they do not become source truth. |
+| Proof, evidence gate, and supportable public claim pressure | [parts/proof-claim-anchors](parts/proof-claim-anchors/README.md) | Mechanics may name proof routes, but proof verdicts stay with `aoa-evals`, source owners, or bundle-local validation. |
+
+## AoA Center Relation
+
+`Agents-of-Abyss` owns boundary-crossing doctrine, bridge modes, owner maps,
+non-transfer stop-lines, and owner-request packets. Its Boundary Bridge package
+names stronger owner routes for `Tree-of-Sophia`, `aoa-kag`, `aoa-routing`,
+`aoa-memo`, `aoa-evals`, `aoa-playbooks`, `aoa-sdk`, `abyss-stack`, and public
+projection surfaces.
+
+There is no direct `ORQ-BRIDGE-TECHNIQUES-*` request in the current AoA
+owner-request queue. Boundary-bridge pressure here is therefore local
+candidate-only practice pressure, not direct owner-request acceptance.
+
+## Source Bridge
+
+Relevant center-side sources consulted for this landing:
+
+- `Agents-of-Abyss:mechanics/boundary-bridge/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/DIRECTION.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/PARTS.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/OWNER_MAP.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/OWNER_REQUESTS.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/PROVENANCE.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/docs/COUNTERPART_BRIDGE.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/boundary-contract/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/non-identity-guard/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/derived-projection/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/owner-handoff/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/proof-review-route/README.md`
+- `Agents-of-Abyss:mechanics/boundary-bridge/parts/compatibility-route/README.md`
+
+Relevant local docs and technique surfaces:
+
+- [Technique Atom Contract](../../docs/TECHNIQUE_ATOM_CONTRACT.md)
+- [Technique Topology Contract](../../docs/TECHNIQUE_TOPOLOGY_CONTRACT.md)
+- [KAG Source Lift Guide](../../docs/KAG_SOURCE_LIFT_GUIDE.md)
+- [KAG Export](../../docs/KAG_EXPORT.md)
+- [Technique Sections](../../docs/TECHNIQUE_SECTIONS.md)
+- [owner-layer-triage](../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md)
+- [nearest-wrong-target-rejection](../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md)
+- [bounded-context-map](../../techniques/docs/bounded-context-map/TECHNIQUE.md)
+- [canonical-owner-with-validated-mirror](../../techniques/docs/canonical-owner-with-validated-mirror/TECHNIQUE.md)
+- [multi-source-primary-input-provenance](../../techniques/docs/multi-source-primary-input-provenance/TECHNIQUE.md)
+- [bounded-relation-lift-for-kag](../../techniques/docs/bounded-relation-lift-for-kag/TECHNIQUE.md)
+- [repo-doc-surface-lift](../../techniques/docs/repo-doc-surface-lift/TECHNIQUE.md)
+- [contract-test-design](../../techniques/evaluation/contract-test-design/TECHNIQUE.md)
+- [fail-closed-evidence-gate](../../techniques/agent-workflows/fail-closed-evidence-gate/TECHNIQUE.md)
+- [audit-to-closeout-proof-loop](../../techniques/agent-workflows/audit-to-closeout-proof-loop/TECHNIQUE.md)

--- a/mechanics/boundary-bridge/README.md
+++ b/mechanics/boundary-bridge/README.md
@@ -1,0 +1,51 @@
+# Boundary Bridge
+
+This package owns the `aoa-techniques` side of Boundary-bridge: owner-boundary,
+non-identity, derived-projection, and proof-claim practice pressure that is not
+yet a new technique bundle.
+
+Boundary-bridge here is thinner than the center mechanic in
+`Agents-of-Abyss`. The center owns boundary-crossing doctrine, bridge modes,
+owner maps, non-transfer stop-lines, and owner-request packets. This repo only
+owns reusable practice-shaped pressure that may later distill into
+`techniques/**/TECHNIQUE.md`.
+
+## Active route
+
+- [Direction](DIRECTION.md)
+- [Parts](PARTS.md)
+- [Provenance](PROVENANCE.md)
+- [Landing Log](LANDING_LOG.md)
+- [Roadmap](ROADMAP.md)
+
+## Functioning parts
+
+- [Owner Boundary Anchors](parts/owner-boundary-anchors/README.md): maps
+  owner placement, nearest-wrong-target rejection, bounded context, and
+  validated-mirror techniques.
+- [Derived Projection Anchors](parts/derived-projection-anchors/README.md):
+  maps source-lift, KAG, relation, provenance, repo-doc, and generated reader
+  surfaces that stay downstream of authored technique bundles.
+- [Proof Claim Anchors](parts/proof-claim-anchors/README.md): maps proof,
+  evidence gate, and public claim practice that keeps supportable claims below
+  owner proof.
+
+## Boundary
+
+Boundary-bridge can prepare and document technique-layer practice. It does not
+define owner acceptance, identity between bridged surfaces,
+Tree-of-Sophia canon, source interpretation, derived projection as source
+truth, routing authority, SDK authority, memory authority, runtime authority,
+public projection authority, proof before `aoa-evals` or the source owner
+lands evidence, generated companion authority, or automatic technique
+promotion.
+
+Stable reusable boundary-bridge practices may later become technique bundles,
+but only through the normal `techniques/**/TECHNIQUE.md` review path.
+
+## AoA relation
+
+`Agents-of-Abyss` owns the center Boundary Bridge mechanic and current owner
+map. The current center queue has no direct `ORQ-BRIDGE-TECHNIQUES-*` request,
+so local boundary-bridge pressure is recorded as candidate-only practice
+pressure in [Owner Request Receipts](../REQUEST_RECEIPTS.md).

--- a/mechanics/boundary-bridge/ROADMAP.md
+++ b/mechanics/boundary-bridge/ROADMAP.md
@@ -1,0 +1,45 @@
+# Boundary Bridge Roadmap
+
+This roadmap records future contour for the `aoa-techniques` boundary-bridge
+package. It does not change technique status, generated contracts,
+boundary-bridge law, or validator behavior by itself.
+
+## Current State
+
+- `owner-boundary-anchors` is the local home for owner placement,
+  nearest-wrong-target rejection, bounded-context, and validated-mirror
+  boundary pressure.
+- `derived-projection-anchors` is the local home for KAG, source-lift,
+  generated reader, provenance, relation, and repo-doc routing boundary
+  pressure.
+- `proof-claim-anchors` is the local home for proof, evidence gate, and public
+  claim boundary pressure.
+- Boundary-bridge pressure is currently non-ORQ candidate-only pressure in this
+  repo, not a direct AoA owner-request landing.
+
+## Next Honest Moves
+
+- Keep boundary-bridge references pointed at existing technique bundle homes
+  when the bundle already exists.
+- Add a new part only if repeated technique-layer bridge signals no longer fit
+  owner-boundary anchors, derived-projection anchors, or proof-claim anchors.
+- Promote a reusable boundary-bridge practice into `techniques/` only after it
+  can name one atomic move, likely domain, likely kind, family posture,
+  capability, substrate, execution profile, risk posture, relations, and
+  validation.
+
+## Stop-lines
+
+- Do not claim owner acceptance from this package.
+- Do not claim identity between bridged surfaces.
+- Do not author Tree-of-Sophia canon or source interpretation from this
+  package.
+- Do not treat derived projection as source truth.
+- Do not import routing authority, SDK authority, memory authority, runtime
+  authority, public projection authority, or generated companion authority into
+  this package.
+- Do not claim proof before `aoa-evals` or the source owner lands evidence.
+- Do not allow automatic technique promotion from boundary-shaped pressure.
+- Do not import AoA boundary-bridge law, ToS meaning, KAG projection truth,
+  route behavior, compatibility authority, memory writeback, proof verdicts,
+  runtime activation, public projection, or owner acceptance into this package.

--- a/mechanics/boundary-bridge/parts/AGENTS.md
+++ b/mechanics/boundary-bridge/parts/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Route card for `mechanics/boundary-bridge/parts/`.
+
+## Purpose
+
+Each part owns one bounded local boundary-bridge route for `aoa-techniques`.
+Parts describe movement around technique canon; they do not become canonical
+technique bundles or cross-owner authority.
+
+## Local law
+
+- Keep part docs concise and owner-bounded.
+- Preserve links to `PROVENANCE.md` when moving, staging, or compacting source
+  material.
+- Keep ToS meaning, KAG projection truth, route behavior, memory, proof,
+  scenario choreography, compatibility, runtime, public projection, and owner
+  acceptance with their owning repositories.
+- Promote into `techniques/` only when the reusable practice can stand as an
+  atomic technique with validation.
+
+## Verify
+
+Use the package and root tests after part changes:
+
+```bash
+python -m unittest tests.test_boundary_bridge_mechanics_topology
+python scripts/validate_repo.py
+```

--- a/mechanics/boundary-bridge/parts/README.md
+++ b/mechanics/boundary-bridge/parts/README.md
@@ -1,0 +1,13 @@
+# Boundary Bridge Parts
+
+Active local parts:
+
+- [Owner Boundary Anchors](owner-boundary-anchors/README.md)
+- [Derived Projection Anchors](derived-projection-anchors/README.md)
+- [Proof Claim Anchors](proof-claim-anchors/README.md)
+
+These parts keep technique-layer boundary-bridge pressure legible. They do not
+own AoA boundary-bridge law, Tree-of-Sophia meaning, KAG projection truth,
+route behavior, memory authority, proof verdicts, scenario choreography,
+`aoa-sdk` compatibility authority, runtime activation, public projection
+authority, owner acceptance, or technique status changes.

--- a/mechanics/boundary-bridge/parts/derived-projection-anchors/README.md
+++ b/mechanics/boundary-bridge/parts/derived-projection-anchors/README.md
@@ -1,0 +1,34 @@
+# Derived Projection Anchors
+
+This part maps current source-lift and generated-reader technique bundles so
+future boundary-bridge work keeps derived surfaces downstream of authored
+sources.
+
+It does not change technique status. The canonical or promoted meaning remains
+inside each `techniques/**/TECHNIQUE.md` file and repo guide.
+
+## Anchor Map
+
+| Surface | Boundary-bridge relevance | Boundary |
+|---|---|---|
+| [KAG Source Lift Guide](../../../../docs/KAG_SOURCE_LIFT_GUIDE.md) | Keeps technique markdown strong enough for bounded KAG-friendly outputs without turning the repo into a graph platform. | Defers graph behavior, scoring, traversal, and new source authority. |
+| [KAG Export](../../../../docs/KAG_EXPORT.md) | Exposes a bounded source-owned export while keeping `TECHNIQUE.md` authoritative. | Does not replace authored technique meaning. |
+| [AOA-T-0043 multi-source-primary-input-provenance](../../../../techniques/docs/multi-source-primary-input-provenance/TECHNIQUE.md) | Marks primary and supporting source inputs when a bridge combines multiple source surfaces. | Does not create graph semantics, ranking doctrine, or bridge architecture. |
+| [AOA-T-0021 bounded-relation-lift-for-kag](../../../../techniques/docs/bounded-relation-lift-for-kag/TECHNIQUE.md) | Lifts direct typed relations as one-step derived hints. | Does not create rationale, weighting, or multi-hop graph truth. |
+| [AOA-T-0046 repo-doc-surface-lift](../../../../techniques/docs/repo-doc-surface-lift/TECHNIQUE.md) | Lifts a bounded public docs/status set into derived routing knowledge. | Does not replace authored docs or become docs taxonomy. |
+| [AOA-T-0018 markdown-technique-section-lift](../../../../techniques/docs/markdown-technique-section-lift/TECHNIQUE.md) | Lifts stable sections from authoritative technique markdown into derived section routing. | Does not invent section IDs, dump section bodies, or replace source markdown. |
+
+## Use
+
+Use this map when a bridge request touches KAG, generated readers, repo-doc
+routing, source-lift, or relation projections.
+
+If the request needs graph behavior, ranking, traversal, generated policy, or
+source authority, route it to the owning layer instead of expanding this part.
+
+## Stop-lines
+
+- Do not treat derived projection as source truth.
+- Do not treat generated companions as authority.
+- Do not let graph convenience outrun authored source bundles, source docs, or
+  owner-local proof.

--- a/mechanics/boundary-bridge/parts/owner-boundary-anchors/README.md
+++ b/mechanics/boundary-bridge/parts/owner-boundary-anchors/README.md
@@ -1,0 +1,32 @@
+# Owner Boundary Anchors
+
+This part maps current owner-boundary technique bundles so future
+boundary-bridge work starts from existing canon instead of redrafting owner
+placement rules inside mechanics.
+
+It does not change technique status. The canonical or promoted meaning remains
+inside each `techniques/**/TECHNIQUE.md` file.
+
+## Anchor Map
+
+| Technique | Boundary-bridge relevance | Boundary |
+|---|---|---|
+| [AOA-T-0076 owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md) | Places one bounded reusable unit in one primary owner layer and rejects one nearest wrong target. | Does not extract donor units, finish promotion review, or make derivative routing a first-authoring owner. |
+| [AOA-T-0090 nearest-wrong-target-rejection](../../../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md) | Makes the closest wrong owner or promotion target explicit so adjacent layers stay distinct. | Does not choose the full placement verdict or author the next surface. |
+| [AOA-T-0016 bounded-context-map](../../../../techniques/docs/bounded-context-map/TECHNIQUE.md) | Names contexts, responsibilities, and handoff interfaces before changes cross the wrong boundary. | Does not define a full architecture program or replace interface cleanup. |
+| [AOA-T-0094 canonical-owner-with-validated-mirror](../../../../techniques/docs/canonical-owner-with-validated-mirror/TECHNIQUE.md) | Keeps one canonical cross-repo owner while allowing mirrors only through explicit parity validation. | Does not make mirrors new primary sources or own rollout choreography. |
+
+## Use
+
+Use this map when a boundary-shaped request appears and the smaller existing
+technique may already answer it.
+
+If the request needs a new atomic move, send it back through candidate review
+instead of editing these anchors into a broader boundary doctrine.
+
+## Stop-lines
+
+- Do not treat owner placement as owner acceptance.
+- Do not treat mirrored or nearby surfaces as source truth.
+- Do not let boundary-bridge language override bundle-local contracts, risks,
+  validation, or adjacent-technique boundaries.

--- a/mechanics/boundary-bridge/parts/proof-claim-anchors/README.md
+++ b/mechanics/boundary-bridge/parts/proof-claim-anchors/README.md
@@ -1,0 +1,33 @@
+# Proof Claim Anchors
+
+This part maps current proof and public-claim boundary techniques so future
+boundary-bridge work can name proof routes without issuing proof from
+mechanics.
+
+It does not change technique status. The canonical or promoted meaning remains
+inside each `techniques/**/TECHNIQUE.md` file.
+
+## Anchor Map
+
+| Technique | Boundary-bridge relevance | Boundary |
+|---|---|---|
+| [AOA-T-0015 contract-test-design](../../../../techniques/evaluation/contract-test-design/TECHNIQUE.md) | Makes one consumer-visible boundary explicit through expected inputs, outputs, and verification. | Does not prove hidden internals or broader owner truth. |
+| [AOA-T-0068 fail-closed-evidence-gate](../../../../techniques/agent-workflows/fail-closed-evidence-gate/TECHNIQUE.md) | Stops mutating execution unless explicit allow evidence exists. | Does not replace proof owners or broad approval policy. |
+| [AOA-T-0092 audit-to-closeout-proof-loop](../../../../techniques/agent-workflows/audit-to-closeout-proof-loop/TECHNIQUE.md) | Turns reviewed audit findings into live-confirmed, proof-backed closeout. | Does not let audit wording become proof by itself. |
+| [AOA-T-0093 recommendation-truth-vs-host-actionability](../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md) | Separates recommendation truth from host actionability when tools or routing surfaces cannot execute a recommendation. | Does not let runnable action or router relevance masquerade as authority. |
+
+## Use
+
+Use this map when a boundary-shaped request wants to claim that a bridge,
+projection, route, receipt, or generated surface is proven or publicly
+supportable.
+
+If the proof question needs a verdict, route to `aoa-evals` or the source
+owner rather than expanding mechanics.
+
+## Stop-lines
+
+- Do not make public claims without evidence.
+- Do not issue proof verdicts from this package.
+- Do not treat generated companions, route hints, owner requests, or audit
+  wording as proof.

--- a/tests/test_boundary_bridge_mechanics_topology.py
+++ b/tests/test_boundary_bridge_mechanics_topology.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_BOUNDARY_BRIDGE_SURFACES = (
+    "mechanics/boundary-bridge/AGENTS.md",
+    "mechanics/boundary-bridge/README.md",
+    "mechanics/boundary-bridge/DIRECTION.md",
+    "mechanics/boundary-bridge/PARTS.md",
+    "mechanics/boundary-bridge/PROVENANCE.md",
+    "mechanics/boundary-bridge/LANDING_LOG.md",
+    "mechanics/boundary-bridge/ROADMAP.md",
+    "mechanics/boundary-bridge/parts/AGENTS.md",
+    "mechanics/boundary-bridge/parts/README.md",
+)
+
+PART_LOCAL_BOUNDARY_BRIDGE_READMES = (
+    "mechanics/boundary-bridge/parts/owner-boundary-anchors/README.md",
+    "mechanics/boundary-bridge/parts/derived-projection-anchors/README.md",
+    "mechanics/boundary-bridge/parts/proof-claim-anchors/README.md",
+)
+
+
+class BoundaryBridgeMechanicsTopologyTestCase(unittest.TestCase):
+    def test_boundary_bridge_active_surfaces_are_discoverable(self) -> None:
+        for relative_path in (
+            ACTIVE_BOUNDARY_BRIDGE_SURFACES + PART_LOCAL_BOUNDARY_BRIDGE_READMES
+        ):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).is_file())
+
+    def test_boundary_bridge_part_map_names_all_current_parts(self) -> None:
+        parts = (
+            REPO_ROOT / "mechanics" / "boundary-bridge" / "PARTS.md"
+        ).read_text(encoding="utf-8")
+        provenance = (
+            REPO_ROOT / "mechanics" / "boundary-bridge" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        for part_name in (
+            "owner-boundary-anchors",
+            "derived-projection-anchors",
+            "proof-claim-anchors",
+        ):
+            with self.subTest(part_name=part_name):
+                self.assertIn(part_name, parts)
+                self.assertIn(part_name, provenance)
+
+    def test_boundary_bridge_stays_outside_direct_orq_lane(self) -> None:
+        receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
+            encoding="utf-8"
+        )
+        direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
+        non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+        compact_non_orq = " ".join(non_orq_section.split())
+
+        self.assertNotIn("ORQ-BRIDGE-TECHNIQUES", direct_section)
+        self.assertIn(
+            "### [boundary-bridge](boundary-bridge/README.md)",
+            non_orq_section,
+        )
+        self.assertIn("Current status: `candidate-only`", non_orq_section)
+        self.assertIn(
+            "direct `ORQ-BRIDGE-TECHNIQUES-*` request",
+            compact_non_orq,
+        )
+        for phrase in (
+            "owner acceptance",
+            "identity between bridged surfaces",
+            "Tree-of-Sophia canon",
+            "source interpretation",
+            "derived projection as source truth",
+            "routing authority",
+            "SDK authority",
+            "memory authority",
+            "runtime authority",
+            "public projection authority",
+            "proof before `aoa-evals` or the source owner lands evidence",
+            "generated companion authority",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_non_orq)
+
+    def test_owner_boundary_anchors_point_to_bundle_local_homes(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "boundary-bridge"
+            / "parts"
+            / "owner-boundary-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for technique_id in ("AOA-T-0076", "AOA-T-0090", "AOA-T-0016", "AOA-T-0094"):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, anchors)
+
+        self.assertIn("does not change technique status", anchors)
+        self.assertIn("owner acceptance", anchors)
+        self.assertIn("techniques/**/TECHNIQUE.md", anchors)
+
+    def test_derived_projection_anchors_preserve_source_authority(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "boundary-bridge"
+            / "parts"
+            / "derived-projection-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "KAG Source Lift Guide",
+            "KAG Export",
+            "AOA-T-0043",
+            "AOA-T-0021",
+            "AOA-T-0046",
+            "AOA-T-0018",
+            "derived projection as source truth",
+            "generated companions as authority",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_proof_claim_anchors_do_not_issue_proof(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "boundary-bridge"
+            / "parts"
+            / "proof-claim-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "AOA-T-0015",
+            "AOA-T-0068",
+            "AOA-T-0092",
+            "AOA-T-0093",
+            "aoa-evals",
+            "Do not issue proof verdicts",
+            "generated companions",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_boundary_bridge_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+        provenance = (
+            REPO_ROOT / "mechanics" / "boundary-bridge" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertFalse(
+            (REPO_ROOT / "mechanics" / "boundary-bridge" / "legacy").exists()
+        )
+        self.assertIn("does not create `legacy/raw/`", provenance)
+        self.assertIn("no local pre-split", provenance)
+
+    def test_boundary_bridge_stop_lines_remain_explicit(self) -> None:
+        direction = (
+            REPO_ROOT / "mechanics" / "boundary-bridge" / "DIRECTION.md"
+        ).read_text(encoding="utf-8")
+        roadmap = (
+            REPO_ROOT / "mechanics" / "boundary-bridge" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        compact_direction = " ".join(direction.split())
+        compact_roadmap = " ".join(roadmap.split())
+
+        for phrase in (
+            "owner acceptance",
+            "identity between bridged surfaces",
+            "Tree-of-Sophia canon",
+            "source interpretation",
+            "derived projection as source truth",
+            "routing authority",
+            "SDK authority",
+            "memory authority",
+            "runtime authority",
+            "public projection authority",
+            "generated companion authority",
+            "proof before `aoa-evals` or the source owner lands evidence",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_direction)
+                self.assertIn(phrase, compact_roadmap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add candidate-only Boundary Bridge mechanic package for aoa-techniques
- map owner-boundary, derived-projection, and proof-claim anchors to existing technique homes
- record Non-ORQ request receipt, decision note, and topology tests

## Validation

- python -m unittest tests.test_boundary_bridge_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- git diff --check