### PR TITLE
Add Growth-cycle stage technique anchors

### DIFF
--- a/mechanics/REQUEST_RECEIPTS.md
+++ b/mechanics/REQUEST_RECEIPTS.md
@@ -165,6 +165,9 @@ or candidate lanes without a direct AoA owner-request ID targeting
   direct `ORQ-GROWTHCYCLE-TECHNIQUES-*` request. Local Growth-cycle surfaces
   preserve technique-layer harvest, feat-reader, questbook, and
   promotion-readiness pressure without claiming center request acceptance.
+  Stage Technique Anchors map many center-stage moves to existing technique
+  bundles while keeping promotion-readiness discrimination as a held local
+  candidate lane.
 
 ### [questbook](questbook/README.md)
 

--- a/mechanics/growth-cycle/DIRECTION.md
+++ b/mechanics/growth-cycle/DIRECTION.md
@@ -25,6 +25,8 @@ This package can name:
 - feat-card reader boundaries
 - questbook followthrough for technique hardening
 - promotion-readiness incubation from reviewed closeout residue
+- stage-to-technique anchors when an existing bundle already owns the smaller
+  reusable move
 
 It cannot name:
 
@@ -44,3 +46,7 @@ canon, quest followthrough, or derived reader support.
 If the output needs execution, proof, memory, routing, playbook choreography,
 runtime activation, or role progression, route to the owner repository instead
 of expanding local prose.
+
+Before extracting a new Growth-cycle technique, use
+[Stage Technique Anchors](parts/stage-technique-anchors/README.md) to check
+whether the move is already covered by an existing bundle.

--- a/mechanics/growth-cycle/LANDING_LOG.md
+++ b/mechanics/growth-cycle/LANDING_LOG.md
@@ -20,3 +20,31 @@ mechanic. It is not a historical source ledger.
   compact active material already distilled into part-local homes.
 - Updated provenance to point to the scaffold instead of treating legacy as an
   absent later add-on.
+
+## 2026-05-03 - Stage Technique Anchors
+
+Changed:
+
+- added `parts/stage-technique-anchors/` as the route from AoA center Growth
+  Cycle stages to existing technique bundles and local hold lanes
+- named current anchors for donor harvest, progression lift, automation
+  opportunity, diagnosis, repair, quest promotion, and owner followthrough
+- kept checkpoint intake and reviewed closeout lower-authority until review and
+  owner-local evidence exist
+- updated the non-ORQ request receipt to show that Growth-cycle remains
+  candidate-only while existing bundles answer many stage-level moves
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_growth_cycle_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```
+
+Not moved:
+
+- no direct `ORQ-GROWTHCYCLE-TECHNIQUES-*` request was claimed
+- no existing technique bundle status changed
+- no achievement, rank, proof, memory, runtime, skill execution, playbook,
+  route, stats, or owner-acceptance authority was claimed

--- a/mechanics/growth-cycle/PARTS.md
+++ b/mechanics/growth-cycle/PARTS.md
@@ -9,6 +9,7 @@ It is not the AoA center stage map and not a raw source inventory.
 | `technique-feat-model` | Keeps feat cards as derived reader surfaces subordinate to technique canon. | [parts/technique-feat-model](parts/technique-feat-model/README.md) | [PROVENANCE](PROVENANCE.md) |
 | `questbook-integration` | Routes durable technique hardening obligations into questbook without turning the repo into a donor backlog. | [parts/questbook-integration](parts/questbook-integration/README.md) | [PROVENANCE](PROVENANCE.md) |
 | `promotion-readiness-incubation` | Preserves reviewed closeout survivors as technique-shaped incubation lanes without premature canon. | [parts/promotion-readiness-incubation](parts/promotion-readiness-incubation/README.md) | [PROVENANCE](PROVENANCE.md) |
+| `stage-technique-anchors` | Maps AoA Growth Cycle stages to existing technique bundles, local hold lanes, and stronger-owner routes. | [parts/stage-technique-anchors](parts/stage-technique-anchors/README.md) | [PROVENANCE](PROVENANCE.md) |
 
 ## Part Rule
 
@@ -16,3 +17,7 @@ If a part starts carrying a stable reusable practice with inputs, outputs,
 risks, examples, and validation, route the practice bundle into `techniques/`.
 Leave this package as the mechanics layer that explains how Growth-cycle
 pressure moved.
+
+Use `stage-technique-anchors` before extracting or redrafting Growth-cycle
+practice. Existing technique bundles stay the first route when they already own
+the atomic move.

--- a/mechanics/growth-cycle/PROVENANCE.md
+++ b/mechanics/growth-cycle/PROVENANCE.md
@@ -16,6 +16,12 @@ source-to-active accounting, and its current raw inventory is empty.
 | Pre-split flat `QUESTBOOK_TECHNIQUE_INTEGRATION.md` | [parts/questbook-integration](parts/questbook-integration/README.md) | Questbook remains a deferred-obligation route, not a donor backlog. |
 | Pre-split flat `REVIEWED_CLOSEOUT_PROMOTION_READINESS_INCUBATION.md` | [parts/promotion-readiness-incubation](parts/promotion-readiness-incubation/README.md) | Reviewed closeout survivors remain incubation pressure, not canonical technique bundles. |
 
+## Center Stage Bridge
+
+| Context source | Current active home | Preservation note |
+|---|---|---|
+| AoA-center Growth Cycle `PARTS.md`, `OWNER_MAP.md`, `OWNER_REQUESTS.md`, and `docs/GROWTH_CYCLE_LAW.md` | [parts/stage-technique-anchors](parts/stage-technique-anchors/README.md) | Center stage order is used as route context only; existing technique bundles own reusable practice, and stronger owners keep implementation, proof, memory, runtime, route, stats, playbook, and owner-acceptance authority. |
+
 ## AoA Center Relation
 
 `Agents-of-Abyss` owns Growth Cycle stage law, owner split, and request packet

--- a/mechanics/growth-cycle/README.md
+++ b/mechanics/growth-cycle/README.md
@@ -83,6 +83,8 @@ matters. Stable reusable practice moves through `techniques/**/TECHNIQUE.md`.
   questbook route into technique hardening work.
 - [Promotion Readiness Incubation](parts/promotion-readiness-incubation/README.md):
   incubation route for technique-shaped survivors from reviewed closeout.
+- [Stage Technique Anchors](parts/stage-technique-anchors/README.md): map AoA
+  Growth Cycle stages to existing technique bundles and local hold lanes.
 
 Growth-cycle surfaces may keep obligations and mastery-shaped readings visible.
 They do not create achievement authority or bypass promotion review.

--- a/mechanics/growth-cycle/ROADMAP.md
+++ b/mechanics/growth-cycle/ROADMAP.md
@@ -6,10 +6,13 @@ commitment and not a source ledger.
 ## Next Passes
 
 1. Decide whether `promotion-readiness-incubation` has repeated enough across
-   reviewed routes to extract a real technique bundle.
+   reviewed routes to extract a real technique bundle. Use
+   `stage-technique-anchors` first so the candidate stays distinct from donor
+   harvest, owner placement, quest promotion, and progression-lift anchors.
 2. Check whether feat-card reader surfaces need a generated manifest or should
    remain examples until stronger evidence exists.
-3. Reconcile quest owner surfaces after generated quest catalog rebuilds.
+3. Reconcile quest owner surfaces after generated quest catalog rebuilds and
+   keep quest promotion distinct from technique canon promotion.
 4. Preserve any discovered raw wave/source material in `legacy/raw/` and keep
    `legacy/INDEX.md`, `legacy/DISTILLATION_LOG.md`, and `PROVENANCE.md`
    aligned.

--- a/mechanics/growth-cycle/parts/README.md
+++ b/mechanics/growth-cycle/parts/README.md
@@ -6,6 +6,7 @@ Active local parts:
 - [Technique Feat Model](technique-feat-model/README.md)
 - [Questbook Integration](questbook-integration/README.md)
 - [Promotion Readiness Incubation](promotion-readiness-incubation/README.md)
+- [Stage Technique Anchors](stage-technique-anchors/README.md)
 
 These parts keep technique-layer growth pressure legible. They do not own AoA
 Growth Cycle stage law, skill execution, proof verdicts, memory canon, runtime

--- a/mechanics/growth-cycle/parts/stage-technique-anchors/README.md
+++ b/mechanics/growth-cycle/parts/stage-technique-anchors/README.md
@@ -1,0 +1,62 @@
+# Stage Technique Anchors
+
+This part maps AoA Growth Cycle stages to existing `aoa-techniques` bundles and
+local hold lanes.
+
+Use it when Growth-cycle pressure appears and the question is whether the next
+move is already covered by a technique, still belongs in a local mechanics
+part, or must route to a stronger owner.
+
+It does not change bundle status. Canonical or promoted meaning remains inside
+each `techniques/**/TECHNIQUE.md` file.
+
+## Stage Anchor Map
+
+| AoA center stage | Local Growth-cycle route | Existing technique anchor | Boundary |
+|---|---|---|---|
+| checkpoint intake | input only; keep checkpoint evidence provisional | [structured-handoff-before-compaction](../../../../techniques/agent-workflows/structured-handoff-before-compaction/TECHNIQUE.md), [receipt-confirmed-handoff-packet](../../../../techniques/agent-workflows/receipt-confirmed-handoff-packet/TECHNIQUE.md), [git-verified-handoff-claims](../../../../techniques/agent-workflows/git-verified-handoff-claims/TECHNIQUE.md) | `mechanics/checkpoint`, `aoa-sdk`, and `aoa-skills` own checkpoint controls and bridge execution. |
+| reviewed closeout chain | [promotion-readiness-incubation](../promotion-readiness-incubation/README.md) only after review | [harvest-packet-contract](../../../../techniques/agent-workflows/harvest-packet-contract/TECHNIQUE.md), [session-donor-harvest](../../../../techniques/agent-workflows/session-donor-harvest/TECHNIQUE.md) | A closeout note is lower-authority until reviewed; the packet is not promotion proof. |
+| donor harvest | [mastery-harvest](../mastery-harvest/README.md) and promotion-readiness incubation | [session-donor-harvest](../../../../techniques/agent-workflows/session-donor-harvest/TECHNIQUE.md), [harvest-packet-contract](../../../../techniques/agent-workflows/harvest-packet-contract/TECHNIQUE.md), [owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md) | Donor harvest names candidate units and owner hints, not final technique truth. |
+| progression lift | [technique-feat-model](../technique-feat-model/README.md) as derived reader support | [progression-evidence-lift](../../../../techniques/agent-workflows/progression-evidence-lift/TECHNIQUE.md), [multi-axis-quest-overlay](../../../../techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md) | Progression and feat language stays descriptive; no rank, score, or owner acceptance. |
+| route forks | questbook integration or hold, depending on the fork | [decision-fork-cards](../../../../techniques/agent-workflows/decision-fork-cards/TECHNIQUE.md), [owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md), [nearest-wrong-target-rejection](../../../../techniques/agent-workflows/nearest-wrong-target-rejection/TECHNIQUE.md) | Fork cards do not choose owner truth unless a bounded owner verdict is actually made. |
+| automation opportunity | route away unless the reusable core is a technique candidate | [automation-fit-matrix](../../../../techniques/agent-workflows/automation-fit-matrix/TECHNIQUE.md), [human-loop-to-seed-lift](../../../../techniques/agent-workflows/human-loop-to-seed-lift/TECHNIQUE.md), [approval-sensitivity-check](../../../../techniques/agent-workflows/approval-sensitivity-check/TECHNIQUE.md) | Automation fit is descriptive and cannot activate hidden schedulers, hooks, runtime, or skills. |
+| diagnosis gate | technique hardening or owner diagnosis only after reviewed friction exists | [diagnosis-from-reviewed-evidence](../../../../techniques/agent-workflows/diagnosis-from-reviewed-evidence/TECHNIQUE.md) | Diagnosis is read-only and does not repair or prove the cause. |
+| repair cycle | questbook integration or technique hardening after diagnosis | [repair-shape-from-diagnosis](../../../../techniques/agent-workflows/repair-shape-from-diagnosis/TECHNIQUE.md), [checkpoint-bound-self-repair](../../../../techniques/agent-workflows/checkpoint-bound-self-repair/TECHNIQUE.md) | Repair shape stays smaller than playbook rollout and behind checkpoint posture when needed. |
+| quest promotion | [questbook-integration](../questbook-integration/README.md) | [quest-unit-promotion-review](../../../../techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md), [multi-axis-quest-overlay](../../../../techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md) | A quest remains a durable obligation until owner evidence supports another surface. |
+| owner followthrough | request receipt, owner route, or hold | [owner-layer-triage](../../../../techniques/agent-workflows/owner-layer-triage/TECHNIQUE.md), [local-pattern-adoption-gate](../../../../techniques/agent-workflows/local-pattern-adoption-gate/TECHNIQUE.md), [skill-proposal-handoff-packet](../../../../techniques/agent-workflows/skill-proposal-handoff-packet/TECHNIQUE.md) | Owner followthrough is not owner acceptance, proof, memory canon, or execution. |
+
+## How To Use
+
+1. Name the AoA center stage signal.
+2. Check whether an existing technique anchor already owns the reusable move.
+3. If an anchor exists, open that bundle rather than adding doctrine here.
+4. If the signal is only local route pressure, update the owning Growth-cycle
+   part and keep it mechanics-only.
+5. If the signal needs hooks, skills, proof, memory, runtime, role, route,
+   playbook, stats, seed, or owner acceptance, route to the stronger owner.
+6. Record a quest only when the obligation survives the current bounded change.
+
+## Open Gaps
+
+- `promotion-readiness-incubation` still has no standalone technique bundle for
+  "promotion-readiness discrimination." The existing anchors cover donor
+  harvest, owner placement, progression, diagnosis, repair, automation, and
+  quest promotion, but not the specific decision of when a promoted technique
+  is ready for canonical review.
+- The feat-card reader model remains an example-level local surface. Do not add
+  generated feat manifests until there is a real reader need beyond this repo.
+- Checkpoint intake remains checkpoint-owned. Growth-cycle may consume
+  reviewed checkpoint evidence, but it should not become a second checkpoint
+  mechanic.
+
+## Stop-lines
+
+- no achievement authority
+- no permanent rank or universal progression score
+- no hidden scheduler or autonomous self-repair
+- no proof verdicts before `aoa-evals`
+- no memory canon before `aoa-memo`
+- no runtime export or activation before `abyss-stack`
+- no executable workflow truth before `aoa-skills`
+- no owner acceptance without owner-local receipt
+- no automatic technique promotion

--- a/tests/test_growth_cycle_mechanics_topology.py
+++ b/tests/test_growth_cycle_mechanics_topology.py
@@ -23,6 +23,7 @@ PART_LOCAL_GROWTH_CYCLE_READMES = (
     "mechanics/growth-cycle/parts/technique-feat-model/README.md",
     "mechanics/growth-cycle/parts/questbook-integration/README.md",
     "mechanics/growth-cycle/parts/promotion-readiness-incubation/README.md",
+    "mechanics/growth-cycle/parts/stage-technique-anchors/README.md",
 )
 
 OLD_FLAT_GROWTH_CYCLE_FILES = (
@@ -57,10 +58,34 @@ class GrowthCycleMechanicsTopologyTestCase(unittest.TestCase):
             "technique-feat-model",
             "questbook-integration",
             "promotion-readiness-incubation",
+            "stage-technique-anchors",
         ):
             with self.subTest(part_name=part_name):
                 self.assertIn(part_name, parts)
                 self.assertIn(part_name, provenance)
+
+    def test_growth_cycle_stage_anchors_name_existing_bundles_and_gaps(self) -> None:
+        anchors = (
+            REPO_ROOT
+            / "mechanics"
+            / "growth-cycle"
+            / "parts"
+            / "stage-technique-anchors"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for required in (
+            "session-donor-harvest",
+            "progression-evidence-lift",
+            "automation-fit-matrix",
+            "diagnosis-from-reviewed-evidence",
+            "repair-shape-from-diagnosis",
+            "quest-unit-promotion-review",
+            "promotion-readiness discrimination",
+            "no automatic technique promotion",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, anchors)
 
     def test_growth_cycle_stays_outside_direct_orq_lane(self) -> None:
         receipts = (REPO_ROOT / "mechanics" / "REQUEST_RECEIPTS.md").read_text(
@@ -73,6 +98,7 @@ class GrowthCycleMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("### [growth-cycle](growth-cycle/README.md)", non_orq_section)
         self.assertIn("Current status: `candidate-only`", non_orq_section)
         self.assertIn("no\n  direct `ORQ-GROWTHCYCLE-TECHNIQUES-*` request", non_orq_section)
+        self.assertIn("Stage Technique Anchors", non_orq_section)
 
     def test_growth_cycle_reference_paths_point_to_part_local_homes(self) -> None:
         expected_paths = (


### PR DESCRIPTION
## Summary
- add a Growth-cycle stage technique anchor part
- map AoA center Growth Cycle stages to existing technique bundles and local hold lanes
- update Growth-cycle route surfaces, request receipts, and topology tests

## Validation
- python -m unittest tests.test_growth_cycle_mechanics_topology
- python scripts/validate_repo.py
- python -m unittest discover -s tests

## Gate review
- approval gate: user requested commit/push/merge; docs/test-only branch is safe to publish through PR
- dry run: diff, topology tests, repo validator, and unittest discover passed before push
- sanitized share: no logs, secrets, private runtime config, or raw source receipts were published