### PR TITLE
[codex] docs: standardize mechanics package cards

### DIFF
--- a/docs/decisions/2026-05-03-mechanics-package-card-standard.md
+++ b/docs/decisions/2026-05-03-mechanics-package-card-standard.md
@@ -1,0 +1,88 @@
+# Mechanics Package Card Standard
+
+Status: accepted
+
+Date: 2026-05-03
+
+## Context
+
+After the mechanics split, active/legacy scaffolding, and owner-request receipt
+work, the mechanics packages had the right files but uneven entry shapes. Some
+package READMEs already behaved like agent-operable cards; others still opened
+with a thin route list or a package-specific gate.
+
+`Agents-of-Abyss` now provides the architectural example for mechanics cards:
+trigger, owned authority, stronger owner split, inputs, outputs, stop-lines,
+validation, and next route. Copying that shape directly into `aoa-techniques`
+would be wrong, because this repository is not the constitutional center. It is
+the technique-canon organ and must stay usable as a standalone public technique
+library.
+
+The earlier repeated law/local/bridge wording also showed the risk: boundary
+separation helps, but heavy blocks in every README make the route feel imposed
+rather than useful.
+
+## Options
+
+- Leave package READMEs uneven and rely on `DIRECTION.md`, `PARTS.md`, and
+  `PROVENANCE.md` for deeper orientation.
+- Copy the AoA center mechanic-card headings directly, including `Center owns`.
+- Adopt the center card shape but translate its authority into an owner-local
+  `aoa-techniques` card.
+
+## Decision
+
+Adopt a local package-card standard for every `mechanics/<slug>/README.md`.
+
+The local headings are:
+
+- `## Mechanic card`
+- `### Trigger`
+- `### Local owns`
+- `### Stronger owner split`
+- `### Inputs`
+- `### Outputs`
+- `### Must not claim`
+- `### Validation`
+- `### Next route`
+
+`mechanics/README.md` owns the package-card standard. `mechanics/AGENTS.md`
+routes agents through the nearest package card before active parts or legacy.
+Package READMEs use `Local owns`, not `Center owns`, because
+`aoa-techniques` names its technique-layer authority and routes stronger law or
+acceptance to `Agents-of-Abyss`, `mechanics/REQUEST_RECEIPTS.md`,
+`PROVENANCE.md`, or the sibling owner only when relevant.
+When a package is named in `mechanics/REQUEST_RECEIPTS.md`, its card status
+should mirror the local receipt posture such as `mapped-with-local-evidence` or
+`candidate-only` without changing the center queue.
+
+This decision does not add package-local `OWNER_MAP.md`, `OWNER_REQUESTS.md`,
+or a mechanics registry to `aoa-techniques`. Those center-side mechanisms stay
+in `Agents-of-Abyss` unless a future owner-local need is proven.
+
+## Consequences
+
+- Future agents can enter any mechanics package with the same compact question
+  set before opening parts or provenance.
+- The packages become longer, but the added text is bounded to routing,
+  ownership, inputs, outputs, stop-lines, validation, and next route.
+- AoA center law remains upstream; local package cards do not import it as
+  implementation authority.
+- Direct center requests still route through `mechanics/REQUEST_RECEIPTS.md`.
+  Candidate-only pressure stays candidate-only until a local owner surface and
+  proof route actually land.
+- New mechanics packages should include the card headings before they grow
+  active parts or legacy scaffolds.
+
+## Verification
+
+The package-card standard is covered by
+`tests/test_mechanics_package_cards.py`.
+
+Verify with:
+
+```bash
+python -m unittest tests.test_mechanics_package_cards
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```

--- a/mechanics/AGENTS.md
+++ b/mechanics/AGENTS.md
@@ -47,7 +47,8 @@ It does not own:
    `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`, and `mechanics/README.md`.
 3. If the work cites an AoA center-side `ORQ-*` request or downstream owner
    request, read `mechanics/REQUEST_RECEIPTS.md`.
-4. Read the nearest package README for the touched path.
+4. Read the nearest package README for the touched path, starting with its
+   local `Mechanic card`.
 5. If the package has `DIRECTION.md`, `PARTS.md`, `PROVENANCE.md`, `legacy/`,
    or `parts/`, use those active route surfaces before opening raw legacy.
 6. For status, release, or promotion changes, also read
@@ -63,6 +64,10 @@ It does not own:
 - When a mechanics surface points to another AoA owner, name the owner route
   and stop-line only as much as the current surface needs. Do not import sibling
   authority or turn boundary notes into a local doctrine block.
+- Package README cards use `Local owns`, not `Center owns`: `aoa-techniques`
+  names its technique-layer authority, then routes stronger law or acceptance
+  to `Agents-of-Abyss`, `REQUEST_RECEIPTS.md`, `PROVENANCE.md`, or the sibling
+  owner only when relevant.
 - When a mechanics surface answers an AoA center-side owner request, keep the
   local receipt in `mechanics/REQUEST_RECEIPTS.md` and do not treat the request
   packet as local acceptance or landing.

--- a/mechanics/README.md
+++ b/mechanics/README.md
@@ -60,6 +60,33 @@ Mechanics can prepare canon. They do not replace canon.
 Cross-repo references stay light: point to the owner, preserve provenance, and
 keep AoA-only context outside the portable technique core.
 
+## Package Card Standard
+
+Each `mechanics/<slug>/README.md` is an agent-operable local card. It should let
+a reader answer when to use the mechanic, what this repository owns, which
+stronger owners keep final truth, what may enter, what may leave, what must not
+be claimed, how to validate the local route, and where to go next.
+
+Use these headings in package READMEs:
+
+| Heading | Purpose |
+|---|---|
+| `## Mechanic card` | compact package status and entry posture |
+| `### Trigger` | when the local mechanic applies |
+| `### Local owns` | what `aoa-techniques` may author here |
+| `### Stronger owner split` | AoA center or sibling owners that keep stronger truth |
+| `### Inputs` | material that may enter this mechanic |
+| `### Outputs` | material that may leave without becoming canon by itself |
+| `### Must not claim` | stop-lines that keep the package below stronger owners |
+| `### Validation` | where to find exact checks for this package |
+| `### Next route` | the next active surface, provenance bridge, or owner route |
+
+This mirrors the AoA center mechanic-card shape, but adapts the authority. The
+center can say what the center owns. This repository says what the local
+technique-canon organ owns, then routes center law through
+`REQUEST_RECEIPTS.md`, package `PROVENANCE.md`, or a sibling owner only when
+that bridge is relevant.
+
 ## Candidate Gate
 
 Before a mechanics candidate becomes a technique bundle, it should pass the
@@ -90,4 +117,5 @@ at a time:
 - preserved source receipts in `legacy/raw/` when raw receipts exist; otherwise
   an explicit empty raw inventory in `legacy/raw/README.md`
 
-Use [agon](agon/README.md) as the first owner-local example of this split.
+Use the package card first, then open active parts. Enter legacy through
+`PROVENANCE.md` only when the source route matters.

--- a/mechanics/agon/README.md
+++ b/mechanics/agon/README.md
@@ -6,7 +6,7 @@ technique canon, skill execution, proof, arena runtime, or ToS meaning.
 
 ## Mechanic card
 
-Status: planted owner-local route.
+Status: candidate-only owner-local route.
 
 ### Trigger
 
@@ -14,19 +14,19 @@ Use this package when an Agon move, owner-binding packet, epistemic extension,
 or recurrence signal asks whether reusable technique-side practice should be
 staged in `aoa-techniques`.
 
-### Center owns
+### Local owns
 
-`Agents-of-Abyss` owns Agon doctrine, lawful move vocabulary, owner-binding
-rules, arena/session law, verdict retention, rank/scar boundaries, and ToS
-threshold routing.
+This package owns the public-safe technique-side candidate route: active part
+contracts, candidate indexes, recurrence observation surfaces, and provenance
+bridges that keep Agon pressure reviewable before any technique bundle exists.
 
 ### Stronger owner split
 
-`aoa-techniques` owns only public-safe reusable practice candidates and later
-technique bundles after normal technique review. `aoa-skills` owns executable
-workflows, `aoa-evals` owns proof verdicts, `aoa-routing` owns routing logic,
-`aoa-memo` owns memory writeback, and `Tree-of-Sophia` owns ToS-authored
-meaning.
+`Agents-of-Abyss` owns Agon doctrine, lawful move vocabulary, owner-binding
+rules, arena/session law, verdict retention, rank/scar boundaries, and ToS
+threshold routing. `aoa-skills` owns executable workflows, `aoa-evals` owns
+proof verdicts, `aoa-routing` owns routing logic, `aoa-memo` owns memory
+writeback, and `Tree-of-Sophia` owns ToS-authored meaning.
 
 Part-local candidate surfaces translate center-owned move pressure into
 public-safe technique review. They do not import center authority.

--- a/mechanics/antifragility/README.md
+++ b/mechanics/antifragility/README.md
@@ -9,6 +9,63 @@ The center owns doctrine, via negativa, anti-authority posture, fragile-pattern
 vocabulary, and owner-request packets. This repo owns reusable practice pressure
 and technique-family bridges that may feed or explain technique bundles.
 
+## Mechanic card
+
+Status: candidate-only practice route with existing technique anchors.
+
+### Trigger
+
+Use this package when stress, chaos, degraded-mode, regrounding, or recovery
+pressure needs a technique-layer route without becoming Antifragility doctrine
+or owner-local cleanup authority.
+
+### Local owns
+
+This package owns portable stress-recovery practice pressure, current
+technique-anchor mapping, active part routes, and provenance bridges that keep
+chaos-wave material reviewable.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns Antifragility doctrine, via negativa, anti-authority
+posture, fragile-pattern vocabulary, and owner-request packets. `aoa-evals`
+owns proof verdicts, `aoa-skills` owns executable recovery workflows,
+`aoa-playbooks` owns recurring stress choreography, `aoa-stats` owns derived
+movement summaries, and `abyss-stack` owns runtime recovery behavior.
+
+### Inputs
+
+- chaos-wave or stress-review pressure
+- degraded-mode, regrounding, and recovery practice notes
+- existing antifragility-recovery technique anchors
+- provenance routes from preserved chaos-wave material
+
+### Outputs
+
+- active practice-pressure parts
+- technique-anchor readouts
+- candidate-only routes for future bundle review
+- no proof, cleanup approval, runtime recovery, or automatic promotion
+
+### Must not claim
+
+- one-score health
+- deletion or cleanup authority
+- proof verdicts
+- runtime self-healing
+- memory, stats, playbook, or routing truth
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Open [PROVENANCE](PROVENANCE.md) only when the chaos-wave source route
+matters. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/audit/README.md
+++ b/mechanics/audit/README.md
@@ -4,7 +4,64 @@ This package owns the `aoa-techniques` side of the cross-project Audit mechanic:
 making promotion pressure, evidence gaps, searched lanes, and canonical
 readiness legible enough to route the next honest move.
 
-Start with:
+## Mechanic card
+
+Status: active promotion and evidence route.
+
+### Trigger
+
+Use this package when technique promotion pressure, evidence gaps, searched
+lanes, canonical-readiness posture, or external proof routes need to be made
+legible before a bundle status or queue changes.
+
+### Local owns
+
+This package owns readiness queues, evidence-sprint runbooks, searched-lane
+memory, active audit parts, and provenance bridges for technique-canon audit
+pressure.
+
+### Stronger owner split
+
+`techniques/**/TECHNIQUE.md` and bundle-local notes own technique status
+evidence. `aoa-evals` owns proof verdicts. `Agents-of-Abyss` owns center Audit
+doctrine and owner-request grammar. Sibling repos own their own downstream
+evidence before it can be treated as accepted use.
+
+### Inputs
+
+- bundle-local evidence notes and review state
+- external or downstream proof surfaces
+- searched-lane records
+- promotion-readiness blockers or closure signals
+- audit provenance from pre-split surfaces
+
+### Outputs
+
+- readiness posture
+- evidence sprint route
+- searched-lane ledger entry
+- owner-local follow-up route
+- no status change unless bundle-local evidence also moves
+
+### Must not claim
+
+- proof verdicts
+- canonical promotion by queue pressure alone
+- sibling owner acceptance
+- generated or ledger authority over authored bundle meaning
+- donor import ownership, which routes to Distillation
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when auditing source lineage. If a
+bundle status would move, update the bundle-local evidence route first.
+
+## Active route
 
 - [Direction](DIRECTION.md): current intent, boundaries, and route posture.
 - [Parts](PARTS.md): active part map.
@@ -12,7 +69,7 @@ Start with:
 - [Landing Log](LANDING_LOG.md): dated accounting for structural landings.
 - [Roadmap](ROADMAP.md): next honest passes.
 
-Current active parts:
+## Functioning parts
 
 - [Promotion Readiness Matrix](parts/promotion-readiness-matrix/README.md):
   active readiness queues and owner-local promotion posture.

--- a/mechanics/boundary-bridge/README.md
+++ b/mechanics/boundary-bridge/README.md
@@ -10,6 +10,65 @@ owner maps, non-transfer stop-lines, and owner-request packets. This repo only
 owns reusable practice-shaped pressure that may later distill into
 `techniques/**/TECHNIQUE.md`.
 
+## Mechanic card
+
+Status: candidate-only practice route.
+
+### Trigger
+
+Use this package when owner-boundary placement, non-identity, derived
+projection, proof-claim, generated-reader, or mirrored-surface pressure needs a
+technique-layer bridge without transferring authority.
+
+### Local owns
+
+This package owns technique-layer boundary practice pressure, local anchor
+parts, generated/source distinction notes, proof-claim caution, and provenance
+bridges to center guidance.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center Boundary Bridge doctrine, bridge modes, owner
+maps, non-transfer stop-lines, and owner-request packets. `Tree-of-Sophia`
+owns ToS meaning, `aoa-kag` owns derived knowledge substrate semantics,
+`aoa-routing` owns route behavior, `aoa-sdk` owns compatibility helpers,
+`aoa-memo` owns memory objects, `aoa-evals` owns proof, and `abyss-stack` owns
+runtime behavior.
+
+### Inputs
+
+- owner-placement or nearest-wrong-target pressure
+- derived projection and generated-reader surfaces
+- proof-claim or public-claim caution
+- boundary-related technique anchors
+- AoA center boundary-bridge provenance
+
+### Outputs
+
+- local anchor maps
+- candidate-only practice routes
+- proof or owner handoff cues
+- no authority transfer or source identity claim
+
+### Must not claim
+
+- owner acceptance
+- identity between bridged surfaces
+- ToS canon or source interpretation
+- generated projection as source truth
+- routing, SDK, memory, runtime, public projection, or proof authority
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when center or sibling source
+bridges matter. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/checkpoint/README.md
+++ b/mechanics/checkpoint/README.md
@@ -9,6 +9,67 @@ The center owns checkpoint law, vocabulary, owner map, stop-lines, and
 cross-owner route grammar. This repo only owns reusable practice-shaped
 pressure that may later distill into `techniques/**/TECHNIQUE.md`.
 
+## Mechanic card
+
+Status: candidate-only practice route.
+
+### Trigger
+
+Use this package when phase handoff, handoff packets, compaction/re-entry, or
+checkpoint-bound repair pressure needs to be narrowed into technique-shaped
+practice without claiming checkpoint implementation authority.
+
+### Local owns
+
+This package owns technique-layer checkpoint practice pressure, active
+candidate lanes, checkpoint-adjacent technique anchors, and provenance bridges
+to center checkpoint guidance.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center Checkpoint law, vocabulary, owner map,
+stop-lines, and cross-owner route grammar. `aoa-skills` owns executable
+checkpoint workflows, `aoa-agents` owns actor and handoff posture, `aoa-memo`
+owns memory/relaunch objects, `aoa-evals` owns proof, `aoa-routing` owns route
+behavior, `aoa-stats` owns derived summaries, and `abyss-stack` owns runtime
+exports.
+
+### Inputs
+
+- phase handoff and handoff-packet pressure
+- compaction or re-entry practice notes
+- checkpoint-bound repair candidates
+- checkpoint-adjacent technique anchors
+- center checkpoint provenance routes
+
+### Outputs
+
+- active candidate lanes
+- technique-anchor maps
+- owner or proof handoff cues
+- no checkpoint protocol, memory, runtime, or status authority
+
+### Must not claim
+
+- checkpoint implementation authority
+- memory canon
+- proof verdicts
+- runtime activation or exports
+- owner acceptance
+- hidden scheduling or autonomous self-repair
+- route or stats truth
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when the center checkpoint source
+route matters. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/distillation/README.md
+++ b/mechanics/distillation/README.md
@@ -5,7 +5,66 @@ mechanic: turning donor, cross-layer, legacy, or long-gap material into active
 technique-shaped candidates without losing provenance or claiming canon too
 early.
 
-Start with:
+## Mechanic card
+
+Status: mapped-with-local-evidence candidate-intake route for `ORQ-DISTILLATION-TECHNIQUES-001`.
+
+### Trigger
+
+Use this package when donor, sibling-repo, legacy, or long-gap material needs
+to be preserved, pruned, narrowed, held, or handed toward one atomic technique
+candidate without becoming canon by summary.
+
+### Local owns
+
+This package owns donor refinery rules, external import runbooks, candidate
+ledgers, long-gap re-entry posture, active extraction routes, and provenance
+bridges for technique-shaped intake.
+
+### Stronger owner split
+
+`techniques/**/TECHNIQUE.md` owns final reusable practice canon. Source
+repositories keep source meaning. `Agents-of-Abyss` owns center Distillation
+law and owner-request grammar. `aoa-evals` owns proof strength. `Tree-of-Sophia`
+owns ToS-authored meaning and compost, not AoA operational distillation.
+
+### Inputs
+
+- external donors
+- sibling-repo candidate notes
+- pre-split or legacy receipts
+- long-gap promoted material
+- candidate registries and generated counts as evidence
+
+### Outputs
+
+- candidate, hold, exclusion, or incubation lane
+- source and owner boundary note
+- compact gate packet for possible bundle drafting
+- no technique promotion without bundle-local review
+
+### Must not claim
+
+- summary as proof
+- foreign doctrine as AoA law
+- source-owner acceptance
+- ToS canon
+- runtime activation
+- memory canon
+- generated registry authority over authored routes
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane and part-local
+registry checks when candidate registries change.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) for source bridges. Draft a technique
+only after the atom and topology questions can be named.
+
+## Active route
 
 - [Direction](DIRECTION.md): current intent, boundaries, and route posture.
 - [Parts](PARTS.md): active part map.
@@ -14,7 +73,7 @@ Start with:
 - [Landing Log](LANDING_LOG.md): dated accounting for structural landings.
 - [Roadmap](ROADMAP.md): next honest passes.
 
-Current active parts:
+## Functioning parts
 
 - [Donor Refinery](parts/donor-refinery/README.md): compact extraction law for
   turning donor material into reusable practice without copying residue.

--- a/mechanics/experience/README.md
+++ b/mechanics/experience/README.md
@@ -4,7 +4,66 @@ This package owns the `aoa-techniques` side of the cross-project Experience
 mechanic: governance, authority, office/service clarity, scope, handoff, appeal,
 and decision techniques that remain bounded by owner consent.
 
-Start with:
+## Mechanic card
+
+Status: mapped-with-local-evidence route for `ORQ-EXPERIENCE-TECHNIQUES-001`.
+
+### Trigger
+
+Use this package when governance, authority, office/service clarity, scope,
+handoff, appeal, or sealed-decision pressure needs a reusable technique-layer
+route without activating a live office or release authority.
+
+### Local owns
+
+This package owns local Experience practice parts, owner-boundary reminders,
+pre-split seed provenance, and public-safe technique candidate routes around
+governance and service clarity.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center Experience contracts, office/service posture, and
+owner-request grammar. `Tree-of-Sophia` owns ToS-authored meaning and write
+boundaries. `aoa-evals` owns proof, `aoa-skills` owns executable workflows, and
+runtime activation belongs outside this repo.
+
+### Inputs
+
+- Experience center request `ORQ-EXPERIENCE-TECHNIQUES-001`
+- governance or authority practice notes
+- office/service scope and handoff pressure
+- appeal, overturn, or sealed decision precedents
+- pre-split Experience seed surfaces through provenance
+
+### Outputs
+
+- reusable practice notes
+- local owner-boundary reminders
+- candidate routes for future technique bundles
+- no live office, release, runtime, or ToS write authority
+
+### Must not claim
+
+- release approval
+- live office activation
+- assistant self-authority
+- runtime truth
+- Tree-of-Sophia write authority
+- proof verdicts
+- skill execution
+- owner acceptance outside this repository
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [REQUEST_RECEIPTS](../REQUEST_RECEIPTS.md) when the ORQ route
+matters and [PROVENANCE](PROVENANCE.md) when auditing pre-split source lineage.
+
+## Active route
 
 - [Direction](DIRECTION.md): current intent, boundaries, and route posture.
 - [Parts](PARTS.md): active part map.
@@ -13,7 +72,7 @@ Start with:
 - [Landing Log](LANDING_LOG.md): dated accounting for structural landings.
 - [Roadmap](ROADMAP.md): next honest passes.
 
-Current active parts:
+## Functioning parts
 
 - [Appeal Reasoning](parts/appeal-reasoning/README.md)
 - [Authority Resolution](parts/authority-resolution/README.md)

--- a/mechanics/growth-cycle/README.md
+++ b/mechanics/growth-cycle/README.md
@@ -4,7 +4,67 @@ This package owns the `aoa-techniques` side of the cross-project Growth Cycle
 mechanic: recurring harvest, questbook followthrough, reviewed closeout
 incubation, and feat-shaped reflection around technique canon.
 
-Start with:
+## Mechanic card
+
+Status: candidate-only harvest and feat route.
+
+### Trigger
+
+Use this package when mastery-harvest, feat-card, questbook followthrough, or
+reviewed-closeout pressure needs to stay visible around technique canon without
+creating achievement authority or bypassing promotion review.
+
+### Local owns
+
+This package owns technique-layer harvest posture, feat-reader reflection,
+questbook integration anchors, promotion-readiness incubation, and provenance
+bridges for growth-cycle pressure.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center Growth Cycle stage law and cross-owner route
+grammar. `aoa-agents` owns role and progression posture, `aoa-skills` owns
+executable closeout workflows, `aoa-evals` owns proof, `aoa-memo` owns memory
+writeback, `aoa-playbooks` owns scenario choreography, and `aoa-stats` owns
+derived movement summaries.
+
+### Inputs
+
+- reviewed closeout survivors
+- mastery or feat-shaped readings
+- questbook followthrough pressure
+- promotion-readiness incubation cues
+- generated feat-card surfaces as evidence only
+
+### Outputs
+
+- harvest posture
+- feat-reader or questbook anchors
+- promotion-readiness incubation lane
+- owner followthrough cue
+- no achievement, rank, proof, or promotion authority
+
+### Must not claim
+
+- achievement authority
+- permanent rank or universal progression score
+- hidden automation
+- memory canon
+- proof verdicts
+- owner acceptance
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when the growth-cycle source route
+matters. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
+## Active route
 
 - [Direction](DIRECTION.md): current intent, boundaries, and route posture.
 - [Parts](PARTS.md): active part map.
@@ -13,7 +73,7 @@ Start with:
 - [Landing Log](LANDING_LOG.md): dated accounting for structural landings.
 - [Roadmap](ROADMAP.md): next honest passes.
 
-Current active parts:
+## Functioning parts
 
 - [Mastery Harvest](parts/mastery-harvest/README.md): posture for harvesting
   mastery signals without inventing achievement authority.

--- a/mechanics/method-growth/README.md
+++ b/mechanics/method-growth/README.md
@@ -5,7 +5,66 @@ mechanic: moving repeated practice toward explicit technique adoption, owner
 landing, retention, pruning, or technique-to-skill handoff without confusing
 practice meaning with execution authority.
 
-Start with:
+## Mechanic card
+
+Status: mapped-with-local-evidence route for `ORQ-METHOD-TECHNIQUES-001`.
+
+### Trigger
+
+Use this package when repeated practice needs an adoption, retention,
+obsolescence, owner-consent, rollback, or technique-to-skill handoff route
+before it becomes a technique bundle or skill proposal.
+
+### Local owns
+
+This package owns technique-side adoption posture, pattern adoption, retention
+checks, obsolescence routes, technique-to-skill handoff boundaries, and
+pre-split v0.7 provenance.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center Method-growth law and owner-request grammar.
+`aoa-skills` owns executable workflow packages, `aoa-evals` owns proof
+verdicts, `aoa-routing` owns route behavior, `aoa-memo` owns memory objects,
+and each sibling owner keeps acceptance of its own operational truth.
+
+### Inputs
+
+- repeated local or sibling practice
+- adoption, retention, rollback, or obsolescence pressure
+- technique-to-skill handoff candidates
+- owner-consent and readiness notes
+- pre-split downstream adoption surfaces through provenance
+
+### Outputs
+
+- adoption or handoff route
+- retention or obsolescence posture
+- owner consent and rollback reminder
+- technique bundle or skill proposal candidate after stronger review
+
+### Must not claim
+
+- sibling owner acceptance
+- skill activation
+- proof verdicts
+- route behavior
+- memory truth
+- automatic technique promotion
+- deprecation without source-linked evidence
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [REQUEST_RECEIPTS](../REQUEST_RECEIPTS.md) when the ORQ route
+matters and [PROVENANCE](PROVENANCE.md) when auditing pre-split adoption
+lineage.
+
+## Active route
 
 - [Direction](DIRECTION.md): current intent, boundaries, and route posture.
 - [Parts](PARTS.md): active part map.
@@ -14,7 +73,7 @@ Start with:
 - [Landing Log](LANDING_LOG.md): dated accounting for structural landings.
 - [Roadmap](ROADMAP.md): next honest passes.
 
-Current active parts:
+## Functioning parts
 
 - [Technique To Skill Handoff](parts/technique-to-skill-handoff/README.md):
   handoff posture between reusable technique canon and bounded skill workflows.

--- a/mechanics/questbook/README.md
+++ b/mechanics/questbook/README.md
@@ -13,6 +13,68 @@ quest-shaped technique anchors.
 Those already-landed local Questbook source and projection surfaces stay in
 their root source and projection homes.
 
+## Mechanic card
+
+Status: candidate-only obligation route around existing quest surfaces.
+
+### Trigger
+
+Use this package when durable technique obligations, quest source/index
+posture, generated quest projections, harvest pressure, or promotion follow-up
+need a technique-layer route without becoming a second roadmap or playbook.
+
+### Local owns
+
+This package owns local questbook mechanics anchors around `QUESTBOOK.md`,
+root `quests/`, schemas, generated quest projections, harvest/promotion cues,
+and provenance bridges to center Questbook guidance.
+
+### Stronger owner split
+
+`QUESTBOOK.md` and root `quests/` own repo-local obligation source. Generated
+quest files are projections. `Agents-of-Abyss` owns center Questbook law and
+owner-request grammar. `aoa-playbooks` owns scenario choreography,
+`aoa-evals` owns proof, `aoa-routing` owns routing behavior, and `aoa-memo`
+owns memory objects.
+
+### Inputs
+
+- durable technique-canon obligations
+- quest source/index/projection pressure
+- harvest and promotion-review cues
+- generated quest projection drift
+- center Questbook provenance routes
+
+### Outputs
+
+- obligation anchor maps
+- source/projection boundary notes
+- harvest or promotion handoff cues
+- no quest closure, playbook, proof, memory, or routing authority
+
+### Must not claim
+
+- second roadmap
+- private scratchpad or raw donor backlog
+- owner acceptance
+- closure proof or proof verdict
+- playbook choreography
+- memory canon
+- routing authority
+- generated quest views as source truth
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use root [QUESTBOOK](../../QUESTBOOK.md) or `quests/` only when source
+obligations move. Use [PROVENANCE](PROVENANCE.md) when center Questbook source
+bridges matter.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/recurrence/README.md
+++ b/mechanics/recurrence/README.md
@@ -10,6 +10,66 @@ bounded continuity, and source ownership. This repo only owns technique-layer
 signals that may help review candidate intake, overlap holds, canonical
 pressure, and decision closure.
 
+## Mechanic card
+
+Status: candidate-only observation route.
+
+### Trigger
+
+Use this package when recurrence signals, generated registry observations,
+readiness beacons, or review-decision closure pressure need to inform technique
+review without becoming operational continuity.
+
+### Local owns
+
+This package owns technique-layer observation producers, review-decision
+closure posture, candidate-intake signal routing, and provenance bridges to
+center recurrence guidance.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns recurrence law and owner-request grammar. `aoa-routing`
+owns dispatch, `aoa-memo` owns memory recall, `aoa-sdk` owns control-plane
+carry, `aoa-evals` owns proof, `aoa-playbooks` owns scenario choreography,
+`aoa-stats` owns derived summaries, `aoa-kag` owns derived knowledge substrate,
+and `abyss-stack` owns runtime return.
+
+### Inputs
+
+- recurrence observations over candidate or generated surfaces
+- live receipt or readiness signals
+- review-decision closure cues
+- cross-layer candidate registry observations
+- center recurrence provenance routes
+
+### Outputs
+
+- observation or closure posture
+- review cue for a local technique surface
+- owner route for proof, memory, routing, runtime, or stats pressure
+- no candidate creation or status change by recurrence alone
+
+### Must not claim
+
+- ambient continuity
+- hidden memory sovereignty
+- runtime return
+- routing dispatch
+- proof verdicts
+- generated evidence as review authority
+- owner acceptance
+- automatic technique creation or promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when the center recurrence source
+route matters. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/release-support/README.md
+++ b/mechanics/release-support/README.md
@@ -10,6 +10,66 @@ release protocol, owner handoff stop-lines, and rollback posture. This repo
 only owns reusable practice-shaped notes that may later distill into technique
 bundles.
 
+## Mechanic card
+
+Status: candidate-only release-practice route.
+
+### Trigger
+
+Use this package when installation, release ritual, rollback rehearsal,
+public-support caution, or post-release watch pressure needs a reusable
+technique-layer route without claiming release authority.
+
+### Local owns
+
+This package owns installation and sovereign-release practice parts,
+release-shaped technique pressure, public-support caution, and provenance
+bridges to center release-support guidance.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns release-support state-transition law, public-claim
+boundaries, federation release protocol, owner handoff stop-lines, and rollback
+posture. `aoa-evals` owns proof, `aoa-sdk` owns compatibility and route ABI
+helpers, `aoa-stats` owns summaries, `abyss-stack` owns deployment and runtime
+rollback, and each sibling owner accepts its own release evidence.
+
+### Inputs
+
+- installation practice notes
+- release ritual or decision-sealing pressure
+- rollback rehearsal and post-release watch cues
+- public-support claim caution
+- center release-support provenance routes
+
+### Outputs
+
+- release-shaped practice anchors
+- owner handoff or public-claim caution
+- future technique bundle candidate
+- no release, proof, runtime, or operator-consent authority
+
+### Must not claim
+
+- GitHub-only release truth
+- release approval
+- unverified public claims
+- operator consent
+- sibling acceptance
+- runtime rollback authority
+- public projection as technique truth
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when center release-support source
+bridges matter. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
 ## Active route
 
 - [Direction](DIRECTION.md)

--- a/mechanics/rpg/README.md
+++ b/mechanics/rpg/README.md
@@ -10,7 +10,72 @@ quest/campaign posture, progression/unlocks, runtime projection, and owner
 requests. This repo owns only local technique-layer anchors around existing
 technique bundles, generated reader surfaces, and mechanics routes.
 
-## Active Route
+## Mechanic card
+
+Status: candidate-only reflection route.
+
+### Trigger
+
+Use this package when feat reflection, progression language, quest overlays,
+chronicle cues, or owner-handoff pressure can make technique work easier to
+read without mutating technique canon.
+
+### Local owns
+
+This package owns local RPG-shaped anchors to technique bundles and mechanics
+surfaces, source-boundary notes, feat/progression/quest-overlay maps, and
+owner-handoff cues for technique-layer pressure.
+
+### Stronger owner split
+
+`Agents-of-Abyss` owns center RPG world grammar and downstream owner posture.
+`aoa-agents` owns role canon, `aoa-skills` owns skill execution,
+`aoa-playbooks` owns scenario and campaign choreography, `aoa-evals` owns proof
+verdicts, `aoa-memo` owns memory and chronicle objects, `aoa-routing` owns
+routing behavior, `aoa-stats` owns summaries, and `abyss-stack` owns runtime
+ledger state.
+
+### Inputs
+
+- feat-card or progression-shaped readings
+- quest-overlay and chronicle pressure
+- owner-handoff cues
+- generated reader surfaces as evidence only
+- center RPG provenance routes
+
+### Outputs
+
+- adjunct reflection anchors
+- owner handoff cues
+- future technique candidate pressure
+- no rank, role, quest, proof, memory, route, or runtime authority
+
+### Must not claim
+
+- hidden ontology
+- runtime ledger state
+- role canon
+- skill truth
+- playbook choreography
+- proof verdicts
+- quest closure
+- memory or chronicle canon
+- routing authority
+- owner acceptance
+- universal power score
+- automatic technique promotion
+
+### Validation
+
+Use [AGENTS](AGENTS.md#verify) for the package validation lane.
+
+### Next route
+
+Start from [DIRECTION](DIRECTION.md), [PARTS](PARTS.md), and the relevant part
+README. Use [PROVENANCE](PROVENANCE.md) only when center RPG source bridges
+matter. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
+
+## Active route
 
 - [Direction](DIRECTION.md)
 - [Parts](PARTS.md)
@@ -18,7 +83,7 @@ technique bundles, generated reader surfaces, and mechanics routes.
 - [Landing Log](LANDING_LOG.md)
 - [Roadmap](ROADMAP.md)
 
-## Functioning Parts
+## Functioning parts
 
 - [Source Boundary Anchors](parts/source-boundary-anchors/README.md): maps
   owner truth, bounded-context, owner-placement, and nearest-wrong-target
@@ -46,7 +111,7 @@ acceptance, universal power score, or automatic technique promotion.
 Stable reusable RPG-shaped practices may later become technique bundles, but
 only through the normal `techniques/**/TECHNIQUE.md` review path.
 
-## AoA Relation
+## AoA relation
 
 `Agents-of-Abyss` owns the center RPG mechanic and its downstream owner
 posture. The current center queue has no direct

--- a/tests/test_mechanics_package_cards.py
+++ b/tests/test_mechanics_package_cards.py
@@ -1,0 +1,138 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MECHANICS_ROOT = REPO_ROOT / "mechanics"
+
+PACKAGE_CARD_HEADINGS = [
+    "## Mechanic card",
+    "### Trigger",
+    "### Local owns",
+    "### Stronger owner split",
+    "### Inputs",
+    "### Outputs",
+    "### Must not claim",
+    "### Validation",
+    "### Next route",
+]
+
+CARD_STATUS_MARKERS = {
+    "agon": "candidate-only",
+    "antifragility": "candidate-only",
+    "boundary-bridge": "candidate-only",
+    "checkpoint": "candidate-only",
+    "distillation": "mapped-with-local-evidence",
+    "experience": "mapped-with-local-evidence",
+    "growth-cycle": "candidate-only",
+    "method-growth": "mapped-with-local-evidence",
+    "questbook": "candidate-only",
+    "recurrence": "candidate-only",
+    "release-support": "candidate-only",
+    "rpg": "candidate-only",
+}
+
+ACTIVE_ROUTE_FILES = [
+    "DIRECTION.md",
+    "PARTS.md",
+    "PROVENANCE.md",
+    "LANDING_LOG.md",
+    "ROADMAP.md",
+]
+
+
+class MechanicsPackageCardTests(unittest.TestCase):
+    def test_mechanics_readme_defines_owner_local_card_standard(self) -> None:
+        readme = (MECHANICS_ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("## Package Card Standard", readme)
+        self.assertIn("`### Local owns`", readme)
+        self.assertIn("This mirrors the AoA center mechanic-card shape", readme)
+        self.assertIn("`REQUEST_RECEIPTS.md`", readme)
+        self.assertIn("package `PROVENANCE.md`", readme)
+
+    def test_mechanics_agents_routes_through_local_cards(self) -> None:
+        agents = (MECHANICS_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("local `Mechanic card`", agents)
+        self.assertIn("Package README cards use `Local owns`, not `Center owns`", agents)
+        self.assertIn("`REQUEST_RECEIPTS.md`", agents)
+        self.assertIn("`PROVENANCE.md`", agents)
+
+    def test_package_card_decision_is_discoverable(self) -> None:
+        decision = (
+            REPO_ROOT
+            / "docs"
+            / "decisions"
+            / "2026-05-03-mechanics-package-card-standard.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Status: accepted", decision)
+        self.assertIn("### Local owns", decision)
+        self.assertIn("should mirror the local receipt posture", decision)
+        self.assertIn("does not add package-local `OWNER_MAP.md`", decision)
+        self.assertIn("tests/test_mechanics_package_cards.py", decision)
+
+    def test_every_mechanic_package_has_local_card_headings(self) -> None:
+        package_dirs = sorted(
+            path for path in MECHANICS_ROOT.iterdir() if path.is_dir()
+        )
+        self.assertGreater(len(package_dirs), 0)
+
+        for package_dir in package_dirs:
+            readme = (package_dir / "README.md").read_text(encoding="utf-8")
+            with self.subTest(package=package_dir.name):
+                for heading in PACKAGE_CARD_HEADINGS:
+                    self.assertIn(heading, readme)
+                self.assertNotIn("### Center owns", readme)
+
+                positions = [readme.index(heading) for heading in PACKAGE_CARD_HEADINGS]
+                self.assertEqual(sorted(positions), positions)
+
+    def test_package_card_status_matches_request_receipt_posture(self) -> None:
+        receipts = (MECHANICS_ROOT / "REQUEST_RECEIPTS.md").read_text(
+            encoding="utf-8"
+        )
+
+        for package_name, status_marker in CARD_STATUS_MARKERS.items():
+            readme = (
+                MECHANICS_ROOT / package_name / "README.md"
+            ).read_text(encoding="utf-8")
+
+            with self.subTest(package=package_name):
+                self.assertIn(f"Status: {status_marker}", readme)
+                self.assertIn(f"[{package_name}]", receipts)
+
+        audit_readme = (MECHANICS_ROOT / "audit" / "README.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("Status: active", audit_readme)
+
+    def test_package_cards_route_to_active_parts_and_route_files(self) -> None:
+        package_dirs = sorted(
+            path for path in MECHANICS_ROOT.iterdir() if path.is_dir()
+        )
+
+        for package_dir in package_dirs:
+            readme = (package_dir / "README.md").read_text(encoding="utf-8")
+            parts_map = (package_dir / "PARTS.md").read_text(encoding="utf-8")
+            part_dirs = sorted(
+                path
+                for path in (package_dir / "parts").iterdir()
+                if path.is_dir()
+            )
+
+            with self.subTest(package=package_dir.name):
+                for route_file in ACTIVE_ROUTE_FILES:
+                    self.assertIn(route_file, readme)
+                    self.assertTrue((package_dir / route_file).is_file())
+
+                for part_dir in part_dirs:
+                    part_route = f"parts/{part_dir.name}/README.md"
+                    self.assertIn(part_route, readme)
+                    self.assertIn(f"`{part_dir.name}`", parts_map)
+                    self.assertTrue((part_dir / "README.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Standardize every `mechanics/<slug>/README.md` around an owner-local mechanic card shape.
- Add the package-card standard to `mechanics/README.md` and route agents through local cards in `mechanics/AGENTS.md`.
- Record the decision and add invariant coverage for card headings, order, receipt status posture, active route files, and part routes.

## Validation

- `python -m unittest tests.test_mechanics_package_cards`
- `python scripts/validate_repo.py`
- `python -m unittest discover -s tests`
- `git diff --check`

## Notes

The cards use `Local owns`, not `Center owns`, so `aoa-techniques` keeps technique-layer authority local while routing stronger law or acceptance to `Agents-of-Abyss`, `REQUEST_RECEIPTS.md`, `PROVENANCE.md`, or the sibling owner only when relevant.