### PR TITLE
[codex] Add post-0054 kind audit hold review

### DIFF
--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,34 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Post-0054 kind-audit hold review
+
+Changed:
+
+- added
+  [post-0054-kind-audit-hold-review](parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md)
+  as the explicit close of the current kind remap lane
+- classified remaining generated audit pressure as already-reviewed holds or
+  tie-break calibration rather than fresh remap candidates
+- updated the technique reform ingress packet and Distillation roadmap so the
+  next route is family shelf review before frontmatter, tree, or schema work
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique frontmatter changed
+- no `kind` value was added, removed, or renamed
+- no technique status, domain, owner, relation, or evidence surface changed
+- no family, tree, schema, or path migration was claimed
+
 ## 2026-05-04 - AOA-T-0054 kind remap
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -28,10 +28,12 @@
    kind ambiguity direct-read review are now landed. The first shortlist remap
    wave moved `AOA-T-0085` from `artifact` to `lift`, `AOA-T-0005` from
    `guardrail` to `workflow`, and `AOA-T-0052` from `handoff` to `workflow`.
-   The second kind ambiguity review pack and `AOA-T-0054` destination check are
-   now landed; `AOA-T-0054` moved from `handoff` to `recovery`. The next honest
-   pass is an updated kind-audit hold review before choosing any further
-   frontmatter candidate.
+   The second kind ambiguity review pack, `AOA-T-0054` destination check, and
+   post-`AOA-T-0054` kind-audit hold review are now landed; `AOA-T-0054` moved
+   from `handoff` to `recovery`, and the remaining generated kind pressure is
+   held as stale false-positive or calibration evidence. The next honest pass
+   is family shelf review before any further frontmatter candidate, tree
+   projection, or schema migration.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -25,6 +25,8 @@ permission slip to remap techniques automatically.
   old false positives and routes `AOA-T-0054` to a destination check
 - `AOA-T-0054` destination check: landed as a bounded correction from
   `handoff` to `recovery`
+- post-`AOA-T-0054` kind-audit hold review: landed as the close of the current
+  remap lane; no new frontmatter candidate chosen
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -45,6 +47,7 @@ permission slip to remap techniques automatically.
 | [First Kind Ambiguity Review Pack](reviews/first-kind-ambiguity-review-pack.md) | direct-read shortlist for later narrow remap work | frontmatter mutation, new kind authority, or status change |
 | [Second Kind Ambiguity Review Pack](reviews/second-kind-ambiguity-review-pack.md) | updated-audit read that routes `AOA-T-0054` to a `handoff` / `workflow` / `recovery` destination check | frontmatter mutation or proof that `AOA-T-0054` must move |
 | [AOA-T-0054 Kind Destination Check](reviews/0054-kind-destination-check.md) | direct-read destination verdict for `AOA-T-0054` from `handoff` toward `recovery` | schema migration, status promotion, or sibling-owner authority |
+| [Post-0054 Kind Audit Hold Review](reviews/post-0054-kind-audit-hold-review.md) | closes the current kind-audit remap lane and classifies remaining generated pressure as holds or calibration | frontmatter mutation, family promotion, tree migration, or proof of generated correctness |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -89,6 +92,7 @@ It should start with one bounded slice:
 - [ ] Read the atom contract and topology contract.
 - [ ] Read the kind registry and kind guide before proposing a `kind` change.
 - [ ] Read the family seed, family scout, and kind ambiguity audit.
+- [ ] Read the technique tree contract before proposing path migration.
 - [ ] Read the Agon frontier review and generated handoff lens for fresh
       topology pressure.
 - [ ] Choose one bounded reform slice and state what remains scout-only.
@@ -98,10 +102,11 @@ It should start with one bounded slice:
 
 ## Next Honest Move
 
-Use the landed `AOA-T-0054` destination check as the close of this remap lane.
-The first remaps landed for `AOA-T-0085` (`artifact` to `lift`) and
+Use the post-`AOA-T-0054` kind-audit hold review as the close of this remap
+lane. The first remaps landed for `AOA-T-0085` (`artifact` to `lift`) and
 `AOA-T-0005` (`guardrail` to `workflow`), the final first-shortlist remap
 landed for `AOA-T-0052` (`handoff` to `workflow`), and the second-pack
-destination check landed `AOA-T-0054` (`handoff` to `recovery`). The next move
-is an updated kind-audit hold review before choosing any further frontmatter
-candidate; do not recycle already-held false positives as automatic remaps.
+destination check landed `AOA-T-0054` (`handoff` to `recovery`). The remaining
+kind-audit pressure is now hold or calibration evidence. The next move is
+family shelf review before any further frontmatter candidate, tree projection,
+or schema migration.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -9,5 +9,6 @@ Current reviews:
 - [first-kind-ambiguity-review-pack](first-kind-ambiguity-review-pack.md)
 - [second-kind-ambiguity-review-pack](second-kind-ambiguity-review-pack.md)
 - [0054-kind-destination-check](0054-kind-destination-check.md)
+- [post-0054-kind-audit-hold-review](post-0054-kind-audit-hold-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md
@@ -1,0 +1,137 @@
+# Post-0054 Kind Audit Hold Review
+
+Status: review-pack-landed, remap lane closed, no frontmatter change.
+
+This packet closes the current `kind` remap lane after the landed
+[AOA-T-0054 destination check](0054-kind-destination-check.md).
+
+It starts from the current generated
+[Kind Ambiguity Audit](../../../../../reports/kind_ambiguity_audit.md), then
+compares the remaining pressure against prior direct-read review packs, landed
+kind corrections, the living kind registry, and bundle summaries. It does not
+change frontmatter and does not authorize any later bundle remap by itself.
+
+## Sources Read
+
+- current [Kind Ambiguity Audit](../../../../../reports/kind_ambiguity_audit.md)
+- [Technique Kind Registry](../../../../../config/technique_kind_registry.yaml)
+- [Technique Kind Guide](../../../../../docs/TECHNIQUE_KIND_GUIDE.md)
+- [First Kind Ambiguity Review Pack](first-kind-ambiguity-review-pack.md)
+- [Second Kind Ambiguity Review Pack](second-kind-ambiguity-review-pack.md)
+- [AOA-T-0054 Kind Destination Check](0054-kind-destination-check.md)
+- bundle frontmatter, summaries, and headings for every technique still named
+  by the generated audit
+
+## Verdict
+
+No new `kind` frontmatter candidate should be chosen from the current audit.
+
+The remaining `candidate remap` and `revisit later` cues are not fresh evidence.
+They are already-reviewed holds or calibration reads whose bundle centers still
+fit the current `kind`.
+
+The current remap lane is closed. Future reform should move to family shelf
+review and tree fitness before any additional kind-frontmatter candidate is
+chosen.
+
+## Closed Remaps
+
+These have already landed as bounded classification corrections with bundle
+frontmatter, generated surfaces, tests, route notes, and decision records moved
+together:
+
+| Technique | Landed correction | Current state |
+|---|---|---|
+| [AOA-T-0085](../../../../../techniques/agent-workflows/multi-axis-quest-overlay/TECHNIQUE.md) | `artifact` -> `lift` | closed |
+| [AOA-T-0005](../../../../../techniques/agent-workflows/new-intent-rollout-checklist/TECHNIQUE.md) | `guardrail` -> `workflow` | closed |
+| [AOA-T-0052](../../../../../techniques/agent-workflows/review-findings-compaction/TECHNIQUE.md) | `handoff` -> `workflow` | closed |
+| [AOA-T-0054](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/TECHNIQUE.md) | `handoff` -> `recovery` | closed |
+
+## Current Audit Disposition
+
+| Audit seam | Techniques | Hold disposition |
+|---|---|---|
+| `workflow` vs `guardrail` | `AOA-T-0028`, `AOA-T-0068`, `AOA-T-0091`, `AOA-T-0093`, `AOA-T-0049`, `AOA-T-0001` | No remap. `AOA-T-0028`, `AOA-T-0091`, and `AOA-T-0093` remain guardrail-centered; `AOA-T-0068`, `AOA-T-0049`, and `AOA-T-0001` remain calibration keeps. |
+| `validation` vs `assessment` | `AOA-T-0086`, `AOA-T-0076`, `AOA-T-0096`, `AOA-T-0088`, `AOA-T-0089` | No remap. `AOA-T-0088` and `AOA-T-0089` stay assessment holds because their outputs classify approval or owner-placement pressure; they do not prove correctness. |
+| `artifact` vs `lift` | `AOA-T-0044`, `AOA-T-0075`, `AOA-T-0008`, `AOA-T-0084`, `AOA-T-0085`, `AOA-T-0006` | No remap. `AOA-T-0075` and `AOA-T-0008` stay lift holds because their outputs are derived from stronger reviewed or published sources. |
+| `composition` vs `distribution` | `AOA-T-0027`, `AOA-T-0012`, `AOA-T-0024`, `AOA-T-0029`, `AOA-T-0035`, `AOA-T-0013` | No remap. The current audit already keeps all six; the seam is useful as tie-break calibration only. |
+| `handoff` vs `workflow` | `AOA-T-0062`, `AOA-T-0057`, `AOA-T-0058`, `AOA-T-0056`, `AOA-T-0060`, `AOA-T-0059` | No remap. After `AOA-T-0054` moved to `recovery`, the remaining handoff entries still center checkpoint, receipt, mailbox, session opening, git-verified continuation, or episode boundaries. |
+
+## Hold Notes
+
+### Guardrail Holds
+
+`AOA-T-0028`, `AOA-T-0091`, and `AOA-T-0093` still include ordered steps, but
+the reusable object is a stop, gate, or boundary:
+
+- `AOA-T-0028` keeps one explicit confirmation seam before mutation.
+- `AOA-T-0091` couples workspace ingress with a mutation guard and keeps
+  `must_confirm` / `blocked_actions` posture central.
+- `AOA-T-0093` preserves the boundary between recommendation truth and host
+  actionability.
+
+These are not next `workflow` candidates unless the bundle text changes enough
+that the gate becomes subordinate to a work loop.
+
+### Assessment Holds
+
+`AOA-T-0088` and `AOA-T-0089` remain `assessment`.
+
+- `AOA-T-0088` classifies approval, rollback, and self-change sensitivity.
+- `AOA-T-0089` emits a bounded promotion verdict for a repeated reviewed quest
+  unit.
+
+Both can reference proof-like inputs, but their reusable outputs are decision
+support, not validation proof.
+
+### Lift Holds
+
+`AOA-T-0075` and `AOA-T-0008` remain `lift`.
+
+- `AOA-T-0075` distills a reviewed session artifact into a bounded donor pack.
+- `AOA-T-0008` turns published summaries into a remediation snapshot.
+
+Their outputs may be durable, but they remain secondary surfaces derived from
+stronger sources.
+
+### Handoff Calibration
+
+After `AOA-T-0054` moved to `recovery`, the remaining handoff audit entries are
+not a queue. They are useful boundary calibration:
+
+- packets and receipts stay `handoff`
+- mailbox and channel continuation stay `handoff`
+- opening rituals and git-verified claims stay `handoff` while continuation is
+  the primary seam
+- episode loops stay `handoff` when checkpoint, continue, stop, or escalate
+  posture is the reusable object
+
+## Reopen Rule
+
+Reopen kind remap work only if at least one of these is true:
+
+- a bundle is edited and its center of gravity changes
+- family shelf review exposes a repeated mismatch that direct reading confirms
+- tree projection review shows path pressure that cannot be explained by
+  `family` or facets alone
+- a new generated audit after source changes names a fresh candidate not already
+  held here
+
+Do not reopen a candidate merely because the generated audit still says
+`candidate remap` or `revisit later`.
+
+## Stop Lines
+
+- Do not change frontmatter from this hold review.
+- Do not add, remove, or rename any `kind` value.
+- Do not treat stale generated candidates as fresh remap pressure.
+- Do not use `family` as hidden kind authority.
+- Do not begin tree migration from kind-audit pressure alone.
+
+## Next Honest Move
+
+Move to family shelf review.
+
+That review should ask which scout families are stable enough to become shelves
+in the future tree, which families need split/merge/rename pressure, and which
+families are still only generated grouping hints.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -89,6 +89,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-kind-ambiguity-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/0054-kind-destination-check.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -695,6 +696,50 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`workflow`", decision)
         self.assertIn("Remap `AOA-T-0054` from `handoff` to `recovery`", destination_check)
         self.assertIn("`AOA-T-0057`", destination_check)
+
+    def test_post_0054_kind_audit_hold_review_closes_remap_lane(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "post-0054-kind-audit-hold-review.md"
+        ).read_text(encoding="utf-8")
+        roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Post-0054 Kind Audit Hold Review", review)
+        self.assertIn("No new `kind` frontmatter candidate", review)
+        self.assertIn("remap lane closed", review)
+        self.assertIn("family shelf review", review)
+        self.assertIn("Do not reopen a candidate merely because", review)
+        self.assertIn("`workflow` vs `guardrail`", review)
+        self.assertIn("`validation` vs `assessment`", review)
+        self.assertIn("`artifact` vs `lift`", review)
+        self.assertIn("`handoff` vs `workflow`", review)
+        self.assertIn("post-0054-kind-audit-hold-review", reviews_index)
+        self.assertIn("Post-0054 Kind Audit Hold Review", ingress)
+        self.assertIn("family shelf review", roadmap)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add a post-AOA-T-0054 kind-audit hold review that closes the current remap lane
- classify remaining generated kind pressure as reviewed holds or calibration rather than fresh frontmatter candidates
- update Distillation ingress, roadmap, landing log, review index, and topology tests for the next family shelf review route

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py