### PR TITLE
Add Experience technique candidate bridge

### DIFF
--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -88,12 +88,15 @@ These statuses are local to this file. They do not change AoA queue status.
   [Sealed Decision](experience/parts/sealed-decision/README.md),
   [Scope Boundary](experience/parts/scope-boundary/README.md),
   [Handoff Compression](experience/parts/handoff-compression/README.md), and
-  [Service Clarity](experience/parts/service-clarity/README.md).
+  [Service Clarity](experience/parts/service-clarity/README.md), and
+  [Technique Candidate Bridge](experience/parts/technique-candidate-bridge/README.md).
 - Owner landing readout:
   - governance and appeal practice live in Governance Precedent, Authority
     Resolution, Appeal Reasoning, and Sealed Decision.
   - office/service practice lives in Scope Boundary, Handoff Compression, and
     Service Clarity.
+  - candidate extraction now routes through Technique Candidate Bridge before a
+    technique bundle is drafted.
   - portable practice stops before live office activation, release approval,
     assistant self-authority, runtime truth, and ToS write authority.
   - technique canon lands only when a real `techniques/**/TECHNIQUE.md` bundle

--- a/mechanics/experience/DIRECTION.md
+++ b/mechanics/experience/DIRECTION.md
@@ -28,6 +28,10 @@ The mechanic receives Experience pressure, but keeps the local output bounded:
    [Handoff Compression](parts/handoff-compression/README.md), and
    [Service Clarity](parts/service-clarity/README.md) for office/service-shaped
    practice that must stay below runtime and release authority.
+6. Use [Technique Candidate Bridge](parts/technique-candidate-bridge/README.md)
+   before drafting any Experience-derived technique bundle, especially when a
+   local part overlaps AoA center governance, office, service, runtime, proof,
+   role, memory, routing, or ToS authority.
 
 ## Boundaries
 
@@ -46,5 +50,6 @@ The first active split moved seven formerly flat Experience files into
 part-local homes. Their seed wording was preserved as active mechanics behavior,
 not promoted into technique bundles.
 
-The next work should decide one part at a time whether the reusable practice is
-ready for `techniques/` or should remain a mechanics-only owner-boundary note.
+The next work should use the candidate bridge to decide one part at a time
+whether the reusable practice is ready for `techniques/`, needs another
+narrowing pass, or should remain a mechanics-only owner-boundary note.

--- a/mechanics/experience/LANDING_LOG.md
+++ b/mechanics/experience/LANDING_LOG.md
@@ -35,3 +35,29 @@ Not moved:
   compact active material already distilled into part-local homes.
 - Updated provenance to point to the scaffold instead of treating legacy as an
   absent later add-on.
+
+## 2026-05-03 - Technique Candidate Bridge
+
+Changed:
+
+- added `parts/technique-candidate-bridge/` as the Experience extraction gate
+- classified current Experience parts into `extract_watch`, `narrow_more`, and
+  `hold_overlap` lanes
+- linked the bridge to nearest existing technique bundles so future extraction
+  starts from current canon instead of redrafting mechanics
+- updated the owner request receipt for `ORQ-EXPERIENCE-TECHNIQUES-001`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_experience_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```
+
+Not moved:
+
+- no Experience part was promoted into `techniques/`
+- no raw legacy source was added
+- no live office, release, runtime, proof, role, memory, routing, or
+  Tree-of-Sophia authority was claimed

--- a/mechanics/experience/PARTS.md
+++ b/mechanics/experience/PARTS.md
@@ -12,6 +12,7 @@ source inventory.
 | `scope-boundary` | Keeps office/service scope below release approval, self-authority, runtime truth, and ToS write authority. | [parts/scope-boundary](parts/scope-boundary/README.md) | [PROVENANCE](PROVENANCE.md) |
 | `handoff-compression` | Names office/service handoff compression practice without becoming execution workflow. | [parts/handoff-compression](parts/handoff-compression/README.md) | [PROVENANCE](PROVENANCE.md) |
 | `service-clarity` | Keeps service clarity practice owner-local and bounded by upstream gates. | [parts/service-clarity](parts/service-clarity/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `technique-candidate-bridge` | Classifies Experience parts into extract-watch, narrow, hold, owner-route, or mechanics-only lanes before any technique promotion. | [parts/technique-candidate-bridge](parts/technique-candidate-bridge/README.md) | [PROVENANCE](PROVENANCE.md) |
 
 ## Part Rule
 
@@ -19,3 +20,7 @@ If a part starts carrying a stable reusable practice with inputs, outputs,
 risks, examples, and validation, route the practice bundle into `techniques/`.
 Leave this package as the mechanics layer that explains how Experience pressure
 moved.
+
+Use `technique-candidate-bridge` before drafting from Experience pressure. It
+keeps candidate classification separate from promotion and from stronger-owner
+authority.

--- a/mechanics/experience/PROVENANCE.md
+++ b/mechanics/experience/PROVENANCE.md
@@ -29,6 +29,12 @@ the active route just because they existed before this split.
 | Pre-split flat `HANDOFF_COMPRESSION_TECHNIQUE.md` | [parts/handoff-compression](parts/handoff-compression/README.md) | Handoff compression remains owner-local contract behavior, not live office execution. |
 | Pre-split flat `SERVICE_CLARITY_TECHNIQUE.md` | [parts/service-clarity](parts/service-clarity/README.md) | Service clarity remains bounded by owner consent and upstream runtime stop-lines. |
 
+## Center Context Bridge
+
+| Context source | Active route | Distilled signal |
+|---|---|---|
+| AoA-center Experience `PARTS.md`, `DIRECTION.md`, `OWNER_REQUESTS.md`, and part contracts | [parts/technique-candidate-bridge](parts/technique-candidate-bridge/README.md) | Local Experience parts must be classified before extraction; center law supplies stop-lines and owner routes, not technique canon. |
+
 ## Legacy Posture
 
 The pre-split files were compact active seed surfaces rather than large wave

--- a/mechanics/experience/README.md
+++ b/mechanics/experience/README.md
@@ -81,6 +81,7 @@ matters and [PROVENANCE](PROVENANCE.md) when auditing pre-split source lineage.
 - [Scope Boundary](parts/scope-boundary/README.md)
 - [Sealed Decision](parts/sealed-decision/README.md)
 - [Service Clarity](parts/service-clarity/README.md)
+- [Technique Candidate Bridge](parts/technique-candidate-bridge/README.md)
 
 Release-shaped surfaces for installation and sovereign release live in
 [release-support](../release-support/README.md).
@@ -88,3 +89,7 @@ Release-shaped surfaces for installation and sovereign release live in
 Experience may produce a reusable practice note, owner-boundary reminder, or
 governance precedent. It does not by itself approve a release, install a live
 office, activate runtime behavior, or write Tree-of-Sophia meaning.
+
+Use the candidate bridge before extracting a technique from Experience pressure;
+it keeps the atom, nearest existing bundles, and stronger-owner routes visible
+without turning the whole mechanic into a technique draft.

--- a/mechanics/experience/ROADMAP.md
+++ b/mechanics/experience/ROADMAP.md
@@ -5,12 +5,17 @@ commitment and not a source ledger.
 
 ## Next Passes
 
-1. Decide whether governance precedent should remain mechanics-only or become a
-   bounded technique bundle.
-2. Separate authority-resolution practice from role contracts owned by
-   `aoa-agents`.
-3. Check whether handoff compression, scope boundary, and service clarity can
-   stand as portable techniques without live office or release authority.
-4. Preserve any discovered real wave/source material in `legacy/raw/` and keep
+1. Review `authority-resolution` through the candidate bridge and decide whether
+   a `capability-authority-separation-check` atom is distinct from owner-layer
+   placement, host-actionability, and role contracts owned by `aoa-agents`.
+2. Review `sealed-decision` through the candidate bridge and decide whether a
+   sealed evidence packet can stay smaller than proof verdicts and general
+   decision-rationale recording.
+3. Split governance precedent from appeal handling before either lane becomes a
+   technique draft.
+4. Keep handoff compression, scope boundary, and service clarity in
+   `hold_overlap` until their portable atom is smaller than live office,
+   release, service runtime, and existing handoff/lifecycle bundles.
+5. Preserve any discovered real wave/source material in `legacy/raw/` and keep
    `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
    aligned.

--- a/mechanics/experience/parts/README.md
+++ b/mechanics/experience/parts/README.md
@@ -9,6 +9,7 @@ Active Experience parts:
 - [scope-boundary](scope-boundary/README.md)
 - [handoff-compression](handoff-compression/README.md)
 - [service-clarity](service-clarity/README.md)
+- [technique-candidate-bridge](technique-candidate-bridge/README.md)
 
 Use [../PARTS.md](../PARTS.md) for the role map and
 [../PROVENANCE.md](../PROVENANCE.md) for source lineage.

--- a/mechanics/experience/parts/technique-candidate-bridge/README.md
+++ b/mechanics/experience/parts/technique-candidate-bridge/README.md
@@ -1,0 +1,75 @@
+# Technique Candidate Bridge
+
+This part decides how Experience pressure can move toward atomic technique
+bundles without copying AoA-center law into `aoa-techniques`.
+
+Use it when a local Experience part looks reusable, but the next honest step is
+still to classify the candidate rather than draft a `techniques/**/TECHNIQUE.md`
+bundle immediately.
+
+It does not change technique status. A technique becomes canonical or promoted
+only in its own bundle.
+
+## Inputs
+
+- one local Experience part
+- the nearest AoA-center Experience part or owner request signal
+- the reusable move that might become one technique
+- nearest existing technique bundles, if any
+- stronger owner routes and stop-lines
+- portability note for use outside OS Abyss
+
+## Outputs
+
+- one candidate verdict: `extract_watch`, `narrow_more`, `hold_overlap`,
+  `route_to_owner`, or `mechanics_only`
+- one nearest existing bundle or owner surface to check first
+- one stop-line that prevents authority transfer
+- one next review move
+
+## Current Candidate Readout
+
+| Local part | Center pressure | Current verdict | Nearest anchor | Next move |
+|---|---|---|---|---|
+| `authority-resolution` | Governance Polis and Runtime Boundary both separate capability, authority, and activation. | `extract_watch` | [owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md), [nearest-wrong-target-rejection](../../../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md), [recommendation-truth-vs-host-actionability](../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md) | Test whether a `capability-authority-separation-check` atom is distinct from owner placement and host-actionability checks. |
+| `sealed-decision` | Governance Polis names appeals, stays, precedents, and authority resolver language. | `extract_watch` | [decision-rationale-recording](../../../../techniques/docs/decision-rationale-recording/TECHNIQUE.md), [fail-closed-evidence-gate](../../../../techniques/agent-workflows/fail-closed-evidence-gate/TECHNIQUE.md) | Test whether a sealed evidence packet is smaller than proof verdicts and broader decision rationale. |
+| `governance-precedent` | Governance Polis names decision tables, policy registry routes, appeal or stay routes, and precedent hints. | `narrow_more` | [local-pattern-adoption-gate](../../../../techniques/agent-workflows/local-pattern-adoption-gate/TECHNIQUE.md), [decision-fork-cards](../../../../techniques/agent-workflows/decision-fork-cards/TECHNIQUE.md) | Split precedent capture from local adoption and from appeal handling before drafting. |
+| `appeal-reasoning` | Governance Polis names appeal, stay, quarantine, dispute, and overturn pressure. | `narrow_more` | [fail-closed-evidence-gate](../../../../techniques/agent-workflows/fail-closed-evidence-gate/TECHNIQUE.md), [decision-rationale-recording](../../../../techniques/docs/decision-rationale-recording/TECHNIQUE.md) | Name one reusable appeal packet, or keep it as governance mechanics. |
+| `scope-boundary` | Office Operations, Service Mesh, Release Deployment, and Runtime Boundary all touch live activation stop-lines. | `hold_overlap` | [confirmation-gated-mutating-action](../../../../techniques/agent-workflows/confirmation-gated-mutating-action/TECHNIQUE.md), [workspace-root-ingress-and-mutation-gate](../../../../techniques/agent-workflows/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md) | Hold until office, release, and runtime authority are separated from the reusable scope check. |
+| `handoff-compression` | Office Operations and Continuity Context both touch role-pair handoff, replay, and re-entry. | `hold_overlap` | [structured-handoff-before-compaction](../../../../techniques/agent-workflows/structured-handoff-before-compaction/TECHNIQUE.md), [receipt-confirmed-handoff-packet](../../../../techniques/agent-workflows/receipt-confirmed-handoff-packet/TECHNIQUE.md), [git-verified-handoff-claims](../../../../techniques/agent-workflows/git-verified-handoff-claims/TECHNIQUE.md) | Hold until the atom is smaller than live office handoff and existing handoff bundles. |
+| `service-clarity` | Service Mesh and Release Deployment touch service operation, compatibility, rollout, and runtime owner requests. | `hold_overlap` | [one-command-service-lifecycle](../../../../techniques/agent-workflows/one-command-service-lifecycle/TECHNIQUE.md), [isolated-service-stop-on-shared-substrate](../../../../techniques/system-recovery/isolated-service-stop-on-shared-substrate/TECHNIQUE.md) | Hold until a portable service-clarity move is separate from service runtime and release choreography. |
+
+## Bridge Rules
+
+- Start from the local part and candidate atom, not from the full center
+  mechanic.
+- If the candidate cannot name one atomic move, keep it in `narrow_more` or
+  `mechanics_only`.
+- If the candidate mainly changes runtime, role, release, proof, memory,
+  routing, or ToS behavior, use `route_to_owner` or `hold_overlap`.
+- If an existing bundle already answers the move, use that bundle instead of
+  redrafting Experience doctrine.
+- If the move is portable, it must still make sense without OS Abyss offices,
+  release trains, runtime services, or owner-request queues.
+
+## Stop-lines
+
+- no live office activation
+- no release approval
+- no runtime truth or dispatch authority
+- no proof verdicts before `aoa-evals`
+- no role or handoff authority before `aoa-agents`
+- no hidden memory or recall authority before `aoa-memo`
+- no Tree-of-Sophia write authority
+- no automatic technique promotion
+
+## Strongest Next Thread
+
+The cleanest next Experience extraction candidate is `authority-resolution`.
+Its likely atom is a capability-versus-authority check: before an agent acts or
+recommends action, name what is technically possible, who is authorized to
+decide, and which owner surface can accept or reject the move.
+
+Keep that next pass separate from owner-layer placement. The question is not
+"which repository owns this reusable unit?" but "does capability imply
+authority here?".

--- a/tests/test_experience_mechanics_topology.py
+++ b/tests/test_experience_mechanics_topology.py
@@ -26,6 +26,7 @@ PART_LOCAL_EXPERIENCE_READMES = (
     "mechanics/experience/parts/scope-boundary/README.md",
     "mechanics/experience/parts/handoff-compression/README.md",
     "mechanics/experience/parts/service-clarity/README.md",
+    "mechanics/experience/parts/technique-candidate-bridge/README.md",
 )
 
 OLD_FLAT_EXPERIENCE_FILES = (
@@ -66,10 +67,35 @@ class ExperienceMechanicsTopologyTestCase(unittest.TestCase):
             "scope-boundary",
             "handoff-compression",
             "service-clarity",
+            "technique-candidate-bridge",
         ):
             with self.subTest(part_name=part_name):
                 self.assertIn(part_name, parts)
                 self.assertIn(part_name, provenance)
+
+    def test_experience_candidate_bridge_preserves_extraction_gate(self) -> None:
+        bridge = (
+            REPO_ROOT
+            / "mechanics"
+            / "experience"
+            / "parts"
+            / "technique-candidate-bridge"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for required in (
+            "extract_watch",
+            "narrow_more",
+            "hold_overlap",
+            "authority-resolution",
+            "sealed-decision",
+            "governance-precedent",
+            "handoff-compression",
+            "no automatic technique promotion",
+            "capability-authority-separation-check",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, bridge)
 
     def test_request_receipt_points_to_experience_parts_without_runtime_authority(self) -> None:
         receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
@@ -81,6 +107,8 @@ class ExperienceMechanicsTopologyTestCase(unittest.TestCase):
 
         self.assertIn("Governance Precedent", experience_section)
         self.assertIn("Handoff Compression", experience_section)
+        self.assertIn("Technique Candidate Bridge", experience_section)
+        self.assertIn("candidate extraction now routes through", experience_section)
         self.assertIn("portable practice stops before live office activation", experience_section)
         self.assertIn("runtime truth", experience_section)
         self.assertIn("ToS write authority", experience_section)


### PR DESCRIPTION
## Summary
- add an Experience technique candidate bridge part
- classify local Experience parts into extract-watch, narrow, and hold lanes
- update Experience route surfaces, request receipts, and topology tests

## Validation
- python -m unittest tests.test_experience_mechanics_topology
- python scripts/validate_repo.py
- python -m unittest discover -s tests

## Gate review
- approval gate: user requested commit/push/merge; docs/test-only branch is safe to publish through PR
- dry run: diff, topology tests, repo validator, and unittest discover passed before push
- sanitized share: no logs, secrets, private runtime config, or raw source receipts were published