### PR TITLE
[codex] Add RPG mechanics and legacy scaffolds

### DIFF
--- a/docs/decisions/2026-05-01-experience-active-parts-split.md
+++ b/docs/decisions/2026-05-01-experience-active-parts-split.md
@@ -28,9 +28,9 @@ active package route files:
 - `parts/AGENTS.md`
 - `parts/README.md`
 
-Do not create `legacy/raw/` in this pass because no large wave receipt or raw
-source packet is being preserved. The previous flat files become active
-part-local homes.
+Treat the previous flat files as active part-local homes, not raw receipts.
+The `2026-05-03` legacy scaffold decision adds a provenance district with empty
+raw inventory for this package.
 
 ## Consequences
 
@@ -41,8 +41,11 @@ part-local homes.
 - Governance, office/service, handoff, and sealed decision practice stay
   portable only as practice notes; they do not become live office, release,
   runtime, proof, or ToS authority.
-- Future work can decide one part at a time whether a real technique bundle is
+- Work can decide one part at a time whether a real technique bundle is
   warranted.
+- Legacy preservation now has a package-local scaffold and must keep
+  `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+  aligned.
 
 ## Verification
 

--- a/docs/decisions/2026-05-01-growth-cycle-active-parts-split.md
+++ b/docs/decisions/2026-05-01-growth-cycle-active-parts-split.md
@@ -29,9 +29,9 @@ active package route files:
 - `parts/AGENTS.md`
 - `parts/README.md`
 
-Do not create `legacy/raw/` in this pass because no large wave receipt or raw
-source packet is being preserved. The previous flat files become active
-part-local homes.
+Treat the previous flat files as active part-local homes, not raw receipts.
+The `2026-05-03` legacy scaffold decision adds a provenance district with empty
+raw inventory for this package.
 
 Add Growth-cycle to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ Center
 Pressure, with `candidate-only` posture.
@@ -49,8 +49,11 @@ roadmaps remain visible to git instead of requiring force-adds for every split.
   backlog.
 - Promotion-readiness incubation remains an explicit holding lane until
   repeated reviewed evidence justifies a real technique bundle.
-- Future mechanics splits can add package roadmaps without silently producing
-  ignored files.
+- Mechanics splits can add package roadmaps without silently producing ignored
+  files.
+- Legacy preservation now has a package-local scaffold and must keep
+  `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+  aligned.
 
 ## Verification
 

--- a/docs/decisions/2026-05-01-method-growth-active-parts-split.md
+++ b/docs/decisions/2026-05-01-method-growth-active-parts-split.md
@@ -28,9 +28,9 @@ active package route files:
 - `parts/AGENTS.md`
 - `parts/README.md`
 
-Do not create `legacy/raw/` in this pass because no large wave receipt or raw
-source packet is being preserved. The previous flat files become active
-part-local homes.
+Treat the previous flat files as active part-local homes, not raw receipts.
+The `2026-05-03` legacy scaffold decision adds a provenance district with empty
+raw inventory for this package.
 
 ## Consequences
 
@@ -38,10 +38,11 @@ part-local homes.
   mature mechanics packages.
 - `ORQ-METHOD-TECHNIQUES-001` can point at concrete local response surfaces
   without treating those surfaces as technique canon.
-- Future work can deepen one Method-growth part at a time instead of editing a
-  flat package root.
-- Legacy preservation remains available later if real wave/source accounting is
-  found.
+- Work can deepen one Method-growth part at a time instead of editing a flat
+  package root.
+- Legacy preservation now has a package-local scaffold and must keep
+  `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+  aligned.
 
 ## Verification
 

--- a/docs/decisions/2026-05-02-recurrence-active-parts-split.md
+++ b/docs/decisions/2026-05-02-recurrence-active-parts-split.md
@@ -34,9 +34,9 @@ active package route files:
 - `parts/AGENTS.md`
 - `parts/README.md`
 
-Do not create `legacy/raw/` in this pass because no large wave receipt or raw
-source packet is being preserved. The previous flat files become active
-part-local homes.
+Treat the previous flat files as active part-local homes, not raw receipts.
+The `2026-05-03` legacy scaffold decision adds a provenance district with empty
+raw inventory for this package.
 
 Add Recurrence to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ Center
 Pressure, with `candidate-only` posture.
@@ -52,6 +52,9 @@ Pressure, with `candidate-only` posture.
 - AoA recurrence law, SDK carry, memo recall, routing dispatch, proof gates,
   runtime return, stats visibility, KAG regrounding, and playbook choreography
   stay with their owning repositories.
+- Legacy preservation now has a package-local scaffold and must keep
+  `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+  aligned.
 
 ## Verification
 

--- a/docs/decisions/2026-05-02-release-support-active-parts-split.md
+++ b/docs/decisions/2026-05-02-release-support-active-parts-split.md
@@ -34,9 +34,9 @@ active package route files:
 - `parts/AGENTS.md`
 - `parts/README.md`
 
-Do not create `legacy/raw/` in this pass because no large wave receipt or raw
-source packet is being preserved. The previous flat files become active
-part-local homes.
+Treat the previous flat files as active part-local homes, not raw receipts.
+The `2026-05-03` legacy scaffold decision adds a provenance district with empty
+raw inventory for this package.
 
 Add Release-support to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ
 Center Pressure, with `candidate-only` posture.
@@ -54,6 +54,9 @@ Center Pressure, with `candidate-only` posture.
   SDK compatibility, stats summaries, runtime deployment, rollback execution,
   sibling acceptance, and ToS write authority stay with their owning
   repositories.
+- Legacy preservation now has a package-local scaffold and must keep
+  `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+  aligned.
 
 ## Verification
 

--- a/docs/decisions/2026-05-03-boundary-bridge-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-boundary-bridge-candidate-mechanic.md
@@ -47,8 +47,9 @@ Create three active parts:
 - `parts/derived-projection-anchors/README.md`
 - `parts/proof-claim-anchors/README.md`
 
-Do not create `legacy/raw/` in this pass because no local pre-split
-boundary-bridge wave receipt or raw source packet is being moved.
+Create the `legacy/` scaffold for source-to-active accounting. Keep raw
+inventory empty because no local pre-split boundary-bridge wave receipt or raw
+source packet is being preserved.
 
 Add Boundary-bridge to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ
 Center Pressure, with `candidate-only` posture.

--- a/docs/decisions/2026-05-03-checkpoint-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-checkpoint-candidate-mechanic.md
@@ -45,8 +45,9 @@ Create two active parts:
 - `parts/phase-handoff-candidate/README.md`
 - `parts/technique-anchors/README.md`
 
-Do not create `legacy/raw/` in this pass because no local pre-split checkpoint
-wave receipt or raw source packet is being moved.
+Create the `legacy/` scaffold for source-to-active accounting. Keep raw
+inventory empty because no local pre-split checkpoint wave receipt or raw
+source packet is being preserved.
 
 Add Checkpoint to `mechanics/REQUEST_RECEIPTS.md` only under Non-ORQ Center
 Pressure, with `candidate-only` posture.

--- a/docs/decisions/2026-05-03-mechanics-legacy-scaffold-bridge.md
+++ b/docs/decisions/2026-05-03-mechanics-legacy-scaffold-bridge.md
@@ -1,0 +1,65 @@
+# Mechanics Legacy Scaffold Bridge
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+Several `mechanics/*/` packages had active route files, parts, and provenance
+bridges but no `legacy/` district because no raw source receipt had been
+preserved during the split. That made the absence of raw material look too much
+like an absence of provenance posture.
+
+The mature mechanics packages already use `legacy/` as a provenance district:
+raw receipts are preserved there, while active behavior stays in `README.md`,
+`DIRECTION.md`, `PARTS.md`, and `parts/`.
+
+## Decision
+
+Add a legacy scaffold to mechanics packages that have no preserved raw receipts:
+
+- `boundary-bridge`
+- `checkpoint`
+- `experience`
+- `growth-cycle`
+- `method-growth`
+- `questbook`
+- `recurrence`
+- `release-support`
+- `rpg`
+
+Each scaffold contains:
+
+- `legacy/AGENTS.md`
+- `legacy/README.md`
+- `legacy/INDEX.md`
+- `legacy/DISTILLATION_LOG.md`
+- `legacy/raw/README.md`
+
+Keep raw inventory empty for these packages until an actual source receipt is
+preserved. The scaffold is still active provenance infrastructure, not a
+placeholder receipt.
+
+## Consequences
+
+- Every grown mechanics package now has a visible place for source-to-active
+  accounting.
+- `PROVENANCE.md` can point to a real legacy district instead of describing
+  legacy as absent.
+- Empty raw inventory is explicit and testable.
+- Future-looking receipt work belongs in package `ROADMAP.md`; current
+  provenance docs describe the present bridge and inventory state.
+- Raw legacy files must not become the only place current active behavior
+  lives.
+
+## Verification
+
+Verify with:
+
+```bash
+python -m unittest tests.test_mechanics_legacy_scaffolds
+python scripts/validate_nested_agents.py
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/docs/decisions/2026-05-03-questbook-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-questbook-candidate-mechanic.md
@@ -47,8 +47,9 @@ Create three active parts:
 - `parts/technique-obligation-anchors/README.md`
 - `parts/harvest-promotion-anchors/README.md`
 
-Do not create `legacy/raw/` in this pass because no local pre-split Questbook
-wave receipt or raw source packet is being moved.
+Create the `legacy/` scaffold for source-to-active accounting. Keep raw
+inventory empty because no local pre-split Questbook wave receipt or raw source
+packet is being preserved.
 
 Do not move `QUESTBOOK.md`, root `quests/`, schemas, or generated quest
 projections into the mechanics package. They remain source and projection

--- a/docs/decisions/2026-05-03-rpg-candidate-mechanic.md
+++ b/docs/decisions/2026-05-03-rpg-candidate-mechanic.md
@@ -1,0 +1,60 @@
+# RPG Candidate Mechanic
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+`Agents-of-Abyss` already has a center RPG mechanic that frames RPG as world
+grammar for progression, quests, campaigns, skills, feats, public presentation,
+runtime projection, and owner handoffs. `aoa-techniques` also already has
+landed local bundles and mechanics surfaces that carry the technique-layer
+side of that pressure, especially progression evidence, multi-axis quest
+overlay, owner-layer triage, quest promotion review, nearest-wrong-target
+rejection, and the growth-cycle Technique Feat Model.
+
+The local repo needed an RPG mechanics route so future agents can find those
+anchors. At the same time, copying the center mechanic or writing broad RPG
+law into `aoa-techniques` would blur owner boundaries.
+
+## Decision
+
+Add `mechanics/rpg/` as a candidate-only local mechanics package.
+
+The package maps four local pressure areas:
+
+- source-boundary anchors
+- feat-progression anchors
+- quest-overlay anchors
+- owner-handoff anchors
+
+Create the `legacy/` scaffold for source-to-active accounting. Keep raw
+inventory empty because no local pre-split RPG receipt is preserved inside
+this repo. Do not claim a direct `ORQ-RPG-TECHNIQUES-*` request or AoA center
+acceptance.
+
+## Consequences
+
+- Future agents can route RPG-shaped technique pressure without inventing a
+  hidden ontology or local role system.
+- Existing RPG-adjacent techniques stay canonical only in their
+  `techniques/**/TECHNIQUE.md` homes.
+- Feat cards, generated projections, quest overlays, and progression deltas
+  remain reader or reflection surfaces until a source owner changes them.
+- Stronger owner routes stay explicit: `aoa-agents`, `aoa-skills`,
+  `aoa-playbooks`, `aoa-evals`, `aoa-memo`, `abyss-stack`, `aoa-stats`, and
+  source-owned `quests/`.
+- Stable reusable practice can still graduate later, but only as one bounded
+  technique bundle with normal review.
+
+## Verification
+
+Verify with:
+
+```bash
+python -m unittest tests.test_rpg_mechanics_topology tests.test_mechanics_request_receipts
+python scripts/validate_nested_agents.py
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -8,7 +8,7 @@ Route card for the `aoa-techniques/mechanics/` surface.
 These files describe how practice moves through the repo by participating in
 cross-project AoA mechanics: method-growth, distillation, audit, growth-cycle,
 Agon, recurrence, experience, release-support, antifragility, checkpoint, and
-boundary-bridge, and questbook.
+boundary-bridge, questbook, and RPG.
 
 Mechanics are not canonical technique bundles. They shape the route into or
 around canon, while `techniques/` owns published technique content and
@@ -21,7 +21,8 @@ This surface owns:
 - owner-local movement grammar for candidate-to-technique flow inside the AoA
   mechanics vocabulary
 - bounded intake, promotion, adoption, mastery, recurrence, release-support,
-  experience, antifragility, checkpoint, boundary-bridge, and questbook routes
+  experience, antifragility, checkpoint, boundary-bridge, questbook, and RPG
+  routes
 - public-safe stop-lines for deciding when a surface must hand off to another
   AoA repo
 - reusable precedent notes that are too procedural for general `docs/` but not
@@ -74,6 +75,9 @@ It does not own:
 - Generated artifacts remain evidence, not authority.
 - Legacy surfaces preserve source lineage. They are not trash archives, and they
   must not be the only place current active behavior lives.
+- Grown mechanics packages should keep a `legacy/` scaffold even when raw
+  inventory is empty. Use it as the provenance district and source-to-active
+  bridge, not as a placeholder receipt store.
 - When a package grows beyond a simple README, prefer the AoA split:
   `DIRECTION.md`, `PARTS.md`, `PROVENANCE.md`, `LANDING_LOG.md`, `parts/`, and
   `legacy/`, one mechanic at a time.
@@ -92,5 +96,6 @@ python scripts/validate_repo.py
 python -m unittest discover -s tests
 ```
 
-If Agon binding candidates, questbook references, manifests, or generated
-reader surfaces change, run their named builders or validators before closeout.
+If Agon binding candidates, questbook references, RPG references, manifests, or
+generated reader surfaces change, run their named builders or validators before
+closeout.

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -27,6 +27,9 @@ receipt route, not a copy of the AoA request queue and not proof of acceptance.
 - [questbook](questbook/README.md): repo-local durable technique obligations,
   quest source/index/projection posture, and harvest/promotion routing around
   canon hardening.
+- [rpg](rpg/README.md): feat, progression, quest-overlay, and owner-handoff
+  reflection that keeps RPG language adjunct to technique canon and owner
+  truth.
 - [agon](agon/README.md): Agon practice-candidate bridges, active parts,
   provenance, and preserved wave receipts.
 - [recurrence](recurrence/README.md): recurrence observation and closure
@@ -82,8 +85,9 @@ at a time:
 - active behavior in `README.md`, `DIRECTION.md`, `PARTS.md`, and `parts/`
 - provenance bridge in `PROVENANCE.md`
 - checked landing history in `LANDING_LOG.md`
-- preserved source receipts in `legacy/raw/`
 - source-to-active accounting in `legacy/INDEX.md` and
   `legacy/DISTILLATION_LOG.md`
+- preserved source receipts in `legacy/raw/` when raw receipts exist; otherwise
+  an explicit empty raw inventory in `legacy/raw/README.md`
 
 Use [agon](agon/README.md) as the first owner-local example of this split.

--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -177,6 +177,18 @@ or candidate lanes without a direct AoA owner-request ID targeting
   technique bundles remain canonical only through their
   `techniques/**/TECHNIQUE.md` homes.
 
+### [rpg](rpg/README.md)
+
+- Current status: `candidate-only`
+- Why it stays separate: the current AoA RPG owner-request queue has no direct
+  `ORQ-RPG-TECHNIQUES-*` request. Local RPG surfaces preserve feat,
+  progression, quest-overlay, and owner-handoff reflection without claiming
+  hidden ontology, runtime ledger state, role canon, skill truth, playbook
+  choreography, proof verdicts, quest closure, memory canon, chronicle
+  authority, routing authority, owner acceptance, universal scoring, or
+  automatic technique promotion. Existing RPG-adjacent technique bundles remain
+  canonical only through their `techniques/**/TECHNIQUE.md` homes.
+
 ### [recurrence](recurrence/README.md)
 
 - Current status: `candidate-only`

--- a/mechanics/boundary-bridge/LANDING_LOG.md
+++ b/mechanics/boundary-bridge/LANDING_LOG.md
@@ -19,6 +19,14 @@ is not a roadmap and not a technique status source.
 - Added topology tests and a decision note for the candidate-only
   boundary-bridge landing.
 
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because no local pre-split Boundary Bridge receipt
+  is preserved.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.
+
 ## Verification Route
 
 Use:

--- a/mechanics/boundary-bridge/PROVENANCE.md
+++ b/mechanics/boundary-bridge/PROVENANCE.md
@@ -4,10 +4,11 @@ This file preserves the active-first bridge from AoA boundary-bridge law,
 local source-lift docs, and existing boundary-adjacent technique bundles to the
 current local parts.
 
-This pass does not create `legacy/raw/` because no local pre-split
-boundary-bridge wave receipt or raw source packet is being moved. The package
-is a new local mechanic built from active center guidance and already-landed
-local surfaces.
+The [legacy scaffold](legacy/README.md) is present for source-to-active
+accounting. Its current raw inventory is empty because no local pre-split
+boundary-bridge wave receipt or raw source packet is being preserved. The
+package is a new local mechanic built from active center guidance and
+already-landed local surfaces.
 
 ## Active Landing Map
 

--- a/mechanics/boundary-bridge/legacy/AGENTS.md
+++ b/mechanics/boundary-bridge/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/boundary-bridge/legacy/`.
+
+## Role
+
+`legacy/` preserves Boundary Bridge source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Boundary Bridge behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_boundary_bridge_mechanics_topology
+```

--- a/mechanics/boundary-bridge/legacy/DISTILLATION_LOG.md
+++ b/mechanics/boundary-bridge/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Boundary Bridge Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from AoA center guidance and
+  landed local technique surfaces.
+
+No current Boundary Bridge rule was moved into raw legacy.

--- a/mechanics/boundary-bridge/legacy/INDEX.md
+++ b/mechanics/boundary-bridge/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Boundary Bridge Legacy Index
+
+## Current Raw Inventory
+
+No raw Boundary Bridge receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Boundary Bridge currently bridges AoA center guidance and landed local surfaces without a local raw receipt. |

--- a/mechanics/boundary-bridge/legacy/README.md
+++ b/mechanics/boundary-bridge/legacy/README.md
@@ -1,0 +1,28 @@
+# Boundary Bridge Legacy
+
+Legacy is the provenance district for Boundary Bridge source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Boundary Bridge claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/boundary-bridge/legacy/raw/README.md
+++ b/mechanics/boundary-bridge/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Boundary Bridge Raw Legacy
+
+Raw Boundary Bridge source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/checkpoint/LANDING_LOG.md
+++ b/mechanics/checkpoint/LANDING_LOG.md
@@ -18,6 +18,14 @@ a roadmap and not a technique status source.
 - Added topology tests and a decision note for the candidate-only checkpoint
   landing.
 
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because no local pre-split Checkpoint receipt is
+  preserved.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.
+
 ## Verification Route
 
 Use:

--- a/mechanics/checkpoint/PROVENANCE.md
+++ b/mechanics/checkpoint/PROVENANCE.md
@@ -4,9 +4,11 @@ This file preserves the active-first bridge from AoA checkpoint law, local
 candidate ledgers, and existing checkpoint-adjacent technique bundles to the
 current local parts.
 
-This pass does not create `legacy/raw/` because no local pre-split checkpoint
-wave receipt or raw source packet is being moved. The package is a new local
-mechanic built from active center guidance and already-landed local surfaces.
+The [legacy scaffold](legacy/README.md) is present for source-to-active
+accounting. Its current raw inventory is empty because no local pre-split
+checkpoint wave receipt or raw source packet is being preserved. The package
+is a new local mechanic built from active center guidance and already-landed
+local surfaces.
 
 ## Active Landing Map
 

--- a/mechanics/checkpoint/legacy/AGENTS.md
+++ b/mechanics/checkpoint/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/checkpoint/legacy/`.
+
+## Role
+
+`legacy/` preserves Checkpoint source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Checkpoint behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_checkpoint_mechanics_topology
+```

--- a/mechanics/checkpoint/legacy/DISTILLATION_LOG.md
+++ b/mechanics/checkpoint/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Checkpoint Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from AoA center guidance,
+  candidate ledgers, and landed local technique surfaces.
+
+No current Checkpoint rule was moved into raw legacy.

--- a/mechanics/checkpoint/legacy/INDEX.md
+++ b/mechanics/checkpoint/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Checkpoint Legacy Index
+
+## Current Raw Inventory
+
+No raw Checkpoint receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Checkpoint currently bridges AoA center guidance, candidate ledgers, and landed local surfaces without a local raw receipt. |

--- a/mechanics/checkpoint/legacy/README.md
+++ b/mechanics/checkpoint/legacy/README.md
@@ -1,0 +1,28 @@
+# Checkpoint Legacy
+
+Legacy is the provenance district for Checkpoint source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Checkpoint claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/checkpoint/legacy/raw/README.md
+++ b/mechanics/checkpoint/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Checkpoint Raw Legacy
+
+Raw Checkpoint source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/experience/LANDING_LOG.md
+++ b/mechanics/experience/LANDING_LOG.md
@@ -27,3 +27,11 @@ Not moved:
 - no raw wave receipt was copied into `legacy/raw/`
 - no Experience surface was promoted into `techniques/`
 - no live office, release, runtime, or Tree-of-Sophia authority was claimed
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because the pre-split Experience seed surfaces were
+  compact active material already distilled into part-local homes.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.

--- a/mechanics/experience/PROVENANCE.md
+++ b/mechanics/experience/PROVENANCE.md
@@ -31,12 +31,10 @@ the active route just because they existed before this split.
 
 ## Legacy Posture
 
-This split did not create `legacy/raw/` because the pre-split files were compact
-active seed surfaces rather than large wave receipts. Their content moved into
-part-local active homes.
-
-Future compaction or raw-wave preservation can add `legacy/` only when there is
-real source accounting to preserve.
+The pre-split files were compact active seed surfaces rather than large wave
+receipts. Their content moved into part-local active homes. The
+[legacy scaffold](legacy/README.md) is present for source-to-active accounting,
+and its current raw inventory is empty.
 
 ## Experience Rule
 

--- a/mechanics/experience/ROADMAP.md
+++ b/mechanics/experience/ROADMAP.md
@@ -11,5 +11,6 @@ commitment and not a source ledger.
    `aoa-agents`.
 3. Check whether handoff compression, scope boundary, and service clarity can
    stand as portable techniques without live office or release authority.
-4. Add legacy receipts only if a later pass discovers real wave/source material
-   that should be preserved outside active route surfaces.
+4. Preserve any discovered real wave/source material in `legacy/raw/` and keep
+   `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+   aligned.

--- a/mechanics/experience/legacy/AGENTS.md
+++ b/mechanics/experience/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/experience/legacy/`.
+
+## Role
+
+`legacy/` preserves Experience source receipts and source-to-active accounting.
+It is a provenance district, not the normal first route for current mechanics
+edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Experience behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_experience_mechanics_topology
+```

--- a/mechanics/experience/legacy/DISTILLATION_LOG.md
+++ b/mechanics/experience/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Experience Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from pre-split compact seed
+  surfaces to part-local homes.
+
+No current Experience rule was moved into raw legacy.

--- a/mechanics/experience/legacy/INDEX.md
+++ b/mechanics/experience/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Experience Legacy Index
+
+## Current Raw Inventory
+
+No raw Experience receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Experience pre-split compact seed surfaces were distilled into active parts rather than preserved as raw receipts. |

--- a/mechanics/experience/legacy/README.md
+++ b/mechanics/experience/legacy/README.md
@@ -1,0 +1,28 @@
+# Experience Legacy
+
+Legacy is the provenance district for Experience source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether an Experience claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/experience/legacy/raw/README.md
+++ b/mechanics/experience/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Experience Raw Legacy
+
+Raw Experience source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/growth-cycle/LANDING_LOG.md
+++ b/mechanics/growth-cycle/LANDING_LOG.md
@@ -12,3 +12,11 @@ mechanic. It is not a historical source ledger.
   `PROVENANCE.md`, `LANDING_LOG.md`, `ROADMAP.md`, and `parts/`.
 - Kept the split local to `aoa-techniques`: no technique bundle was promoted,
   no quest was closed, and no AoA Growth Cycle stage law was imported.
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because the pre-split Growth-cycle surfaces were
+  compact active material already distilled into part-local homes.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.

--- a/mechanics/growth-cycle/PROVENANCE.md
+++ b/mechanics/growth-cycle/PROVENANCE.md
@@ -4,7 +4,8 @@ This file preserves the active-first bridge from pre-split Growth-cycle flat
 files to the current part-local homes.
 
 The pre-split files were compact active mechanics surfaces, not raw wave
-receipts. This pass therefore does not create `legacy/raw/`.
+receipts. The [legacy scaffold](legacy/README.md) is present for
+source-to-active accounting, and its current raw inventory is empty.
 
 ## Active Landing Map
 

--- a/mechanics/growth-cycle/ROADMAP.md
+++ b/mechanics/growth-cycle/ROADMAP.md
@@ -10,5 +10,6 @@ commitment and not a source ledger.
 2. Check whether feat-card reader surfaces need a generated manifest or should
    remain examples until stronger evidence exists.
 3. Reconcile quest owner surfaces after generated quest catalog rebuilds.
-4. Add legacy receipts only if a later pass discovers raw wave/source material
-   that should be preserved outside active route surfaces.
+4. Preserve any discovered raw wave/source material in `legacy/raw/` and keep
+   `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+   aligned.

--- a/mechanics/growth-cycle/legacy/AGENTS.md
+++ b/mechanics/growth-cycle/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/growth-cycle/legacy/`.
+
+## Role
+
+`legacy/` preserves Growth Cycle source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Growth Cycle behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_growth_cycle_mechanics_topology
+```

--- a/mechanics/growth-cycle/legacy/DISTILLATION_LOG.md
+++ b/mechanics/growth-cycle/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Growth Cycle Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from pre-split compact active
+  surfaces to part-local homes.
+
+No current Growth Cycle rule was moved into raw legacy.

--- a/mechanics/growth-cycle/legacy/INDEX.md
+++ b/mechanics/growth-cycle/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Growth Cycle Legacy Index
+
+## Current Raw Inventory
+
+No raw Growth Cycle receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Growth Cycle pre-split compact active surfaces were distilled into active parts rather than preserved as raw receipts. |

--- a/mechanics/growth-cycle/legacy/README.md
+++ b/mechanics/growth-cycle/legacy/README.md
@@ -1,0 +1,28 @@
+# Growth Cycle Legacy
+
+Legacy is the provenance district for Growth Cycle source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Growth Cycle claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/growth-cycle/legacy/raw/README.md
+++ b/mechanics/growth-cycle/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Growth Cycle Raw Legacy
+
+Raw Growth Cycle source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/method-growth/LANDING_LOG.md
+++ b/mechanics/method-growth/LANDING_LOG.md
@@ -27,3 +27,11 @@ Not moved:
 - no raw wave receipt was copied into `legacy/raw/`
 - no adoption surface was promoted into `techniques/`
 - no technique-to-skill handoff was treated as skill acceptance
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because the pre-split adoption surfaces were compact
+  active material already distilled into part-local homes.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.

--- a/mechanics/method-growth/PROVENANCE.md
+++ b/mechanics/method-growth/PROVENANCE.md
@@ -29,12 +29,10 @@ the active route just because they existed before this split.
 
 ## Legacy Posture
 
-This split did not create `legacy/raw/` because the pre-split files were current
-compact active surfaces rather than large wave receipts. Their content moved
-into part-local active homes.
-
-Future compaction or raw-wave preservation can add `legacy/` only when there is
-real source accounting to preserve.
+The pre-split files were current compact active surfaces rather than large wave
+receipts. Their content moved into part-local active homes. The
+[legacy scaffold](legacy/README.md) is present for source-to-active accounting,
+and its current raw inventory is empty.
 
 ## Method-Growth Rule
 

--- a/mechanics/method-growth/ROADMAP.md
+++ b/mechanics/method-growth/ROADMAP.md
@@ -10,5 +10,6 @@ commitment and not a source ledger.
    handoff part.
 3. Decide whether retention and obsolescence should become candidate technique
    bundles or remain mechanics-only adoption governance.
-4. Add legacy receipts only if a later pass discovers real wave/source material
-   that should be preserved outside active route surfaces.
+4. Preserve any discovered real wave/source material in `legacy/raw/` and keep
+   `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
+   aligned.

--- a/mechanics/method-growth/legacy/AGENTS.md
+++ b/mechanics/method-growth/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/method-growth/legacy/`.
+
+## Role
+
+`legacy/` preserves Method-growth source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Method-growth behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_method_growth_mechanics_topology
+```

--- a/mechanics/method-growth/legacy/DISTILLATION_LOG.md
+++ b/mechanics/method-growth/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Method-Growth Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from pre-split compact adoption
+  surfaces to part-local homes.
+
+No current Method-growth rule was moved into raw legacy.

--- a/mechanics/method-growth/legacy/INDEX.md
+++ b/mechanics/method-growth/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Method-Growth Legacy Index
+
+## Current Raw Inventory
+
+No raw Method-growth receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Method-growth pre-split compact adoption surfaces were distilled into active parts rather than preserved as raw receipts. |

--- a/mechanics/method-growth/legacy/README.md
+++ b/mechanics/method-growth/legacy/README.md
@@ -1,0 +1,28 @@
+# Method-Growth Legacy
+
+Legacy is the provenance district for Method-growth source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Method-growth claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/method-growth/legacy/raw/README.md
+++ b/mechanics/method-growth/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Method-Growth Raw Legacy
+
+Raw Method-growth source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/questbook/LANDING_LOG.md
+++ b/mechanics/questbook/LANDING_LOG.md
@@ -19,6 +19,14 @@ a roadmap and not a quest source or technique status source.
 - Added topology tests and a decision note for the candidate-only Questbook
   landing.
 
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because no local pre-split Questbook receipt is
+  preserved.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.
+
 ## Verification Route
 
 Use:

--- a/mechanics/questbook/PROVENANCE.md
+++ b/mechanics/questbook/PROVENANCE.md
@@ -4,9 +4,10 @@ This file preserves the active-first bridge from AoA Questbook law, local
 Questbook source surfaces, and existing quest-adjacent technique bundles to
 the current local parts.
 
-This pass does not create `legacy/raw/` because no local pre-split Questbook
-wave receipt or raw source packet is being moved. The package is a local
-mechanic built around already-landed source surfaces: `QUESTBOOK.md`,
+The [legacy scaffold](legacy/README.md) is present for source-to-active
+accounting. Its current raw inventory is empty because no local pre-split
+Questbook wave receipt or raw source packet is being preserved. The package is
+a local mechanic built around already-landed source surfaces: `QUESTBOOK.md`,
 `quests/`, schemas, generated projections, and Growth-cycle Questbook
 integration.
 

--- a/mechanics/questbook/legacy/AGENTS.md
+++ b/mechanics/questbook/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/questbook/legacy/`.
+
+## Role
+
+`legacy/` preserves Questbook source receipts and source-to-active accounting.
+It is a provenance district, not the normal first route for current mechanics
+edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Questbook behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_questbook_mechanics_topology
+```

--- a/mechanics/questbook/legacy/DISTILLATION_LOG.md
+++ b/mechanics/questbook/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Questbook Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from AoA center guidance and
+  already-landed local quest source surfaces.
+
+No current Questbook rule was moved into raw legacy.

--- a/mechanics/questbook/legacy/INDEX.md
+++ b/mechanics/questbook/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Questbook Legacy Index
+
+## Current Raw Inventory
+
+No raw Questbook receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Questbook currently bridges AoA center guidance and already-landed local quest source surfaces without a local raw receipt. |

--- a/mechanics/questbook/legacy/README.md
+++ b/mechanics/questbook/legacy/README.md
@@ -1,0 +1,28 @@
+# Questbook Legacy
+
+Legacy is the provenance district for Questbook source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Questbook claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/questbook/legacy/raw/README.md
+++ b/mechanics/questbook/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Questbook Raw Legacy
+
+Raw Questbook source receipts are preserved here only when they are real source
+packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/recurrence/LANDING_LOG.md
+++ b/mechanics/recurrence/LANDING_LOG.md
@@ -17,3 +17,11 @@ technique review.
   `ORQ-RECURRENCE-TECHNIQUES-*` request exists in the current AoA queue.
 - Added topology coverage for the active recurrence split and updated manifest
   topology coverage to the new part-local producer path.
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because the pre-split recurrence surfaces were
+  compact active material already distilled into part-local homes.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.

--- a/mechanics/recurrence/PROVENANCE.md
+++ b/mechanics/recurrence/PROVENANCE.md
@@ -4,7 +4,8 @@ This file preserves the active-first bridge from pre-split recurrence flat
 files to the current part-local homes.
 
 The pre-split files were compact active mechanics surfaces, not raw wave
-receipts. This pass therefore does not create `legacy/raw/`.
+receipts. The [legacy scaffold](legacy/README.md) is present for
+source-to-active accounting, and its current raw inventory is empty.
 
 ## Active Landing Map
 

--- a/mechanics/recurrence/legacy/AGENTS.md
+++ b/mechanics/recurrence/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/recurrence/legacy/`.
+
+## Role
+
+`legacy/` preserves Recurrence source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Recurrence behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_recurrence_mechanics_topology
+```

--- a/mechanics/recurrence/legacy/DISTILLATION_LOG.md
+++ b/mechanics/recurrence/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Recurrence Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from pre-split compact active
+  surfaces to part-local homes.
+
+No current Recurrence rule was moved into raw legacy.

--- a/mechanics/recurrence/legacy/INDEX.md
+++ b/mechanics/recurrence/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Recurrence Legacy Index
+
+## Current Raw Inventory
+
+No raw Recurrence receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Recurrence pre-split compact active surfaces were distilled into active parts rather than preserved as raw receipts. |

--- a/mechanics/recurrence/legacy/README.md
+++ b/mechanics/recurrence/legacy/README.md
@@ -1,0 +1,28 @@
+# Recurrence Legacy
+
+Legacy is the provenance district for Recurrence source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Recurrence claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/recurrence/legacy/raw/README.md
+++ b/mechanics/recurrence/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Recurrence Raw Legacy
+
+Raw Recurrence source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/release-support/LANDING_LOG.md
+++ b/mechanics/release-support/LANDING_LOG.md
@@ -16,3 +16,11 @@ substitute for technique review, public-claim proof, or owner acceptance.
   `mechanics/REQUEST_RECEIPTS.md`; no direct
   `ORQ-RELEASE-TECHNIQUES-*` request exists in the current AoA queue.
 - Added topology coverage for the active release-support split.
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because the pre-split release-support surfaces were
+  compact active material already distilled into part-local homes.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.

--- a/mechanics/release-support/PROVENANCE.md
+++ b/mechanics/release-support/PROVENANCE.md
@@ -4,7 +4,8 @@ This file preserves the active-first bridge from pre-split release-support flat
 files to the current part-local homes.
 
 The pre-split files were compact active mechanics surfaces, not raw wave
-receipts. This pass therefore does not create `legacy/raw/`.
+receipts. The [legacy scaffold](legacy/README.md) is present for
+source-to-active accounting, and its current raw inventory is empty.
 
 ## Active Landing Map
 

--- a/mechanics/release-support/legacy/AGENTS.md
+++ b/mechanics/release-support/legacy/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `mechanics/release-support/legacy/`.
+
+## Role
+
+`legacy/` preserves Release Support source receipts and source-to-active
+accounting. It is a provenance district, not the normal first route for current
+mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current Release Support behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_release_support_mechanics_topology
+```

--- a/mechanics/release-support/legacy/DISTILLATION_LOG.md
+++ b/mechanics/release-support/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# Release Support Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from pre-split compact active
+  surfaces to part-local homes.
+
+No current Release Support rule was moved into raw legacy.

--- a/mechanics/release-support/legacy/INDEX.md
+++ b/mechanics/release-support/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# Release Support Legacy Index
+
+## Current Raw Inventory
+
+No raw Release Support receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | Release Support pre-split compact active surfaces were distilled into active parts rather than preserved as raw receipts. |

--- a/mechanics/release-support/legacy/README.md
+++ b/mechanics/release-support/legacy/README.md
@@ -1,0 +1,28 @@
+# Release Support Legacy
+
+Legacy is the provenance district for Release Support source receipts and
+source-to-active accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether a Release Support claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/release-support/legacy/raw/README.md
+++ b/mechanics/release-support/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# Release Support Raw Legacy
+
+Raw Release Support source receipts are preserved here only when they are real
+source packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/rpg/AGENTS.md
+++ b/mechanics/rpg/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+Route card for the `aoa-techniques/mechanics/rpg/` package.
+
+## Purpose
+
+`mechanics/rpg/` owns the `aoa-techniques` side of RPG-shaped practice
+pressure: feat reflection, progression language, quest overlays, and owner
+handoffs that may help agents read technique work without mutating technique
+canon.
+
+This package is candidate-only. It is not the AoA center RPG mechanic, not a
+runtime ledger, not a role system, and not a proof or quest authority.
+
+## Owner Lane
+
+This package owns:
+
+- local anchors from RPG-shaped pressure to existing technique bundles and
+  mechanics surfaces
+- source-boundary notes that keep RPG vocabulary below owner truth
+- feat, progression, and quest-overlay mapping that may later distill into
+  smaller technique bundles
+- handoff notes to stronger AoA owners when the pressure stops being a
+  technique-layer concern
+
+It does not own:
+
+- AoA center RPG law, which belongs in `Agents-of-Abyss`
+- role canon or actor identity, which belongs in `aoa-agents`
+- skill execution truth, which belongs in `aoa-skills`
+- scenario or campaign choreography, which belongs in `aoa-playbooks`
+- proof verdicts, which belong in `aoa-evals`
+- memory or chronicle canon, which belongs in `aoa-memo`
+- runtime state, unlock ledgers, or session behavior, which belongs in
+  `abyss-stack`
+- technique bundle meaning, which belongs in `techniques/**/TECHNIQUE.md`
+
+## Start Here
+
+1. Read the repository root `AGENTS.md`, then `mechanics/AGENTS.md`.
+2. Read `README.md`, `DIRECTION.md`, `PARTS.md`, and `PROVENANCE.md`.
+3. Read the part README for the touched path.
+4. When changing status, read `LANDING_LOG.md` and `ROADMAP.md`.
+5. When promoting a reusable practice, route it through
+   `techniques/**/TECHNIQUE.md` and the normal canonical review path.
+
+## Local Law
+
+- RPG language here is a reader and reflection aid. It must not become hidden
+  ontology, rank, permission, routing authority, proof authority, or runtime
+  state.
+- The local package can map existing techniques and mechanics pressure. It
+  must not copy the AoA center RPG mechanic or rewrite sibling owner law.
+- A feat, unlock, quest hook, campaign hint, or chronicle cue stays adjunct
+  unless a stronger owner accepts it in its own surface.
+- Generated reader surfaces remain evidence or projection, not source truth.
+- Stable local practice must become a bounded technique bundle before it can
+  claim reusable canon.
+
+## Verify
+
+After changing this package, run:
+
+```bash
+python -m unittest tests.test_rpg_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```
+
+If nested AGENTS coverage changes, also run:
+
+```bash
+python scripts/validate_nested_agents.py
+```

--- a/mechanics/rpg/DIRECTION.md
+++ b/mechanics/rpg/DIRECTION.md
@@ -1,0 +1,58 @@
+# RPG Direction
+
+## Source-Of-Truth Split
+
+- `README.md` is the entrypoint and boundary statement for the local RPG
+  package.
+- `PARTS.md` is the active part map.
+- `parts/*/README.md` files own the current local anchor maps.
+- `PROVENANCE.md` explains the active bridge, the legacy scaffold, and which
+  landed surfaces this package connects.
+- `LANDING_LOG.md` records checked landing history.
+- `ROADMAP.md` names the next honest work without turning it into current
+  authority.
+
+## Local Contour
+
+This package can name:
+
+- existing technique bundles that already carry progression, quest overlay,
+  owner placement, and rejection practice
+- generated or mechanics reader surfaces that make feat-shaped technique
+  reading possible
+- owner handoff routes when RPG-shaped pressure stops being a technique-layer
+  matter
+- candidate gaps that may later become small `TECHNIQUE.md` bundles
+
+This package cannot name as local authority:
+
+- AoA center RPG law or center owner acceptance
+- hidden ontology behind technique work
+- runtime ledger state or unlock state
+- role canon, party identity, agent identity, or actor law
+- skill execution truth
+- playbook choreography or campaign ownership
+- proof verdicts or public quality proof
+- quest closure or source quest authority
+- memory canon, chronicle authority, or writeback authority
+- routing authority, dispatch authority, or owner acceptance
+- a universal power score
+- automatic technique promotion
+
+## Growth Rule
+
+RPG-shaped pressure should stay in mechanics while it is still a map, reminder,
+or candidate lane. It should move into `techniques/` only when one atomic
+practice can name stable inputs, outputs, contracts, risks, examples, and
+validation.
+
+## Review Posture
+
+A reviewer should be able to answer three questions before accepting a change
+here:
+
+1. What existing local technique or mechanics surface is being clarified?
+2. Which stronger owner keeps the authority that RPG language might otherwise
+   overreach?
+3. What would make this pressure ready for a real technique bundle, and what
+   still keeps it candidate-only?

--- a/mechanics/rpg/LANDING_LOG.md
+++ b/mechanics/rpg/LANDING_LOG.md
@@ -1,0 +1,44 @@
+# RPG Landing Log
+
+## 2026-05-03 - Candidate Mechanics Surface
+
+Landed a local RPG mechanics package as candidate-only technique-layer
+pressure.
+
+Included:
+
+- package route surfaces: `README.md`, `DIRECTION.md`, `PARTS.md`,
+  `PROVENANCE.md`, `LANDING_LOG.md`, and `ROADMAP.md`
+- active part maps for source-boundary, feat-progression, quest-overlay, and
+  owner-handoff anchors
+- legacy scaffold files for source-to-active accounting with an empty raw
+  inventory
+- root mechanics map and request-receipt visibility
+- topology tests for package presence, stop-lines, and owner handoffs
+
+Explicitly not included:
+
+- local raw receipts, because no local pre-split RPG receipt was found
+- direct `ORQ-RPG-TECHNIQUES-*` acceptance or landing
+- runtime ledger state, role canon, skill truth, playbook choreography, proof
+  verdict, quest closure, memory canon, routing authority, universal scoring,
+  owner acceptance, or automatic technique promotion
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Added `legacy/` scaffold files for source-to-active accounting.
+- Kept raw inventory empty because no local pre-split RPG receipt is preserved.
+- Updated provenance to point to the scaffold instead of treating legacy as an
+  absent later add-on.
+
+## Verification Route
+
+Use:
+
+```bash
+python -m unittest tests.test_rpg_mechanics_topology tests.test_mechanics_request_receipts
+python scripts/validate_nested_agents.py
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+git diff --check
+```

--- a/mechanics/rpg/PARTS.md
+++ b/mechanics/rpg/PARTS.md
@@ -1,0 +1,19 @@
+# RPG Parts
+
+This file maps current RPG-shaped pressure to active `aoa-techniques` parts.
+It is not the AoA center RPG part map and not a replacement for technique
+canon.
+
+| Part | Current role | Active source | Provenance |
+|---|---|---|---|
+| `source-boundary-anchors` | Maps owner truth, context boundaries, owner placement, and nearest-wrong-target guardrails so RPG vocabulary stays adjunct. | [parts/source-boundary-anchors](parts/source-boundary-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `feat-progression-anchors` | Maps progression-evidence lift, technique feat reader surfaces, and growth-cycle mastery pressure without one-score or promotion authority. | [parts/feat-progression-anchors](parts/feat-progression-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `quest-overlay-anchors` | Maps quest-, RPG-, and chronicle-shaped reflection over reviewed evidence without taking quest, campaign, proof, memory, or routing authority. | [parts/quest-overlay-anchors](parts/quest-overlay-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `owner-handoff-anchors` | Maps when RPG-shaped pressure must hand off to stronger owner repos rather than widening local mechanics. | [parts/owner-handoff-anchors](parts/owner-handoff-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
+
+## Part Rule
+
+If a part starts carrying a stable reusable practice with inputs, outputs,
+risks, examples, and validation, route that practice into `techniques/`. Leave
+this package as the mechanics layer that explains how RPG-shaped pressure
+moved.

--- a/mechanics/rpg/PROVENANCE.md
+++ b/mechanics/rpg/PROVENANCE.md
@@ -1,0 +1,75 @@
+# RPG Provenance
+
+## Status
+
+This package is a local candidate-only mechanics surface. The
+[legacy scaffold](legacy/README.md) is present for source-to-active accounting,
+and its current raw inventory is empty because no local pre-split RPG wave,
+seed, or raw receipt is preserved inside `aoa-techniques`.
+
+The active package was assembled from two kinds of source:
+
+- the AoA center RPG mechanic, which owns the cross-project RPG grammar
+- already-landed `aoa-techniques` bundles and mechanics surfaces that carry
+  the local technique-layer side of progression, feat, quest-overlay, owner
+  placement, and promotion pressure
+
+## AoA Center Bridge
+
+The center bridge was read from `Agents-of-Abyss:mechanics/rpg/`:
+
+- `README.md`
+- `DIRECTION.md`
+- `PARTS.md`
+- `PROVENANCE.md`
+- center part surfaces for source boundary, vocabulary overlay, quest/campaign,
+  progression/unlocks, runtime projection, and owner handoffs
+
+Those surfaces are constitutional and ecosystem-facing. This package does not
+copy them. It keeps only the local technique-layer route that can be reviewed
+inside `aoa-techniques`.
+
+## Local Source Bridge
+
+Current local anchors include:
+
+- `techniques/agent-workflows/progression-evidence-lift/TECHNIQUE.md`
+  (`AOA-T-0084`)
+- `techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md`
+  (`AOA-T-0085`)
+- `techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md`
+  (`AOA-T-0076`)
+- `techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md`
+  (`AOA-T-0089`)
+- `techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md`
+  (`AOA-T-0090`)
+- `techniques/docs/bounded-context-map/TECHNIQUE.md` (`AOA-T-0016`)
+- `mechanics/growth-cycle/parts/technique-feat-model/README.md`
+- `mechanics/growth-cycle/parts/mastery-harvest/README.md`
+- `mechanics/growth-cycle/parts/promotion-readiness-incubation/README.md`
+- `mechanics/questbook/README.md`
+- `quests/` and generated quest projection surfaces, as source/projection
+  context only
+- `generated/technique_feat_cards.min.example.json`, as reader evidence only
+
+## Active Part Bridge
+
+The current local parts are:
+
+- `source-boundary-anchors`
+- `feat-progression-anchors`
+- `quest-overlay-anchors`
+- `owner-handoff-anchors`
+
+## Non-Authority Notes
+
+The local bridge does not establish:
+
+- a direct `ORQ-RPG-TECHNIQUES-*` landing
+- AoA center RPG acceptance
+- runtime state, role canon, skill truth, playbook choreography, proof
+  verdict, quest closure, memory canon, routing authority, owner acceptance,
+  universal scoring, or automatic technique promotion
+
+Any future local RPG technique must cite its own source evidence and pass the
+normal `techniques/**/TECHNIQUE.md` review path.

--- a/mechanics/rpg/README.md
+++ b/mechanics/rpg/README.md
@@ -1,0 +1,54 @@
+# RPG
+
+This package owns the `aoa-techniques` side of RPG-shaped practice pressure:
+feat reflection, progression language, quest overlays, and owner handoffs that
+make technique work easier to read without changing what technique canon is.
+
+RPG here is thinner than the center mechanic in `Agents-of-Abyss`. The center
+owns RPG as ecosystem world grammar: source boundary, vocabulary overlay,
+quest/campaign posture, progression/unlocks, runtime projection, and owner
+requests. This repo owns only local technique-layer anchors around existing
+technique bundles, generated reader surfaces, and mechanics routes.
+
+## Active Route
+
+- [Direction](DIRECTION.md)
+- [Parts](PARTS.md)
+- [Provenance](PROVENANCE.md)
+- [Landing Log](LANDING_LOG.md)
+- [Roadmap](ROADMAP.md)
+
+## Functioning Parts
+
+- [Source Boundary Anchors](parts/source-boundary-anchors/README.md): maps
+  owner truth, bounded-context, owner-placement, and nearest-wrong-target
+  guardrails so RPG vocabulary stays below source authority.
+- [Feat Progression Anchors](parts/feat-progression-anchors/README.md): maps
+  progression-evidence lift, technique feat cards, and growth-cycle mastery
+  surfaces without creating a universal score or automatic promotion.
+- [Quest Overlay Anchors](parts/quest-overlay-anchors/README.md): maps
+  quest-, RPG-, and chronicle-shaped reflection over reviewed evidence without
+  owning quest closure, campaign choreography, memory canon, or routing
+  authority.
+- [Owner Handoff Anchors](parts/owner-handoff-anchors/README.md): maps when
+  RPG-shaped pressure must leave `aoa-techniques` for `aoa-agents`,
+  `aoa-skills`, `aoa-playbooks`, `aoa-evals`, `aoa-memo`, `abyss-stack`,
+  `aoa-stats`, or source-owned `quests/`.
+
+## Boundary
+
+RPG can help technique work become legible as feats, progression deltas, quest
+hooks, or owner-handoff cues. It does not define hidden ontology, runtime
+ledger state, role canon, skill truth, playbook choreography, proof verdicts,
+quest closure, memory canon, chronicle authority, routing authority, owner
+acceptance, universal power score, or automatic technique promotion.
+
+Stable reusable RPG-shaped practices may later become technique bundles, but
+only through the normal `techniques/**/TECHNIQUE.md` review path.
+
+## AoA Relation
+
+`Agents-of-Abyss` owns the center RPG mechanic and its downstream owner
+posture. The current center queue has no direct
+`ORQ-RPG-TECHNIQUES-*` request, so local RPG pressure is recorded as
+candidate-only practice pressure in [Owner Request Receipts](../REQUEST_RECEIPTS.md).

--- a/mechanics/rpg/ROADMAP.md
+++ b/mechanics/rpg/ROADMAP.md
@@ -1,0 +1,42 @@
+# RPG Roadmap
+
+## Current State
+
+RPG is present as a candidate-only mechanics package for `aoa-techniques`.
+It maps existing technique-layer anchors and keeps stronger owner authority
+outside this repo.
+
+## Next Honest Moves
+
+1. Watch for repeated local use of feat, unlock, quest-overlay, or owner-handoff
+   language that is precise enough to become one atomic technique.
+2. If repeated practice appears, split one candidate at a time and route it
+   through the normal `techniques/**/TECHNIQUE.md` review path.
+3. Keep the package aligned with AoA center RPG when center owner requests
+   change, without copying center doctrine into local mechanics.
+4. Add examples only when they come from reviewed local evidence and do not
+   become hidden runtime state, role canon, proof verdict, quest closure,
+   memory canon, routing authority, or universal scoring.
+
+## Stop-Lines
+
+Do not use this package to create:
+
+- hidden ontology
+- runtime ledger state or unlock state
+- role canon, party identity, or actor law
+- skill execution truth
+- playbook choreography or campaign ownership
+- proof verdicts or public proof
+- quest closure or source quest authority
+- memory canon or chronicle authority
+- routing authority or dispatch authority
+- owner acceptance
+- a universal power score
+- automatic technique promotion
+
+## Graduation Signal
+
+A local RPG practice can leave mechanics only when it is small enough to stand
+as one technique bundle with stable inputs, outputs, contracts, risks, examples,
+and validation.

--- a/mechanics/rpg/legacy/AGENTS.md
+++ b/mechanics/rpg/legacy/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+Route card for `mechanics/rpg/legacy/`.
+
+## Role
+
+`legacy/` preserves RPG source receipts and source-to-active accounting. It is
+a provenance district, not the normal first route for current mechanics edits.
+
+## Editing Posture
+
+- Start in `../README.md`, `../DIRECTION.md`, `../PARTS.md`, and `../parts/`
+  for current behavior.
+- Use `../PROVENANCE.md` as the active bridge into this district.
+- Keep `INDEX.md`, `DISTILLATION_LOG.md`, and `raw/README.md` aligned.
+- Do not place current RPG behavior only in raw legacy files.
+- Do not invent raw receipts; preserve only actual source packets.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_rpg_mechanics_topology
+```

--- a/mechanics/rpg/legacy/DISTILLATION_LOG.md
+++ b/mechanics/rpg/legacy/DISTILLATION_LOG.md
@@ -1,0 +1,12 @@
+# RPG Legacy Distillation Log
+
+## 2026-05-03 - Legacy Scaffold Bridge
+
+- Created a legacy scaffold for source-to-active accounting.
+- Raw inventory remains empty.
+- Active behavior remains in `../README.md`, `../DIRECTION.md`,
+  `../PARTS.md`, and `../parts/`.
+- `../PROVENANCE.md` remains the active bridge from AoA center guidance and
+  landed local technique surfaces.
+
+No current RPG rule was moved into raw legacy.

--- a/mechanics/rpg/legacy/INDEX.md
+++ b/mechanics/rpg/legacy/INDEX.md
@@ -1,0 +1,17 @@
+# RPG Legacy Index
+
+## Current Raw Inventory
+
+No raw RPG receipts are preserved in this package.
+
+## Active Bridge
+
+- Active provenance bridge: [../PROVENANCE.md](../PROVENANCE.md)
+- Active part map: [../PARTS.md](../PARTS.md)
+- Active parts: [../parts/](../parts/)
+
+## Source Index
+
+| Source receipt | Status | Active route | Note |
+|---|---|---|---|
+| none | scaffold | [../PROVENANCE.md](../PROVENANCE.md) | RPG currently bridges AoA center guidance and landed local technique surfaces without a local raw receipt. |

--- a/mechanics/rpg/legacy/README.md
+++ b/mechanics/rpg/legacy/README.md
@@ -1,0 +1,28 @@
+# RPG Legacy
+
+Legacy is the provenance district for RPG source receipts and source-to-active
+accounting.
+
+This scaffold is present even while the raw inventory is empty, so preserved
+source has a canonical landing route instead of being mixed into active docs.
+
+## Layout
+
+- `raw/`: preserved source packets. Current raw inventory: none preserved.
+- `INDEX.md`: maps preserved source receipts to active routes.
+- `DISTILLATION_LOG.md`: records source-to-active accounting decisions.
+
+The active package reaches this district through
+[`../PROVENANCE.md`](../PROVENANCE.md).
+
+## Use This When
+
+- checking whether an RPG claim has preserved source material
+- adding a real source receipt after active provenance names its route
+- auditing why raw inventory is empty for this package
+
+## Stop-Lines
+
+- Do not use raw legacy files as the normal first route for current edits.
+- Do not make a raw file the only place current active behavior lives.
+- Do not create placeholder source receipts.

--- a/mechanics/rpg/legacy/raw/README.md
+++ b/mechanics/rpg/legacy/raw/README.md
@@ -1,0 +1,16 @@
+# RPG Raw Legacy
+
+Raw RPG source receipts are preserved here only when they are real source
+packets that should remain reviewable after distillation.
+
+Current raw inventory: none preserved.
+
+## Intake Rule
+
+When a receipt is preserved here, update:
+
+- `../INDEX.md`
+- `../DISTILLATION_LOG.md`
+- `../../PROVENANCE.md`
+
+Do not add placeholder receipts.

--- a/mechanics/rpg/parts/AGENTS.md
+++ b/mechanics/rpg/parts/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Route card for `aoa-techniques/mechanics/rpg/parts/`.
+
+## Purpose
+
+`parts/` holds the active RPG anchor maps for this repo. Each part names one
+local pressure area and the stronger owner boundaries around it.
+
+## Local Law
+
+- Parts map candidate pressure. They do not create technique canon.
+- Part READMEs may cite existing technique bundles and mechanics surfaces, but
+  they must not move source truth out of those homes.
+- If a part becomes an executable, repeatable practice, promote one atomic
+  move into `techniques/` instead of expanding the part indefinitely.
+- RPG language remains adjunct to owner truth, proof, memory, routing, runtime,
+  role, skill, playbook, and quest authority.
+
+## Verify
+
+Run:
+
+```bash
+python -m unittest tests.test_rpg_mechanics_topology
+```

--- a/mechanics/rpg/parts/README.md
+++ b/mechanics/rpg/parts/README.md
@@ -1,0 +1,17 @@
+# RPG Parts
+
+These parts map current RPG-shaped technique pressure. They are active anchor
+maps, not a copy of the AoA center RPG part system.
+
+## Active Parts
+
+- [Source Boundary Anchors](source-boundary-anchors/README.md)
+- [Feat Progression Anchors](feat-progression-anchors/README.md)
+- [Quest Overlay Anchors](quest-overlay-anchors/README.md)
+- [Owner Handoff Anchors](owner-handoff-anchors/README.md)
+
+## Rule
+
+Keep each part small enough to show one local pressure area, its existing
+anchors, and its owner stop-lines. Move stable reusable practice into
+`techniques/` rather than making mechanics carry canon.

--- a/mechanics/rpg/parts/feat-progression-anchors/README.md
+++ b/mechanics/rpg/parts/feat-progression-anchors/README.md
@@ -1,0 +1,44 @@
+# Feat Progression Anchors
+
+## Purpose
+
+This part maps the local feat and progression side of RPG-shaped technique
+pressure. It keeps mastery reflection readable without turning it into rank,
+permission, status law, or technique promotion.
+
+## Local Anchors
+
+- `AOA-T-0084`
+  (`techniques/agent-workflows/progression-evidence-lift/TECHNIQUE.md`) owns
+  bounded multi-axis progression deltas from reviewed evidence.
+- `mechanics/growth-cycle/parts/technique-feat-model/README.md` defines the
+  Technique Feat Model: feat cards as derived reader surfaces over technique
+  canon.
+- `generated/technique_feat_cards.min.example.json` shows feat-card projection
+  shape as reader evidence only.
+- `mechanics/growth-cycle/parts/mastery-harvest/README.md` keeps mastery
+  movement tied to reviewed evidence and harvest posture.
+- `mechanics/growth-cycle/parts/promotion-readiness-incubation/README.md`
+  keeps promotion pressure staged before canon.
+
+## Use
+
+Use this part when an existing technique reads like a transferable feat, edge,
+stance, or small unlock and that reading would help a small agent choose or
+apply it.
+
+The expected move is small:
+
+1. Start from an existing `techniques/**/TECHNIQUE.md` bundle or reviewed
+   evidence.
+2. Reflect the feat or progression reading as derived help.
+3. Keep the source status in the technique bundle and generated reader evidence.
+4. Reject universal score, permission, rank, or automatic promotion language.
+
+## Stop-Lines
+
+This part does not change technique status, grant unlock authority, grant
+rights, create one universal score, or replace the source technique bundle.
+
+Feat cards and progression notes remain reader surfaces until a separate
+review path changes the source-owned technique.

--- a/mechanics/rpg/parts/owner-handoff-anchors/README.md
+++ b/mechanics/rpg/parts/owner-handoff-anchors/README.md
@@ -1,0 +1,32 @@
+# Owner Handoff Anchors
+
+## Purpose
+
+This part maps where RPG-shaped pressure must leave `aoa-techniques` instead
+of expanding local mechanics into another owner's domain.
+
+## Handoff Map
+
+| Pressure | Stronger owner | Stop-line in `aoa-techniques` |
+|---|---|---|
+| role, party, persona, actor boundary, or identity | `aoa-agents` | no role canon or actor law |
+| executable workflow or reusable agent procedure | `aoa-skills` | no skill truth or live execution package |
+| scenario composition, campaign flow, or multi-step route method | `aoa-playbooks` | no playbook choreography or campaign ownership |
+| proof, verdict, benchmark, or public quality claim | `aoa-evals` | no proof verdict or public proof authority |
+| memory writeback, recall object, or chronicle canon | `aoa-memo` | no memory canon or chronicle authority |
+| runtime session state, unlock ledger, or projection behavior | `abyss-stack` | no runtime ledger state or unlock state |
+| movement summary, counters, or derived observability | `aoa-stats` | no stats authority or universal power score |
+| source quest files and durable obligations | `quests/` plus repo owner docs | no quest closure or generated quest source truth |
+| reusable technique practice | `techniques/**/TECHNIQUE.md` | no automatic technique promotion from mechanics |
+
+## Use
+
+Use this part when RPG wording starts to imply owner acceptance. The local move
+is to name the pressure, name the owner, and stop before importing that owner's
+authority.
+
+## Stop-Lines
+
+This part does not grant owner acceptance. It only routes. If the receiving
+owner needs to accept, land, or reject the pressure, that work must happen in
+the receiving owner surface.

--- a/mechanics/rpg/parts/quest-overlay-anchors/README.md
+++ b/mechanics/rpg/parts/quest-overlay-anchors/README.md
@@ -1,0 +1,48 @@
+# Quest Overlay Anchors
+
+## Purpose
+
+This part maps the quest-, RPG-, and chronicle-shaped overlay side of local
+technique pressure. It keeps narrative reflection useful while owner truth,
+proof, routing, memory, and quest source stay elsewhere.
+
+## Local Anchors
+
+- `AOA-T-0085`
+  (`techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md`) owns
+  adjunct quest-, RPG-, or chronicle-shaped reflection over a bounded reviewed
+  base.
+- `AOA-T-0089`
+  (`techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md`) owns
+  one bounded promotion verdict for one repeated reviewed quest unit.
+- `AOA-T-0078`
+  (`techniques/agent-workflows/decision-fork-cards/TECHNIQUE.md`) keeps route
+  cards explicit when a choice surface, not flavor, is the real need.
+- `mechanics/questbook/` keeps local Questbook source, index, projection, and
+  harvest/promotion pressure visible.
+- `quests/` owns source quest files for this repository. Generated quest views
+  stay projections.
+
+## Use
+
+Use this part when quest or RPG language can make an already reviewed route,
+progression result, or promotion pressure easier to read.
+
+The expected move is small:
+
+1. Start from a reviewed base, such as a progression delta, route reflection,
+   or repeated quest unit.
+2. Add only the smallest helpful quest hook, campaign hint, chronicle cue, or
+   ability-like reflection.
+3. Keep the underlying owner, proof, memory, and quest source surfaces named.
+4. Reject overlay text that tries to perform closure, campaign choreography,
+   routing, proof, or memory work.
+
+## Stop-Lines
+
+This part does not own quest closure, campaign choreography, playbook method,
+proof verdicts, memory canon, chronicle authority, routing authority, RPG
+playable reading authority, generated quest source truth, or automatic
+technique promotion.
+
+Quest overlays stay smaller than the reviewed base they annotate.

--- a/mechanics/rpg/parts/source-boundary-anchors/README.md
+++ b/mechanics/rpg/parts/source-boundary-anchors/README.md
@@ -1,0 +1,43 @@
+# Source Boundary Anchors
+
+## Purpose
+
+This part maps the source-boundary side of RPG-shaped technique pressure. It
+exists so agents can use RPG vocabulary as a reader aid without confusing it
+with owner truth, ontology, routing, or canon.
+
+## Local Anchors
+
+- `AOA-T-0016` (`techniques/docs/bounded-context-map/TECHNIQUE.md`) keeps
+  overloaded terms and neighboring contexts explicit.
+- `AOA-T-0076`
+  (`techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md`) chooses one
+  primary owner for one bounded reusable unit.
+- `AOA-T-0090`
+  (`techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md`)
+  keeps the closest adjacent owner visibly rejected.
+- `mechanics/boundary-bridge/` keeps owner-boundary, derived-projection, and
+  proof-claim pressure outside false identity.
+
+## Use
+
+Use this part when RPG words such as class, feat, quest, campaign, party,
+unlock, reputation, or chronicle could improve legibility but might also blur
+source ownership.
+
+The expected move is small:
+
+1. Name the source-owned surface.
+2. Name what the RPG word is allowed to clarify.
+3. Name the owner truth that remains elsewhere.
+4. Reject the nearest wrong authority claim.
+
+## Stop-Lines
+
+This part does not create hidden ontology, owner acceptance, routing authority,
+role canon, skill truth, playbook choreography, proof verdicts, quest closure,
+memory canon, chronicle authority, runtime state, universal scoring, or
+automatic technique promotion.
+
+If the boundary itself becomes a reusable practice, route it to a real
+`techniques/**/TECHNIQUE.md` bundle.

--- a/tests/test_boundary_bridge_mechanics_topology.py
+++ b/tests/test_boundary_bridge_mechanics_topology.py
@@ -149,15 +149,32 @@ class BoundaryBridgeMechanicsTopologyTestCase(unittest.TestCase):
             with self.subTest(expected=expected):
                 self.assertIn(expected, anchors)
 
-    def test_boundary_bridge_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+    def test_boundary_bridge_legacy_scaffold_marks_empty_raw_inventory(self) -> None:
         provenance = (
             REPO_ROOT / "mechanics" / "boundary-bridge" / "PROVENANCE.md"
         ).read_text(encoding="utf-8")
-
-        self.assertFalse(
-            (REPO_ROOT / "mechanics" / "boundary-bridge" / "legacy").exists()
+        legacy_dir = REPO_ROOT / "mechanics" / "boundary-bridge" / "legacy"
+        raw_files = sorted(
+            path.name for path in (legacy_dir / "raw").iterdir() if path.is_file()
         )
-        self.assertIn("does not create `legacy/raw/`", provenance)
+
+        for relative_path in (
+            "legacy/AGENTS.md",
+            "legacy/README.md",
+            "legacy/INDEX.md",
+            "legacy/DISTILLATION_LOG.md",
+            "legacy/raw/README.md",
+        ):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue(
+                    (
+                        REPO_ROOT / "mechanics" / "boundary-bridge" / relative_path
+                    ).is_file()
+                )
+
+        self.assertEqual(["README.md"], raw_files)
+        self.assertIn("legacy scaffold", provenance)
+        self.assertIn("current raw inventory is empty", provenance)
         self.assertIn("no local pre-split", provenance)
 
     def test_boundary_bridge_stop_lines_remain_explicit(self) -> None:

--- a/tests/test_checkpoint_mechanics_topology.py
+++ b/tests/test_checkpoint_mechanics_topology.py
@@ -116,14 +116,32 @@ class CheckpointMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("does not change technique status", anchors)
         self.assertIn("techniques/**/TECHNIQUE.md", anchors)
 
-    def test_checkpoint_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+    def test_checkpoint_legacy_scaffold_marks_empty_raw_inventory(self) -> None:
         provenance = (
             REPO_ROOT / "mechanics" / "checkpoint" / "PROVENANCE.md"
         ).read_text(encoding="utf-8")
+        compact_provenance = " ".join(provenance.split())
+        legacy_dir = REPO_ROOT / "mechanics" / "checkpoint" / "legacy"
+        raw_files = sorted(
+            path.name for path in (legacy_dir / "raw").iterdir() if path.is_file()
+        )
 
-        self.assertFalse((REPO_ROOT / "mechanics" / "checkpoint" / "legacy").exists())
-        self.assertIn("does not create `legacy/raw/`", provenance)
-        self.assertIn("no local pre-split checkpoint", provenance)
+        for relative_path in (
+            "legacy/AGENTS.md",
+            "legacy/README.md",
+            "legacy/INDEX.md",
+            "legacy/DISTILLATION_LOG.md",
+            "legacy/raw/README.md",
+        ):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue(
+                    (REPO_ROOT / "mechanics" / "checkpoint" / relative_path).is_file()
+                )
+
+        self.assertEqual(["README.md"], raw_files)
+        self.assertIn("legacy scaffold", provenance)
+        self.assertIn("current raw inventory is empty", provenance)
+        self.assertIn("no local pre-split checkpoint", compact_provenance)
 
     def test_checkpoint_stop_lines_remain_explicit(self) -> None:
         direction = (

--- a/tests/test_mechanics_legacy_scaffolds.py
+++ b/tests/test_mechanics_legacy_scaffolds.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+LEGACY_SCAFFOLD_MECHANICS = (
+    "boundary-bridge",
+    "checkpoint",
+    "experience",
+    "growth-cycle",
+    "method-growth",
+    "questbook",
+    "recurrence",
+    "release-support",
+    "rpg",
+)
+
+SCAFFOLD_FILES = (
+    "legacy/AGENTS.md",
+    "legacy/README.md",
+    "legacy/INDEX.md",
+    "legacy/DISTILLATION_LOG.md",
+    "legacy/raw/README.md",
+)
+
+
+class MechanicsLegacyScaffoldTestCase(unittest.TestCase):
+    def test_scaffold_files_exist_for_mechanics_without_raw_receipts(self) -> None:
+        for mechanic in LEGACY_SCAFFOLD_MECHANICS:
+            with self.subTest(mechanic=mechanic):
+                for relative_path in SCAFFOLD_FILES:
+                    self.assertTrue(
+                        (REPO_ROOT / "mechanics" / mechanic / relative_path).is_file()
+                    )
+
+    def test_scaffold_raw_inventory_is_empty_except_readme(self) -> None:
+        for mechanic in LEGACY_SCAFFOLD_MECHANICS:
+            raw_dir = REPO_ROOT / "mechanics" / mechanic / "legacy" / "raw"
+            raw_files = sorted(path.name for path in raw_dir.iterdir() if path.is_file())
+
+            with self.subTest(mechanic=mechanic):
+                self.assertEqual(["README.md"], raw_files)
+
+    def test_scaffold_provenance_points_to_legacy_without_absence_language(self) -> None:
+        banned_fragments = (
+            "does not create `legacy/raw/`",
+            "can add `legacy/`",
+            "no `legacy/raw/` directory",
+        )
+
+        for mechanic in LEGACY_SCAFFOLD_MECHANICS:
+            provenance = (
+                REPO_ROOT / "mechanics" / mechanic / "PROVENANCE.md"
+            ).read_text(encoding="utf-8")
+            landing_log = (
+                REPO_ROOT / "mechanics" / mechanic / "LANDING_LOG.md"
+            ).read_text(encoding="utf-8")
+
+            with self.subTest(mechanic=mechanic):
+                self.assertIn("legacy scaffold", provenance)
+                self.assertIn("current raw inventory is empty", provenance)
+                self.assertIn("Legacy Scaffold Bridge", landing_log)
+                for banned in banned_fragments:
+                    self.assertNotIn(banned, provenance)
+
+    def test_scaffold_legacy_surfaces_preserve_bridge_contract(self) -> None:
+        for mechanic in LEGACY_SCAFFOLD_MECHANICS:
+            legacy_root = REPO_ROOT / "mechanics" / mechanic / "legacy"
+            combined = "\n".join(
+                (legacy_root / relative_path).read_text(encoding="utf-8")
+                for relative_path in (
+                    "AGENTS.md",
+                    "README.md",
+                    "INDEX.md",
+                    "DISTILLATION_LOG.md",
+                    "raw/README.md",
+                )
+            )
+
+            with self.subTest(mechanic=mechanic):
+                self.assertIn("source-to-active accounting", combined)
+                self.assertIn("Current raw inventory: none preserved", combined)
+                self.assertIn("../PROVENANCE.md", combined)
+                self.assertIn("Do not add placeholder receipts", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mechanics_request_receipts.py
+++ b/tests/test_mechanics_request_receipts.py
@@ -41,12 +41,18 @@ class MechanicsRequestReceiptsTestCase(unittest.TestCase):
         non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
         self.assertIn("### [agon](agon/README.md)", non_orq_section)
         self.assertIn("### [growth-cycle](growth-cycle/README.md)", non_orq_section)
+        self.assertIn("### [rpg](rpg/README.md)", non_orq_section)
         self.assertIn("Current status: `candidate-only`", non_orq_section)
         self.assertIn("no direct\n  `ORQ-AGON-TECHNIQUES-*` request", non_orq_section)
         self.assertIn("no\n  direct `ORQ-GROWTHCYCLE-TECHNIQUES-*` request", non_orq_section)
+        self.assertIn("no direct\n  `ORQ-RPG-TECHNIQUES-*` request", non_orq_section)
         self.assertNotIn("ORQ-AGON-TECHNIQUES", receipts.split("## Non-ORQ Center Pressure", 1)[0])
         self.assertNotIn(
             "ORQ-GROWTHCYCLE-TECHNIQUES",
+            receipts.split("## Non-ORQ Center Pressure", 1)[0],
+        )
+        self.assertNotIn(
+            "ORQ-RPG-TECHNIQUES",
             receipts.split("## Non-ORQ Center Pressure", 1)[0],
         )
 

--- a/tests/test_questbook_mechanics_topology.py
+++ b/tests/test_questbook_mechanics_topology.py
@@ -168,14 +168,32 @@ class QuestbookMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("does not change technique status", anchors)
         self.assertIn("techniques/**/TECHNIQUE.md", anchors)
 
-    def test_questbook_does_not_create_legacy_raw_without_source_receipts(self) -> None:
+    def test_questbook_legacy_scaffold_marks_empty_raw_inventory(self) -> None:
         provenance = (
             REPO_ROOT / "mechanics" / "questbook" / "PROVENANCE.md"
         ).read_text(encoding="utf-8")
+        compact_provenance = " ".join(provenance.split())
+        legacy_dir = REPO_ROOT / "mechanics" / "questbook" / "legacy"
+        raw_files = sorted(
+            path.name for path in (legacy_dir / "raw").iterdir() if path.is_file()
+        )
 
-        self.assertFalse((REPO_ROOT / "mechanics" / "questbook" / "legacy").exists())
-        self.assertIn("does not create `legacy/raw/`", provenance)
-        self.assertIn("no local pre-split Questbook", provenance)
+        for relative_path in (
+            "legacy/AGENTS.md",
+            "legacy/README.md",
+            "legacy/INDEX.md",
+            "legacy/DISTILLATION_LOG.md",
+            "legacy/raw/README.md",
+        ):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue(
+                    (REPO_ROOT / "mechanics" / "questbook" / relative_path).is_file()
+                )
+
+        self.assertEqual(["README.md"], raw_files)
+        self.assertIn("legacy scaffold", provenance)
+        self.assertIn("current raw inventory is empty", provenance)
+        self.assertIn("no local pre-split Questbook", compact_provenance)
 
     def test_questbook_stop_lines_remain_explicit(self) -> None:
         direction = (

--- a/tests/test_rpg_mechanics_topology.py
+++ b/tests/test_rpg_mechanics_topology.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_RPG_SURFACES = (
+    "mechanics/rpg/AGENTS.md",
+    "mechanics/rpg/README.md",
+    "mechanics/rpg/DIRECTION.md",
+    "mechanics/rpg/PARTS.md",
+    "mechanics/rpg/PROVENANCE.md",
+    "mechanics/rpg/LANDING_LOG.md",
+    "mechanics/rpg/ROADMAP.md",
+    "mechanics/rpg/parts/AGENTS.md",
+    "mechanics/rpg/parts/README.md",
+)
+
+PART_LOCAL_RPG_READMES = (
+    "mechanics/rpg/parts/source-boundary-anchors/README.md",
+    "mechanics/rpg/parts/feat-progression-anchors/README.md",
+    "mechanics/rpg/parts/quest-overlay-anchors/README.md",
+    "mechanics/rpg/parts/owner-handoff-anchors/README.md",
+)
+
+
+class RPGMechanicsTopologyTestCase(unittest.TestCase):
+    def test_rpg_active_surfaces_are_discoverable(self) -> None:
+        for relative_path in ACTIVE_RPG_SURFACES + PART_LOCAL_RPG_READMES:
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).is_file())
+
+    def test_rpg_part_map_names_all_current_parts(self) -> None:
+        parts = (REPO_ROOT / "mechanics" / "rpg" / "PARTS.md").read_text(
+            encoding="utf-8"
+        )
+        provenance = (REPO_ROOT / "mechanics" / "rpg" / "PROVENANCE.md").read_text(
+            encoding="utf-8"
+        )
+
+        for part_name in (
+            "source-boundary-anchors",
+            "feat-progression-anchors",
+            "quest-overlay-anchors",
+            "owner-handoff-anchors",
+        ):
+            with self.subTest(part_name=part_name):
+                self.assertIn(part_name, parts)
+                self.assertIn(part_name, provenance)
+
+    def test_rpg_is_visible_in_mechanics_map(self) -> None:
+        agents = (REPO_ROOT / "mechanics" / "AGENTS.md").read_text(
+            encoding="utf-8"
+        )
+        readme = (REPO_ROOT / "mechanics" / "README.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("boundary-bridge, questbook, and RPG", agents)
+        self.assertIn("[rpg](rpg/README.md)", readme)
+        self.assertIn("quest-overlay", readme)
+        self.assertIn("owner-handoff", readme)
+
+    def test_rpg_stays_outside_direct_orq_lane(self) -> None:
+        receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
+            encoding="utf-8"
+        )
+        direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
+        non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+        compact_non_orq = " ".join(non_orq_section.split())
+
+        self.assertNotIn("ORQ-RPG-TECHNIQUES", direct_section)
+        self.assertIn("### [rpg](rpg/README.md)", non_orq_section)
+        self.assertIn("Current status: `candidate-only`", non_orq_section)
+        self.assertIn("direct `ORQ-RPG-TECHNIQUES-*` request", compact_non_orq)
+
+        for phrase in (
+            "hidden ontology",
+            "runtime ledger state",
+            "role canon",
+            "skill truth",
+            "playbook choreography",
+            "proof verdicts",
+            "quest closure",
+            "memory canon",
+            "chronicle authority",
+            "routing authority",
+            "owner acceptance",
+            "universal scoring",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_non_orq)
+
+    def test_source_boundary_anchors_preserve_owner_truth(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "rpg"
+            / "parts"
+            / "source-boundary-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "AOA-T-0016",
+            "AOA-T-0076",
+            "AOA-T-0090",
+            "mechanics/boundary-bridge/",
+            "owner truth",
+            "hidden ontology",
+            "nearest wrong authority claim",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_feat_progression_anchors_stay_reader_only(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "rpg"
+            / "parts"
+            / "feat-progression-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "AOA-T-0084",
+            "Technique Feat Model",
+            "generated/technique_feat_cards.min.example.json",
+            "techniques/**/TECHNIQUE.md",
+            "does not change technique status",
+            "one universal score",
+            "automatic promotion",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_quest_overlay_anchors_do_not_take_quest_or_memory_authority(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "rpg"
+            / "parts"
+            / "quest-overlay-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "AOA-T-0085",
+            "AOA-T-0089",
+            "AOA-T-0078",
+            "Questbook",
+            "quests/",
+            "quest closure",
+            "campaign choreography",
+            "memory canon",
+            "routing authority",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_owner_handoff_anchors_name_stronger_owners(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "rpg"
+            / "parts"
+            / "owner-handoff-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for expected in (
+            "aoa-agents",
+            "aoa-skills",
+            "aoa-playbooks",
+            "aoa-evals",
+            "aoa-memo",
+            "abyss-stack",
+            "aoa-stats",
+            "quests/",
+            "techniques/**/TECHNIQUE.md",
+            "owner acceptance",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, anchors)
+
+    def test_rpg_legacy_scaffold_marks_empty_raw_inventory(self) -> None:
+        provenance = (REPO_ROOT / "mechanics" / "rpg" / "PROVENANCE.md").read_text(
+            encoding="utf-8"
+        )
+        legacy_dir = REPO_ROOT / "mechanics" / "rpg" / "legacy"
+        raw_files = sorted(
+            path.name for path in (legacy_dir / "raw").iterdir() if path.is_file()
+        )
+
+        for relative_path in (
+            "legacy/AGENTS.md",
+            "legacy/README.md",
+            "legacy/INDEX.md",
+            "legacy/DISTILLATION_LOG.md",
+            "legacy/raw/README.md",
+        ):
+            with self.subTest(relative_path=relative_path):
+                self.assertTrue(
+                    (REPO_ROOT / "mechanics" / "rpg" / relative_path).is_file()
+                )
+
+        self.assertEqual(["README.md"], raw_files)
+        self.assertIn("legacy scaffold", provenance)
+        self.assertIn("current raw inventory is empty", provenance)
+        self.assertIn("no local pre-split RPG", provenance)
+
+    def test_rpg_stop_lines_remain_explicit(self) -> None:
+        direction = (REPO_ROOT / "mechanics" / "rpg" / "DIRECTION.md").read_text(
+            encoding="utf-8"
+        )
+        roadmap = (REPO_ROOT / "mechanics" / "rpg" / "ROADMAP.md").read_text(
+            encoding="utf-8"
+        )
+        compact_direction = " ".join(direction.split())
+        compact_roadmap = " ".join(roadmap.split())
+
+        for phrase in (
+            "hidden ontology",
+            "runtime ledger state",
+            "role canon",
+            "skill execution truth",
+            "playbook choreography",
+            "proof verdicts",
+            "quest closure",
+            "memory canon",
+            "chronicle authority",
+            "routing authority",
+            "owner acceptance",
+            "universal power score",
+            "automatic technique promotion",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, compact_direction)
+                self.assertIn(phrase, compact_roadmap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add candidate-only RPG mechanics package with active parts, provenance, landing log, roadmap, and topology coverage
- add legacy scaffold bridges for grown mechanics packages with empty raw inventories
- update mechanics guidance, request receipts, decision notes, and tests around legacy scaffold posture

## Validation

- python -m unittest tests.test_mechanics_legacy_scaffolds tests.test_boundary_bridge_mechanics_topology tests.test_checkpoint_mechanics_topology tests.test_questbook_mechanics_topology tests.test_rpg_mechanics_topology tests.test_mechanics_request_receipts
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- git diff --check