### PR TITLE
Add second kind ambiguity review pack

### DIFF
--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,33 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Second kind ambiguity review pack
+
+Changed:
+
+- added
+  [second-kind-ambiguity-review-pack](parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md)
+  as the updated-audit read after the first shortlist remap wave closed
+- kept repeated audit candidates as review holds where direct bundle reading
+  still supports `guardrail`, `lift`, or `assessment`
+- routed `AOA-T-0054` to a destination check against `handoff`, `workflow`, and
+  `recovery` before any frontmatter change
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique frontmatter changed
+- no `kind` value was added, removed, or renamed
+- no technique status, domain, owner, relation, or evidence surface changed
+- no broad classification migration was claimed
+
 ## 2026-05-04 - AOA-T-0052 kind remap
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -28,8 +28,10 @@
    kind ambiguity direct-read review are now landed. The first shortlist remap
    wave moved `AOA-T-0085` from `artifact` to `lift`, `AOA-T-0005` from
    `guardrail` to `workflow`, and `AOA-T-0052` from `handoff` to `workflow`.
-   The next honest pass is a fresh kind ambiguity read over the updated audit
-   before any further frontmatter change.
+   The second kind ambiguity review pack is now landed. The next honest pass is
+   an `AOA-T-0054` destination check against `handoff`, `workflow`, and
+   `recovery`; keep current frontmatter unless that check proves a stronger
+   destination.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -20,6 +20,8 @@ permission slip to remap techniques automatically.
 - topology scout review pack: landed as a human review layer, not schema truth
 - kind ambiguity review pack: landed from direct bundle reading, not remap
   authority
+- second kind ambiguity review pack: landed as the updated-audit read; it holds
+  old false positives and routes `AOA-T-0054` to a destination check
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -37,6 +39,7 @@ permission slip to remap techniques automatically.
 | [Technique Family Scout](../../../../reports/technique_family_scout.md) | generated family counts and likely clusters | automatic frontmatter migration authority |
 | [Kind Ambiguity Audit](../../../../reports/kind_ambiguity_audit.md) | tie-break seams that deserve human review | automatic remap authority |
 | [First Kind Ambiguity Review Pack](reviews/first-kind-ambiguity-review-pack.md) | direct-read shortlist for later narrow remap work | frontmatter mutation, new kind authority, or status change |
+| [Second Kind Ambiguity Review Pack](reviews/second-kind-ambiguity-review-pack.md) | updated-audit read that routes `AOA-T-0054` to a `handoff` / `workflow` / `recovery` destination check | frontmatter mutation or proof that `AOA-T-0054` must move |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -87,8 +90,10 @@ It should start with one bounded slice:
 
 ## Next Honest Move
 
-Use the landed kind ambiguity review pack to choose one narrow remap wave. The
-first remaps landed for `AOA-T-0085` (`artifact` to `lift`) and `AOA-T-0005`
-(`guardrail` to `workflow`), and the final shortlist remap landed for
-`AOA-T-0052` (`handoff` to `workflow`). The next move is a fresh kind ambiguity
-read over the updated audit before choosing any further frontmatter candidate.
+Use the landed second kind ambiguity review pack before any further frontmatter
+candidate. The first remaps landed for `AOA-T-0085` (`artifact` to `lift`) and
+`AOA-T-0005` (`guardrail` to `workflow`), and the final shortlist remap landed
+for `AOA-T-0052` (`handoff` to `workflow`). The next move is a narrow
+`AOA-T-0054` destination check against `handoff`, `workflow`, and `recovery`.
+That check may still keep current `handoff`; do not remap from the review pack
+alone.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -7,5 +7,6 @@ Current reviews:
 
 - [first-topology-scout-review-pack](first-topology-scout-review-pack.md)
 - [first-kind-ambiguity-review-pack](first-kind-ambiguity-review-pack.md)
+- [second-kind-ambiguity-review-pack](second-kind-ambiguity-review-pack.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md
@@ -1,0 +1,70 @@
+# Second Kind Ambiguity Review Pack
+
+Status: review-pack-landed, no frontmatter remap.
+
+This packet is the fresh read after the first kind ambiguity shortlist closed.
+It starts from the updated `reports/kind_ambiguity_audit.md`, then checks the
+remaining pressure against direct bundle text, the kind registry, and the first
+review pack.
+
+It does not change frontmatter and does not authorize a broad remap wave.
+
+## Source Packet
+
+- updated `reports/kind_ambiguity_audit.md`
+- [Technique Kind Registry](../../../../../config/technique_kind_registry.yaml)
+- [Technique Kind Guide](../../../../../docs/TECHNIQUE_KIND_GUIDE.md)
+- [Technique Topology Scout](../../../../../reports/technique_topology_scout.md)
+- [First Kind Ambiguity Review Pack](first-kind-ambiguity-review-pack.md)
+
+## Verdict
+
+The updated audit is cleaner after the landed `AOA-T-0085`, `AOA-T-0005`, and
+`AOA-T-0052` corrections, but it still repeats several already-reviewed false
+positives. Those should stay held unless new bundle text changes the center of
+gravity.
+
+The only fresh pressure point is `AOA-T-0054`
+`compaction-resilient-skill-loading`. The audit frames it as `handoff` vs
+`workflow`, but direct reading exposes a third plausible destination:
+`recovery`. The bundle is about bounded skill availability after context
+compaction, which is continuation across loss, not an ordinary steady-state work
+loop.
+
+Next move: run one destination check for `AOA-T-0054` against `handoff`,
+`workflow`, and `recovery`. Do not remap it from this packet alone.
+
+## Direct Reads
+
+| Technique | Current kind | Audit pressure | Review result |
+|---|---:|---|---|
+| [AOA-T-0054](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/TECHNIQUE.md) | `handoff` | candidate remap to `workflow` | Hold for a destination check. The bundle centers post-compaction skill-availability recovery and resume. Workflow steps exist, but the normal-path loss makes `recovery` a real third candidate beside `handoff` and `workflow`. |
+| [AOA-T-0028](../../../../../techniques/agent-workflows/confirmation-gated-mutating-action/TECHNIQUE.md) | `guardrail` | candidate remap to `workflow` | Keep `guardrail`. The confirmation seam is still the center; procedure protects the gate. |
+| [AOA-T-0093](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md) | `guardrail` | candidate remap to `workflow` | Keep `guardrail`. Recommendation truth vs host executability is boundary posture, not a work loop. |
+| [AOA-T-0091](../../../../../techniques/agent-workflows/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md) | `guardrail` | revisit later | Keep `guardrail` for now. Ingress is procedural, but `must_confirm` and `blocked_actions` remain the reusable contract. |
+| [AOA-T-0068](../../../../../techniques/agent-workflows/fail-closed-evidence-gate/TECHNIQUE.md) | `guardrail` | keep current kind | Keep `guardrail`. Non-allow blocking before mutation is the center. |
+| [AOA-T-0075](../../../../../techniques/agent-workflows/session-donor-harvest/TECHNIQUE.md) | `lift` | candidate remap to `artifact` | Keep `lift`. The donor pack is a bounded derived surface from reviewed evidence, not primary artifact authority. |
+| [AOA-T-0008](../../../../../techniques/evaluation/published-summary-remediation-snapshot/TECHNIQUE.md) | `lift` | candidate remap to `artifact` | Keep `lift`. It derives a read-only remediation snapshot from already published summaries. |
+| [AOA-T-0088](../../../../../techniques/agent-workflows/approval-sensitivity-check/TECHNIQUE.md) | `assessment` | revisit later against `validation` | Keep `assessment`. The output is an approval-burden classification and downgrade route, not proof or permission. |
+| [AOA-T-0089](../../../../../techniques/agent-workflows/quest-unit-promotion-review/TECHNIQUE.md) | `assessment` | revisit later against `validation` | Keep `assessment`. The output is owner-placement decision support, not validation proof and not promotion completion. |
+
+## Boundary Notes
+
+- The first shortlist remap wave is closed. `AOA-T-0085`, `AOA-T-0005`, and
+  `AOA-T-0052` already landed as bounded frontmatter corrections.
+- Repeated audit candidates are now review holds, not automatic next remaps.
+- `AOA-T-0054` should be read with the registry definition of `recovery`, not
+  only with the audit's `handoff` vs `workflow` tie-break.
+- A destination check may still keep `AOA-T-0054` as `handoff`; the point is to
+  name the real fork before touching bundle frontmatter.
+
+## Next Honest Move
+
+Perform a narrow `AOA-T-0054` destination check:
+
+1. read the bundle, example, checks, and notes again;
+2. compare the primary reusable object against `handoff`, `workflow`, and
+   `recovery`;
+3. update frontmatter only if the destination check proves a stronger fit than
+   current `handoff`;
+4. add a decision note only if a public kind correction lands.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -87,6 +87,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/README.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-topology-scout-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-kind-ambiguity-review-pack.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -555,6 +556,41 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Keep `assessment`", review)
         self.assertIn("Do not change frontmatter from this review alone", review)
         self.assertIn("fresh kind ambiguity read", review)
+
+    def test_second_kind_ambiguity_review_pack_routes_0054_without_remap(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "second-kind-ambiguity-review-pack.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Second Kind Ambiguity Review Pack", review)
+        self.assertIn("updated `reports/kind_ambiguity_audit.md`", review)
+        self.assertIn("does not change frontmatter", review)
+        self.assertIn("`AOA-T-0054`", review)
+        self.assertIn("compaction-resilient-skill-loading", review)
+        self.assertIn("`handoff`", review)
+        self.assertIn("`workflow`", review)
+        self.assertIn("`recovery`", review)
+        self.assertIn("destination check", review)
+        self.assertIn("first shortlist remap wave is closed", review)
+        self.assertIn("Keep `guardrail`", review)
+        self.assertIn("Keep `lift`", review)
+        self.assertIn("Keep `assessment`", review)
+        self.assertIn("Second Kind Ambiguity Review Pack", ingress)
+        self.assertIn("`AOA-T-0054`", ingress)
 
     def test_0085_kind_remap_landed_without_status_change(self) -> None:
         catalog = json.loads(


### PR DESCRIPTION
## Summary
- add the second kind ambiguity review pack for the updated audit pass
- route AOA-T-0054 to a narrow handoff/workflow/recovery destination check without changing frontmatter
- update Distillation ingress, roadmap, landing log, and topology tests

## Verification
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- git diff --check
- public-share guard plus manual approval/dry-run/sanitization review