### PR TITLE
[codex] Add questbook candidate mechanic

### DIFF
--- a/docs/decisions/2026-05-03-questbook-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-questbook-candidate-mechanic.md
@@ -1,0 +1,81 @@
+# Questbook Candidate Mechanic
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+`Agents-of-Abyss` has a landed Questbook mechanic that owns common Questbook
+law, lifecycle vocabulary, lane-first source model, relation posture,
+owner-request packets, and cross-owner route grammar. Its owner request packet
+routes recurring quest choreography to `aoa-playbooks`, closure proof to
+`aoa-evals`, lessons and recall to `aoa-memo`, and cross-repo handoff routing
+to `aoa-routing`.
+
+`aoa-techniques` already has a local Questbook substrate: `QUESTBOOK.md`,
+`quests/*.yaml`, `schemas/quest.schema.json`,
+`schemas/quest_dispatch.schema.json`, `generated/quest_catalog.min.json`,
+`generated/quest_dispatch.min.json`, and Growth-cycle Questbook integration.
+It also has quest-adjacent technique bundles for donor harvest, owner
+placement, harvest packets, decision forks, quest-unit promotion review,
+nearest-wrong-target rejection, and quest overlays.
+
+The current AoA queue has no direct `ORQ-QUESTBOOK-TECHNIQUES-*` request, so
+this repo should not present questbook work as center request acceptance.
+
+## Decision
+
+Add a local `mechanics/questbook/` package as candidate-only practice
+pressure around already-landed local Questbook source and projection surfaces.
+
+Create active package route files:
+
+- `AGENTS.md`
+- `README.md`
+- `DIRECTION.md`
+- `PARTS.md`
+- `PROVENANCE.md`
+- `LANDING_LOG.md`
+- `ROADMAP.md`
+- `parts/AGENTS.md`
+- `parts/README.md`
+
+Create three active parts:
+
+- `parts/source-index-anchors/README.md`
+- `parts/technique-obligation-anchors/README.md`
+- `parts/harvest-promotion-anchors/README.md`
+
+Do not create `legacy/raw/` in this pass because no local pre-split Questbook
+wave receipt or raw source packet is being moved.
+
+Do not move `QUESTBOOK.md`, `quests/`, schemas, or generated quest projections
+into the mechanics package. They remain source and projection surfaces that
+the mechanics package explains.
+
+Add Questbook to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ Center
+Pressure, with `candidate-only` posture.
+
+## Consequences
+
+- Questbook pressure becomes discoverable in the mechanics map without
+  importing AoA center law as local implementation authority.
+- Existing local quest source files and generated quest projections keep their
+  current homes and remain validated through existing repo checks.
+- Existing quest-adjacent technique bundles remain canonical only through
+  their `techniques/**/TECHNIQUE.md` homes.
+- A second roadmap, private scratchpad, raw donor backlog, owner acceptance,
+  closure proof, proof verdicts, playbook choreography, memory canon, routing
+  authority, generated quest truth, RPG playable reading authority, and
+  technique promotion stay outside this package.
+
+## Verification
+
+Verify with:
+
+```bash
+python -m unittest tests.test_questbook_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -8,7 +8,7 @@ Route card for the `aoa-techniques/mechanics/` surface.
 These files describe how practice moves through the repo by participating in
 cross-project AoA mechanics: method-growth, distillation, audit, growth-cycle,
 Agon, recurrence, experience, release-support, antifragility, checkpoint, and
-boundary-bridge.
+boundary-bridge, and questbook.
 
 Mechanics are not canonical technique bundles. They shape the route into or
 around canon, while `techniques/` owns published technique content and
@@ -21,7 +21,7 @@ This surface owns:
 - owner-local movement grammar for candidate-to-technique flow inside the AoA
   mechanics vocabulary
 - bounded intake, promotion, adoption, mastery, recurrence, release-support,
-  experience, antifragility, checkpoint, and boundary-bridge routes
+  experience, antifragility, checkpoint, boundary-bridge, and questbook routes
 - public-safe stop-lines for deciding when a surface must hand off to another
   AoA repo
 - reusable precedent notes that are too procedural for general `docs/` but not

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -24,6 +24,9 @@ receipt route, not a copy of the AoA request queue and not proof of acceptance.
   ledgers, and canonical-pressure visibility.
 - [growth-cycle](growth-cycle/README.md): mastery harvest, feat reflection,
   questbook integration, and reviewed closeout incubation.
+- [questbook](questbook/README.md): repo-local durable technique obligations,
+  quest source/index/projection posture, and harvest/promotion routing around
+  canon hardening.
 - [agon](agon/README.md): Agon practice-candidate bridges, active parts,
   provenance, and preserved wave receipts.
 - [recurrence](recurrence/README.md): recurrence observation and closure

--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -163,6 +163,20 @@ or candidate lanes without a direct AoA owner-request ID targeting
   preserve technique-layer harvest, feat-reader, questbook, and
   promotion-readiness pressure without claiming center request acceptance.
 
+### [questbook](questbook/README.md)
+
+- Current status: `candidate-only`
+- Why it stays separate: the current AoA Questbook owner-request queue has no
+  direct `ORQ-QUESTBOOK-TECHNIQUES-*` request. Local Questbook surfaces
+  preserve repo-local durable technique obligations, source quest files,
+  generated quest projections, and harvest/promotion pressure without claiming
+  a second roadmap, private scratchpad, raw donor backlog, owner acceptance,
+  closure proof, proof verdicts, playbook choreography, memory canon, routing
+  authority, generated quest views as source truth, RPG playable reading
+  authority, or automatic technique promotion. Existing quest-related
+  technique bundles remain canonical only through their
+  `techniques/**/TECHNIQUE.md` homes.
+
 ### [recurrence](recurrence/README.md)
 
 - Current status: `candidate-only`

--- a/mechanics/questbook/AGENTS.md
+++ b/mechanics/questbook/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+Route card for `mechanics/questbook/`.
+
+## Purpose
+
+This package owns the `aoa-techniques` side of Questbook: local mechanics
+pressure around durable technique obligations, quest source surfaces,
+generated quest projections, and harvest/promotion routes that may later feed
+technique canon.
+
+It does not own AoA Questbook law, playbook choreography, closure proof,
+memory canon, routing behavior, RPG playable reading authority, owner
+acceptance, generated quest truth, or technique status changes.
+
+## Start here
+
+1. Root `AGENTS.md`.
+2. `mechanics/AGENTS.md`.
+3. `mechanics/questbook/README.md`.
+4. `DIRECTION.md`, `PARTS.md`, `PROVENANCE.md`, and the touched part README.
+5. `QUESTBOOK.md`, `quests/`, schemas, or generated quest projections only
+   when the task touches their route or source/projection boundary.
+
+## Local law
+
+- Keep Questbook here technique-layered: durable obligations around canon
+  hardening, donor follow-through, generated/source drift, and harvest
+  candidates.
+- Treat `QUESTBOOK.md` as the human index, `quests/*.yaml` as repo-local
+  source quest objects, and generated quest files as projections only.
+- Do not move `QUESTBOOK.md`, `quests/`, schemas, or generated projections into
+  this package as part of mechanics cleanup.
+- Do not import `Agents-of-Abyss` Questbook law as local implementation
+  authority.
+- Do not treat quests, generated quest views, route notes, owner requests, or
+  harvest pressure as proof, owner acceptance, public closure, playbook truth,
+  memory truth, routing authority, or automatic technique promotion.
+- If a stable reusable practice emerges, route it into `techniques/` through
+  the normal technique review path.
+
+## Verify
+
+Use the root validation path after changes:
+
+```bash
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/questbook/DIRECTION.md
+++ b/mechanics/questbook/DIRECTION.md
@@ -1,0 +1,56 @@
+# Questbook Direction
+
+Questbook in `aoa-techniques` keeps durable technique obligations visible
+without turning the repository into a second roadmap, donor backlog, or
+parallel source of technique truth.
+
+This file owns the local direction only. AoA center owns common Questbook law,
+lifecycle vocabulary, lane-first source model, relation posture, owner-request
+packets, and cross-owner route grammar.
+
+## Source-of-truth Split
+
+- `README.md`: package entry card and shortest route.
+- `DIRECTION.md`: current local direction.
+- `PARTS.md`: active part map.
+- `parts/`: concise local mechanics surfaces.
+- `PROVENANCE.md`: bridge from AoA Questbook, local Questbook source surfaces,
+  and existing technique bundles to active parts.
+- `LANDING_LOG.md`: dated structural accounting.
+- `ROADMAP.md`: future contour, not a historical ledger.
+- `QUESTBOOK.md`: repo-local human index for durable technique obligations.
+- `quests/*.yaml`: repo-local source quest objects.
+- `schemas/` and `generated/`: source contracts and derived projections.
+
+## Local Contour
+
+This package can name:
+
+- the local route from `QUESTBOOK.md` to `quests/*.yaml`, schemas, and
+  generated quest projections
+- technique-layer obligations around canon hardening, donor-refinery
+  follow-through, generated/source drift, review-pattern harvest,
+  promotion-readiness, and feat reflection
+- existing technique bundles that handle donor harvest, owner placement,
+  harvest packet shape, decision forks, quest-unit promotion, and
+  nearest-wrong-target rejection
+- the boundary between quest pressure, candidate mechanics, and technique canon
+
+It cannot name:
+
+- AoA Questbook law or owner acceptance
+- a second roadmap, private scratchpad, or raw donor backlog
+- generated quest views as source truth
+- closure proof, proof verdicts, playbook choreography, memory canon, routing
+  authority, or RPG playable reading authority
+- automatic technique promotion
+
+## Growth Rule
+
+Add detail only when repeated technique-layer obligation work needs a clearer
+route into source quest objects, generated projection review, harvest review,
+or future bundle promotion.
+
+If the output needs recurring choreography, proof, memory, routing behavior,
+RPG reading, runtime activation, or owner acceptance, route to the owner
+repository instead of expanding local prose.

--- a/mechanics/questbook/LANDING_LOG.md
+++ b/mechanics/questbook/LANDING_LOG.md
@@ -1,0 +1,30 @@
+# Questbook Landing Log
+
+This ledger records structural landings for `mechanics/questbook/`. It is not
+a roadmap and not a quest source or technique status source.
+
+## 2026-05-03
+
+- Added the local Questbook mechanic package as candidate-only practice
+  pressure.
+- Created active route files: `AGENTS.md`, `README.md`, `DIRECTION.md`,
+  `PARTS.md`, `PROVENANCE.md`, `LANDING_LOG.md`, and `ROADMAP.md`.
+- Created active parts:
+  - `parts/source-index-anchors/README.md`
+  - `parts/technique-obligation-anchors/README.md`
+  - `parts/harvest-promotion-anchors/README.md`
+- Updated `mechanics/README.md`, `mechanics/AGENTS.md`, and
+  `mechanics/REQUEST_RECEIPTS.md` so questbook is discoverable without
+  claiming a direct `ORQ-QUESTBOOK-TECHNIQUES-*` lane.
+- Added topology tests and a decision note for the candidate-only Questbook
+  landing.
+
+## Verification Route
+
+Use:
+
+```bash
+python -m unittest tests.test_questbook_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/questbook/PARTS.md
+++ b/mechanics/questbook/PARTS.md
@@ -1,0 +1,17 @@
+# Questbook Parts
+
+This file maps current questbook pressure to active `aoa-techniques` parts. It
+is not the AoA center Questbook part map and not a quest source inventory.
+
+| Part | Current role | Active source | Provenance |
+|---|---|---|---|
+| `source-index-anchors` | Maps the local human index, source quest files, schemas, and generated quest projections without moving source truth into mechanics. | [parts/source-index-anchors](parts/source-index-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `technique-obligation-anchors` | Maps canon hardening, donor follow-through, generated/source drift, promotion-readiness, and feat-reflection obligations. | [parts/technique-obligation-anchors](parts/technique-obligation-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `harvest-promotion-anchors` | Maps harvest and promotion-review technique anchors without treating quest pressure as canon. | [parts/harvest-promotion-anchors](parts/harvest-promotion-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+
+## Part Rule
+
+If a part starts carrying a stable reusable practice with inputs, outputs,
+risks, examples, and validation, route the practice bundle into `techniques/`.
+Leave this package as the mechanics layer that explains how Questbook pressure
+moved.

--- a/mechanics/questbook/PROVENANCE.md
+++ b/mechanics/questbook/PROVENANCE.md
@@ -1,0 +1,72 @@
+# Questbook Provenance
+
+This file preserves the active-first bridge from AoA Questbook law, local
+Questbook source surfaces, and existing quest-adjacent technique bundles to
+the current local parts.
+
+This pass does not create `legacy/raw/` because no local pre-split Questbook
+wave receipt or raw source packet is being moved. The package is a local
+mechanic built around already-landed source surfaces: `QUESTBOOK.md`,
+`quests/`, schemas, generated projections, and Growth-cycle Questbook
+integration.
+
+## Active Landing Map
+
+| Source pressure | Current active home | Preservation note |
+|---|---|---|
+| Repo-local Questbook index, source quest files, schemas, and generated projections | [parts/source-index-anchors](parts/source-index-anchors/README.md) | Source quest meaning stays in `quests/*.yaml`; generated projections remain derived. |
+| Technique-layer durable obligations | [parts/technique-obligation-anchors](parts/technique-obligation-anchors/README.md) | Canon hardening, donor follow-through, generated/source drift, promotion-readiness, and feat reflection stay anchored to existing owner surfaces. |
+| Harvest and promotion-review pressure | [parts/harvest-promotion-anchors](parts/harvest-promotion-anchors/README.md) | Existing bundles keep harvest and promotion verdicts in technique canon rather than mechanics prose. |
+
+## AoA Center Relation
+
+`Agents-of-Abyss` owns common Questbook law, lifecycle vocabulary, lane-first
+source model, relation posture, owner-request packets, and cross-owner route
+grammar. Its Questbook package names stronger owner routes for
+`aoa-playbooks`, `aoa-evals`, `aoa-memo`, and `aoa-routing`.
+
+There is no direct `ORQ-QUESTBOOK-TECHNIQUES-*` request in the current AoA
+owner-request queue. Questbook pressure here is therefore local candidate-only
+practice pressure, not direct owner-request acceptance.
+
+## Source Bridge
+
+Relevant center-side sources consulted for this landing:
+
+- `Agents-of-Abyss:mechanics/questbook/README.md`
+- `Agents-of-Abyss:mechanics/questbook/DIRECTION.md`
+- `Agents-of-Abyss:mechanics/questbook/PARTS.md`
+- `Agents-of-Abyss:mechanics/questbook/OWNER_REQUESTS.md`
+- `Agents-of-Abyss:mechanics/questbook/PROVENANCE.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/model-spine/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/source-contract/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/lifecycle-law/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/generated-views/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/relation-shape/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/execution-passport/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/harvest-route/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/owner-handoffs/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/lane-owner-routes/README.md`
+- `Agents-of-Abyss:mechanics/questbook/parts/model-spine/RPG_PLAYABLE_READING.md`
+
+Relevant local docs, source surfaces, and technique bundles:
+
+- [QUESTBOOK](../../QUESTBOOK.md)
+- [quest source store](../../quests/)
+- [quest schema](../../schemas/quest.schema.json)
+- [quest dispatch schema](../../schemas/quest_dispatch.schema.json)
+- [quest catalog](../../generated/quest_catalog.min.json)
+- [quest dispatch](../../generated/quest_dispatch.min.json)
+- [Growth-cycle Questbook Integration](../growth-cycle/parts/questbook-integration/README.md)
+- [Promotion Readiness Matrix](../audit/parts/promotion-readiness-matrix/README.md)
+- [Distillation Cross-layer Candidate Ledger](../distillation/parts/cross-layer-candidate-ledger/README.md)
+- [Donor Refinery](../distillation/parts/donor-refinery/README.md)
+- [Technique Feat Model](../growth-cycle/parts/technique-feat-model/README.md)
+- [Promotion Readiness Incubation](../growth-cycle/parts/promotion-readiness-incubation/README.md)
+- [session-donor-harvest](../../techniques/agent-workflows/session-donor-harvest/TECHNIQUE.md)
+- [owner-layer-triage](../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md)
+- [harvest-packet-contract](../../techniques/agent-workflows/harvest-packet-contract/TECHNIQUE.md)
+- [decision-fork-cards](../../techniques/agent-workflows/decision-fork-cards/TECHNIQUE.md)
+- [quest-unit-promotion-review](../../techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md)
+- [nearest-wrong-target-rejection](../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md)
+- [multi-axis-quest-overlay](../../techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md)

--- a/mechanics/questbook/README.md
+++ b/mechanics/questbook/README.md
@@ -1,0 +1,53 @@
+# Questbook
+
+This package owns the `aoa-techniques` side of Questbook: repo-local durable
+technique obligations, quest source/index/projection posture, and
+harvest/promotion pressure that is not itself a new technique bundle.
+
+Questbook here is thinner than the center mechanic in `Agents-of-Abyss`. The
+center owns common Questbook law, lifecycle vocabulary, lane-first source
+model, relation posture, owner-request packets, and cross-owner route grammar.
+This repo owns only the local technique-layer route around its existing
+`QUESTBOOK.md`, `quests/`, schemas, generated quest projections, and
+quest-shaped technique anchors.
+Those already-landed local Questbook source and projection surfaces stay in
+their current homes.
+
+## Active route
+
+- [Direction](DIRECTION.md)
+- [Parts](PARTS.md)
+- [Provenance](PROVENANCE.md)
+- [Landing Log](LANDING_LOG.md)
+- [Roadmap](ROADMAP.md)
+
+## Functioning parts
+
+- [Source Index Anchors](parts/source-index-anchors/README.md): maps
+  `QUESTBOOK.md`, `quests/*.yaml`, schemas, and generated quest projections.
+- [Technique Obligation Anchors](parts/technique-obligation-anchors/README.md):
+  maps canon hardening, donor follow-through, generated/source drift,
+  promotion-readiness, and feat-reflection obligations.
+- [Harvest Promotion Anchors](parts/harvest-promotion-anchors/README.md): maps
+  session harvest, owner placement, packet, fork, quest-promotion, and
+  nearest-wrong-target technique anchors.
+
+## Boundary
+
+Questbook can keep technique-layer obligations visible and route repeated
+pressure toward review. It does not define a second roadmap, private
+scratchpad, raw donor backlog, owner acceptance, closure proof, proof verdicts,
+playbook choreography, memory canon, routing authority, generated quest views
+as source truth, RPG playable reading authority, or automatic technique
+promotion.
+
+Stable reusable questbook practices may later become technique bundles, but
+only through the normal `techniques/**/TECHNIQUE.md` review path.
+
+## AoA relation
+
+`Agents-of-Abyss` owns the center Questbook mechanic and current owner-request
+packet. The current center queue has no direct
+`ORQ-QUESTBOOK-TECHNIQUES-*` request, so local questbook pressure is recorded
+as candidate-only practice pressure in
+[Owner Request Receipts](../REQUEST_RECEIPTS.md).

--- a/mechanics/questbook/ROADMAP.md
+++ b/mechanics/questbook/ROADMAP.md
@@ -1,0 +1,46 @@
+# Questbook Roadmap
+
+This roadmap records future contour for the `aoa-techniques` questbook
+package. It does not change quest source state, generated contracts, Questbook
+law, technique status, or validator behavior by itself.
+
+## Current State
+
+- `source-index-anchors` is the local home for the `QUESTBOOK.md`,
+  `quests/*.yaml`, schema, and generated projection boundary.
+- `technique-obligation-anchors` is the local home for canon-hardening,
+  donor-refinery follow-through, generated/source drift, promotion-readiness,
+  and feat-reflection obligation pressure.
+- `harvest-promotion-anchors` is the local home for harvest and
+  promotion-review technique anchors.
+- Questbook pressure is currently non-ORQ candidate-only pressure in this
+  repo, not a direct AoA owner-request landing.
+
+## Next Honest Moves
+
+- Keep `QUESTBOOK.md`, `quests/*.yaml`, schemas, and generated quest
+  projections in their current source/projection homes.
+- Add a new part only if repeated technique-layer quest signals no longer fit
+  source-index anchors, technique-obligation anchors, or harvest-promotion
+  anchors.
+- Promote a reusable questbook practice into `techniques/` only after it can
+  name one atomic move, likely domain, likely kind, family posture,
+  capability, substrate, execution profile, risk posture, relations, and
+  validation.
+- Leave RPG playable readings for the later RPG mechanic pass unless they are
+  only being cited as a stop-line.
+
+## Stop-lines
+
+- Do not claim Questbook law or owner acceptance from this package.
+- Do not turn Questbook into a second roadmap.
+- Do not turn Questbook into a private scratchpad.
+- Do not turn Questbook into a raw donor backlog.
+- Do not treat generated quest views as source truth.
+- Do not claim closure proof or proof verdicts from this package.
+- Do not import playbook choreography, memory canon, routing authority, RPG
+  playable reading authority, runtime activation, or owner acceptance into
+  this package.
+- Do not allow automatic technique promotion from quest-shaped pressure.
+- Do not move `QUESTBOOK.md`, `quests/`, schemas, or generated projections into
+  this package as part of mechanics cleanup.

--- a/mechanics/questbook/parts/AGENTS.md
+++ b/mechanics/questbook/parts/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Route card for `mechanics/questbook/parts/`.
+
+## Purpose
+
+Each part owns one bounded local Questbook route for `aoa-techniques`. Parts
+describe movement around technique canon; they do not become canonical
+technique bundles, quest source truth, or cross-owner authority.
+
+## Local law
+
+- Keep part docs concise and owner-bounded.
+- Preserve links to `PROVENANCE.md` when moving, staging, or compacting source
+  material.
+- Keep source quest truth in `quests/*.yaml`, generated projections in
+  `generated/`, and technique meaning in `techniques/**/TECHNIQUE.md`.
+- Keep proof, memory, routing, playbook choreography, RPG reading, runtime, and
+  owner acceptance with their owning repositories or surfaces.
+- Promote into `techniques/` only when the reusable practice can stand as an
+  atomic technique with validation.
+
+## Verify
+
+Use the package and root tests after part changes:
+
+```bash
+python -m unittest tests.test_questbook_mechanics_topology
+python scripts/validate_repo.py
+```

--- a/mechanics/questbook/parts/README.md
+++ b/mechanics/questbook/parts/README.md
@@ -1,0 +1,12 @@
+# Questbook Parts
+
+Active local parts:
+
+- [Source Index Anchors](source-index-anchors/README.md)
+- [Technique Obligation Anchors](technique-obligation-anchors/README.md)
+- [Harvest Promotion Anchors](harvest-promotion-anchors/README.md)
+
+These parts keep technique-layer Questbook pressure legible. They do not own
+AoA Questbook law, source quest truth, generated projection truth, closure
+proof, proof verdicts, playbook choreography, memory canon, routing authority,
+RPG playable reading authority, owner acceptance, or technique status changes.

--- a/mechanics/questbook/parts/harvest-promotion-anchors/README.md
+++ b/mechanics/questbook/parts/harvest-promotion-anchors/README.md
@@ -1,0 +1,37 @@
+# Harvest Promotion Anchors
+
+This part maps current harvest and promotion-review technique bundles so
+future Questbook work can route repeated obligations without turning quest
+pressure into canon.
+
+It does not change technique status. The canonical or promoted meaning remains
+inside each `techniques/**/TECHNIQUE.md` file.
+
+## Anchor Map
+
+| Technique | Questbook relevance | Boundary |
+|---|---|---|
+| [AOA-T-0075 session-donor-harvest](../../../../techniques/agent-workflows/session-donor-harvest/TECHNIQUE.md) | Extracts bounded reusable units from reviewed artifacts before a durable quest or owner placement follows. | Does not decide final owner or promotion verdict. |
+| [AOA-T-0076 owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md) | Places one candidate unit in one primary owner layer and rejects first-authoring drift into derived surfaces. | Does not perform final quest promotion review. |
+| [AOA-T-0077 harvest-packet-contract](../../../../techniques/agent-workflows/harvest-packet-contract/TECHNIQUE.md) | Keeps reviewed harvest outputs explicit so quest hooks remain pointers, not hidden verdicts. | Does not replace donor extraction, routing, progression, or quest verdicts. |
+| [AOA-T-0078 decision-fork-cards](../../../../techniques/agent-workflows/decision-fork-cards/TECHNIQUE.md) | Makes materially different next routes visible when a quest-shaped follow-up could branch. | Does not become routing authority or playbook design. |
+| [AOA-T-0089 quest-unit-promotion-review](../../../../techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md) | Reviews one repeated quest-shaped unit and emits one bounded keep-or-promote verdict. | Does not author the destination surface. |
+| [AOA-T-0090 nearest-wrong-target-rejection](../../../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md) | Keeps adjacent promotion targets distinct when quest pressure tempts a convenient owner. | Does not replace the verdict workflow. |
+| [AOA-T-0085 multi-axis-quest-overlay](../../../../techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md) | Names quest-shaped reflection as adjunct over evidence-backed progression. | Does not grant proof, routing authority, or RPG truth. |
+
+## Use
+
+Use this map when repeated quest-shaped work may need harvest, placement,
+branch cards, promotion review, or nearest-wrong-target rejection before a new
+technique bundle is drafted.
+
+If the request is really recurring scenario method, route to `aoa-playbooks`.
+If it is proof or closure, route to `aoa-evals`. If it is memory or lesson
+retention, route to `aoa-memo`.
+
+## Stop-lines
+
+- Do not treat quest pressure as technique canon.
+- Do not promote a quest because it is old or visible.
+- Do not issue proof verdicts from this package.
+- Do not let quest or RPG language replace owner-layer truth.

--- a/mechanics/questbook/parts/source-index-anchors/README.md
+++ b/mechanics/questbook/parts/source-index-anchors/README.md
@@ -1,0 +1,35 @@
+# Source Index Anchors
+
+This part maps the current local Questbook source and projection surfaces so
+future questbook work starts from existing repo truth instead of redrafting the
+Questbook model inside mechanics.
+
+It does not change quest source state or technique status.
+
+## Anchor Map
+
+| Surface | Questbook relevance | Boundary |
+|---|---|---|
+| [QUESTBOOK.md](../../../../QUESTBOOK.md) | Human index for deferred canon-hardening, donor-refinery, generated/source alignment, and harvest obligations. | Does not become a second roadmap or full quest history. |
+| [`quests/*.yaml`](../../../../quests/) | Repo-local `work_quest_v1` source quest objects such as `AOA-TECH-Q-0003` through `AOA-TECH-Q-0007`. | Source objects do not prove owner acceptance, closure, or technique promotion. |
+| [quest schema](../../../../schemas/quest.schema.json) | Contract for source quest objects. | Does not import AoA center lane law or sibling owner truth. |
+| [quest dispatch schema](../../../../schemas/quest_dispatch.schema.json) | Contract for thin dispatch projections. | Does not create routing authority. |
+| [quest catalog](../../../../generated/quest_catalog.min.json) | Generated compact catalog from source quest files. | Does not author quest meaning. |
+| [quest dispatch](../../../../generated/quest_dispatch.min.json) | Generated dispatch projection from source quest files. | Does not grant execution permission or owner acceptance. |
+
+## Use
+
+Use this map when a mechanics change needs to explain how local Questbook
+surfaces relate without moving source truth into this package.
+
+If the task changes quest source data or generated projections, use the
+existing quest validators and generated-surface checks through
+`scripts/validate_repo.py`.
+
+## Stop-lines
+
+- Do not move `QUESTBOOK.md`, `quests/`, schemas, or generated projections
+  into this package.
+- Do not treat generated quest views as source truth.
+- Do not use source quest existence as closure proof, owner acceptance,
+  routing authority, or automatic technique promotion.

--- a/mechanics/questbook/parts/technique-obligation-anchors/README.md
+++ b/mechanics/questbook/parts/technique-obligation-anchors/README.md
@@ -1,0 +1,36 @@
+# Technique Obligation Anchors
+
+This part maps the current local obligations that Questbook may hold for
+`aoa-techniques`: canon hardening, donor follow-through, generated/source
+alignment, promotion-readiness, and feat reflection.
+
+It does not change quest state or technique status. The canonical or promoted
+meaning remains inside each `techniques/**/TECHNIQUE.md` file and owner-local
+review surface.
+
+## Anchor Map
+
+| Surface | Questbook relevance | Boundary |
+|---|---|---|
+| [Growth-cycle Questbook Integration](../../../growth-cycle/parts/questbook-integration/README.md) | Explains how durable technique obligations fit this repo without becoming donor backlog. | Does not move Questbook source truth into Growth Cycle or mechanics prose. |
+| [Promotion Readiness Matrix](../../../audit/parts/promotion-readiness-matrix/README.md) | Keeps promotion gates and donor signals readable while Questbook holds surviving deferred obligations. | Does not flip technique status. |
+| [Distillation Cross-layer Candidate Ledger](../../../distillation/parts/cross-layer-candidate-ledger/README.md) | Preserves candidate pressure that may later produce durable obligations. | Does not make candidates canonical. |
+| [Donor Refinery](../../../distillation/parts/donor-refinery/README.md) | Holds donor refinement posture before quest-worthy follow-through survives. | Does not become a quest source store. |
+| [Technique Feat Model](../../../growth-cycle/parts/technique-feat-model/README.md) | Grounds `AOA-TECH-Q-0005` style feat reflection in source-first technique canon. | Does not turn feat cards into skills, playbooks, or status authority. |
+| [Promotion Readiness Incubation](../../../growth-cycle/parts/promotion-readiness-incubation/README.md) | Grounds `AOA-TECH-Q-0006` and `AOA-TECH-Q-0007` style reanchor pressure. | Does not promote one closeout into a technique bundle. |
+
+## Use
+
+Use this map when a deferred technique obligation needs an anchor before it is
+kept in Questbook, harvested, dropped, or routed to a stronger owner.
+
+If the obligation needs proof, route to `aoa-evals`. If it needs recurring
+choreography, route to `aoa-playbooks`. If it needs memory or recall, route to
+`aoa-memo`. If it needs route behavior, route to `aoa-routing`.
+
+## Stop-lines
+
+- Do not turn every donor note into a quest.
+- Do not use Questbook to bypass promotion readiness.
+- Do not treat promotion-readiness pressure, feat reflection, or generated
+  drift as technique canon.

--- a/tests/test_questbook_mechanics_topology.py
+++ b/tests/test_questbook_mechanics_topology.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_QUESTBOOK_SURFACES = (
+    "mechanics/questbook/AGENTS.md",
+    "mechanics/questbook/README.md",
+    "mechanics/questbook/DIRECTION.md",
+    "mechanics/questbook/PARTS.md",
+    "mechanics/questbook/PROVENANCE.md",
+    "mechanics/questbook/LANDING_LOG.md",
+    "mechanics/questbook/ROADMAP.md",
+    "mechanics/questbook/parts/AGENTS.md",
+    "mechanics/questbook/parts/README.md",
+)
+
+PART_LOCAL_QUESTBOOK_READMES = (
+    "mechanics/questbook/parts/source-index-anchors/README.md",
+    "mechanics/questbook/parts/technique-obligation-anchors/README.md",
+    "mechanics/questbook/parts/harvest-promotion-anchors/README.md",
+)
+
+
+class QuestbookMechanicsTopologyTestCase(unittest.TestCase):
+    def test_questbook_active_surfaces_are_discoverable(self) -> None:
+        for relative_path in ACTIVE_QUESTBOOK_SURFACES + PART_LOCAL_QUESTBOOK_READMES:
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).is_file())
+
+    def test_questbook_part_map_names_all_current_parts(self) -> None:
+        parts = (REPO_ROOT / "mechanics" / "questbook" / "PARTS.md").read_text(
+            encoding="utf-8"
+        )
+        provenance = (
+            REPO_ROOT / "mechanics" / "questbook" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        for part_name in (
+            "source-index-anchors",
+            "technique-obligation-anchors",
+            "harvest-promotion-anchors",
+        ):
+            with self.subTest(part_name=part_name):
+                self.assertIn(part_name, parts)
+                self.assertIn(part_name, provenance)
+
+    def test_questbook_is_visible_in_mechanics_map(self) -> None:
+        agents = (REPO_ROOT / "mechanics" / "AGENTS.md").read_text(
+            encoding="utf-8"
+        )
+        readme = (REPO_ROOT / "mechanics" / "README.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("questbook", agents)
+        self.assertIn("[questbook](questbook/README.md)", readme)
+        self.assertIn("canon hardening", readme)
+
+    def test_questbook_stays_outside_direct_orq_lane(self) -> None:
+        receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
+            encoding="utf-8"
+        )
+        direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
+        non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+        compact_non_orq = " ".join(non_orq_section.split())
+
+        self.assertNotIn("ORQ-QUESTBOOK-TECHNIQUES", direct_section)
+        self.assertIn("### [questbook](questbook/README.md)", non_orq_section)
+        self.assertIn("Current status: `candidate-only`", non_orq_section)
+        self.assertIn(
+            "direct `ORQ-QUESTBOOK-TECHNIQUES-*` request",
+            compact_non_orq,
+        )
+        for phrase in (
+            "second roadmap",
+            "private scratchpad",
+            "raw donor backlog",
+            "owner acceptance",
+            "closure proof",
+            "proof verdicts",
+            "playbook choreography",
+            "memory canon",
+            "routing authority",
+            "generated quest views as source truth",
+            "RPG playable reading authority",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_non_orq)
+
+    def test_source_index_anchors_preserve_source_projection_split(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "questbook"
+            / "parts"
+            / "source-index-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "QUESTBOOK.md",
+            "quests/*.yaml",
+            "work_quest_v1",
+            "quest.schema.json",
+            "quest_dispatch.schema.json",
+            "quest_catalog.min.json",
+            "quest_dispatch.min.json",
+            "generated quest views as source truth",
+            "owner acceptance",
+            "automatic technique promotion",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_technique_obligation_anchors_point_to_local_homes(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "questbook"
+            / "parts"
+            / "technique-obligation-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "Growth-cycle Questbook Integration",
+            "Promotion Readiness Matrix",
+            "Distillation Cross-layer Candidate Ledger",
+            "Donor Refinery",
+            "Technique Feat Model",
+            "Promotion Readiness Incubation",
+            "aoa-evals",
+            "aoa-playbooks",
+            "aoa-memo",
+            "aoa-routing",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_harvest_promotion_anchors_point_to_bundle_local_homes(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "questbook"
+            / "parts"
+            / "harvest-promotion-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for technique_id in (
+            "AOA-T-0075",
+            "AOA-T-0076",
+            "AOA-T-0077",
+            "AOA-T-0078",
+            "AOA-T-0089",
+            "AOA-T-0090",
+            "AOA-T-0085",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, anchors)
+
+        self.assertIn("does not change technique status", anchors)
+        self.assertIn("techniques/**/TECHNIQUE.md", anchors)
+
+    def test_questbook_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+        provenance = (
+            REPO_ROOT / "mechanics" / "questbook" / "PROVENANCE.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertFalse((REPO_ROOT / "mechanics" / "questbook" / "legacy").exists())
+        self.assertIn("does not create `legacy/raw/`", provenance)
+        self.assertIn("no local pre-split Questbook", provenance)
+
+    def test_questbook_stop_lines_remain_explicit(self) -> None:
+        direction = (
+            REPO_ROOT / "mechanics" / "questbook" / "DIRECTION.md"
+        ).read_text(encoding="utf-8")
+        roadmap = (REPO_ROOT / "mechanics" / "questbook" / "ROADMAP.md").read_text(
+            encoding="utf-8"
+        )
+        compact_direction = " ".join(direction.split())
+        compact_roadmap = " ".join(roadmap.split())
+
+        for phrase in (
+            "second roadmap",
+            "private scratchpad",
+            "raw donor backlog",
+            "generated quest views as source truth",
+            "closure proof",
+            "proof verdicts",
+            "playbook choreography",
+            "memory canon",
+            "routing authority",
+            "RPG playable reading authority",
+            "owner acceptance",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_direction)
+                self.assertIn(phrase, compact_roadmap)
+
+    def test_questbook_package_does_not_move_source_surfaces(self) -> None:
+        readme = (REPO_ROOT / "mechanics" / "questbook" / "README.md").read_text(
+            encoding="utf-8"
+        )
+        roadmap = (REPO_ROOT / "mechanics" / "questbook" / "ROADMAP.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertTrue((REPO_ROOT / "QUESTBOOK.md").is_file())
+        self.assertTrue((REPO_ROOT / "quests" / "AOA-TECH-Q-0003.yaml").is_file())
+        self.assertTrue((REPO_ROOT / "schemas" / "quest.schema.json").is_file())
+        self.assertTrue((REPO_ROOT / "generated" / "quest_catalog.min.json").is_file())
+        self.assertIn("Do not move `QUESTBOOK.md`, `quests/`", roadmap)
+        self.assertIn("already-landed local Questbook source", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add candidate-only Questbook mechanic package around existing aoa-techniques quest source/projection surfaces
- map source-index, technique-obligation, and harvest-promotion anchors
- record Non-ORQ request receipt, decision note, and topology tests

## Validation

- python -m unittest tests.test_questbook_mechanics_topology tests.test_mechanics_request_receipts tests.test_validate_repo
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- git diff --check