### PR TITLE
[codex] Add family shelf review pack

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 | Field | Direction |
 |---|---|
 | Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles while leaving the current domain-folder layout in place. |
-| Next honest move | Build a non-authoritative tree projection over the current `107` bundles, review family shelves for tree fitness, and pilot one bounded subtree before any broad path migration. |
+| Next honest move | Use the landed family shelf review pack to build a non-authoritative tree projection over the current `107` bundles, then pilot one bounded subtree before any broad path migration. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -184,8 +184,8 @@ trigger is real.
 
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
-- Add a generated tree projection only after the kind-audit hold review and
-  family shelf review show a stable enough trunk/shelf draft.
+- Add a generated tree projection as the next bounded reform slice now that
+  the kind-audit hold review and family shelf review have landed.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -164,11 +164,10 @@ migration wave lands.
 
 The next reform slice should:
 
-1. close the current kind-audit hold review
-2. review family shelves for tree fitness
-3. add a non-authoritative tree projection over all current bundles
-4. choose one pilot shelf or trunk for direct-read migration review
-5. only then move files, update links, and regenerate derived surfaces
+1. use the landed kind-audit hold review and family shelf review as input
+2. add a non-authoritative tree projection over all current bundles
+3. choose one pilot shelf or trunk for direct-read migration review
+4. only then move files, update links, and regenerate derived surfaces
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,36 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Family shelf review pack
+
+Changed:
+
+- added
+  [first-family-shelf-review-pack](parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md)
+  as the review layer over all `26` scout families before tree projection
+- sorted families into stable shelf candidates, boundary-watch families,
+  split pressure, and singleton hold posture without promoting `family` into
+  frontmatter
+- updated the technique reform ingress packet and Distillation roadmap so the
+  next route is a non-authoritative tree projection over all `107` bundles
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no technique frontmatter changed
+- no `family`, `tree_path`, or scout topology axis became required schema truth
+- no `domain`, `kind`, status, relation, owner, or generated catalog authority
+  changed
+
 ## 2026-05-04 - Post-0054 kind-audit hold review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -31,9 +31,10 @@
    The second kind ambiguity review pack, `AOA-T-0054` destination check, and
    post-`AOA-T-0054` kind-audit hold review are now landed; `AOA-T-0054` moved
    from `handoff` to `recovery`, and the remaining generated kind pressure is
-   held as stale false-positive or calibration evidence. The next honest pass
-   is family shelf review before any further frontmatter candidate, tree
-   projection, or schema migration.
+   held as stale false-positive or calibration evidence.
+   The first family shelf review pack is also landed; the next honest pass is
+   a non-authoritative tree projection over all `107` bundles before any
+   further frontmatter candidate, path migration, or schema migration.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -27,6 +27,8 @@ permission slip to remap techniques automatically.
   `handoff` to `recovery`
 - post-`AOA-T-0054` kind-audit hold review: landed as the close of the current
   remap lane; no new frontmatter candidate chosen
+- family shelf review: landed as a tree-fitness review over `26` scout
+  families; `family` remains scout-only and the corpus tree remains unmigrated
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -48,6 +50,7 @@ permission slip to remap techniques automatically.
 | [Second Kind Ambiguity Review Pack](reviews/second-kind-ambiguity-review-pack.md) | updated-audit read that routes `AOA-T-0054` to a `handoff` / `workflow` / `recovery` destination check | frontmatter mutation or proof that `AOA-T-0054` must move |
 | [AOA-T-0054 Kind Destination Check](reviews/0054-kind-destination-check.md) | direct-read destination verdict for `AOA-T-0054` from `handoff` toward `recovery` | schema migration, status promotion, or sibling-owner authority |
 | [Post-0054 Kind Audit Hold Review](reviews/post-0054-kind-audit-hold-review.md) | closes the current kind-audit remap lane and classifies remaining generated pressure as holds or calibration | frontmatter mutation, family promotion, tree migration, or proof of generated correctness |
+| [First Family Shelf Review Pack](reviews/first-family-shelf-review-pack.md) | reviews all `26` scout families for stable shelf candidates, boundary watch, split pressure, singleton holds, and trunk fitness | `family` frontmatter truth, path migration, schema change, or proof that the draft tree is final |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -61,12 +64,12 @@ A first reform pass may:
 - add tests that keep generated topology weaker than authored bundle meaning
 - add a decision note before any schema, template, or validator contract changes
 
-It should start with one bounded slice:
+It should continue one bounded slice at a time:
 
-1. `family` optional shelf review
-2. generated `capability_class` / `substrate` / `execution_profile` /
+1. `family` optional shelf review, now landed as review evidence only
+2. non-authoritative `tree_path` projection after family shelves are reviewed
+3. generated `capability_class` / `substrate` / `execution_profile` /
    `risk_posture` scout projection
-3. non-authoritative `tree_path` projection after family shelves are reviewed
 4. one kind tie-break review pack from `reports/kind_ambiguity_audit.md`
 5. relation topology guidance only after direct relations repeatedly help
    composition, conflict, sequence, or prerequisite routing
@@ -102,11 +105,9 @@ It should start with one bounded slice:
 
 ## Next Honest Move
 
-Use the post-`AOA-T-0054` kind-audit hold review as the close of this remap
-lane. The first remaps landed for `AOA-T-0085` (`artifact` to `lift`) and
-`AOA-T-0005` (`guardrail` to `workflow`), the final first-shortlist remap
-landed for `AOA-T-0052` (`handoff` to `workflow`), and the second-pack
-destination check landed `AOA-T-0054` (`handoff` to `recovery`). The remaining
-kind-audit pressure is now hold or calibration evidence. The next move is
-family shelf review before any further frontmatter candidate, tree projection,
-or schema migration.
+Use the first family shelf review pack as the close of the shelf-readiness
+pass. The current `26` scout families are now sorted into stable shelf
+candidates, boundary-watch families, split pressure, and singleton hold
+posture. The next move is a non-authoritative tree projection over all `107`
+bundles before any further frontmatter candidate, path migration, or schema
+migration.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -10,5 +10,6 @@ Current reviews:
 - [second-kind-ambiguity-review-pack](second-kind-ambiguity-review-pack.md)
 - [0054-kind-destination-check](0054-kind-destination-check.md)
 - [post-0054-kind-audit-hold-review](post-0054-kind-audit-hold-review.md)
+- [first-family-shelf-review-pack](first-family-shelf-review-pack.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md
@@ -1,0 +1,196 @@
+# First Family Shelf Review Pack
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Generated lens:
+[Technique Family Scout](../../../../../reports/technique_family_scout.md)
+and
+[Technique Family Scout JSON](../../../../../reports/technique_family_scout.json)
+
+Registry:
+[Technique Family Seed](../../../../../config/technique_family_seed.yaml)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: review-pack-landed, not frontmatter truth, not path migration.
+
+## Verdict
+
+The family scout is strong enough to feed the next non-authoritative tree
+projection, but not strong enough to become required frontmatter, generated
+truth, or automatic path migration authority.
+
+The current lens covers `107` techniques across `26` scout families. Those
+families already behave like future shelves: they are narrower than `domain`,
+broader than one `kind`, and useful for human browsing. The tree should use
+them as placement evidence, especially for the second path segment, while
+bundle frontmatter and authored technique meaning remain stronger than the
+scout assignment.
+
+This review does not add `family` to bundle frontmatter, does not move any
+bundle, does not change `domain`, `kind`, `status`, or relations, and does not
+claim that the draft trunks are final.
+
+## Boundary Map
+
+| Context | Owns | Does not own |
+|---|---|---|
+| bundle truth | one atomic technique move, current `domain`, current `kind`, local evidence, relations, status | generated family, future path, trunk acceptance |
+| scout family | semantic shelf pressure and clustering evidence | promotion status, quality score, automatic path move |
+| tree shelf | future browsable neighborhood under one trunk | the whole classification record |
+| tree trunk | durable practice district for the root tree | every substrate, capability, risk, or relation detail |
+| generated projection | reviewable proposed placement over all bundles | authored meaning or migration authority |
+
+The useful distinction is:
+
+- `family` answers which shelf the technique resembles.
+- `shelf` answers where a reader should browse in the future tree.
+- `trunk` answers the larger practice district.
+- `domain` and `kind` remain the current authoritative frontmatter axes.
+
+## Family Disposition
+
+| family | scout count | trunk candidate | shelf posture | note |
+|---|---:|---|---|---|
+| `agent-workflows-core` | `5` | `execution` | stable-shelf-candidate | Strong canonical backbone; good anchor, but path moves still need direct bundle reading. |
+| `intent-chain` | `2` | `execution` | small-shelf-candidate | Coherent enough to keep visible; too small to pilot alone. |
+| `docs-boundary` | `4` | `instruction` | stable-shelf-candidate | Clean public/document-role shelf with canonical support. |
+| `instruction-surface` | `7` | `instruction` | projection-pilot-candidate | Large enough and semantically clean enough for early tree projection review. |
+| `evaluation-chain` | `3` | `proof` | stable-shelf-candidate | Clear validation chain; keep separate from broad proof doctrine. |
+| `published-summary` | `4` | `proof` | stable-shelf-candidate | Canonical-heavy shelf around summary integrity and rendering. |
+| `skill-support` | `3` | `proof` | stable-shelf-candidate | Boundary/testing support shelf; watch overlap with `instruction` only by direct read. |
+| `kag-source-lift` | `8` | `knowledge-lift` | projection-pilot-candidate | Strong source-lift shelf; should not turn into KAG owner authority. |
+| `history-artifacts` | `6` | `history` | stable-shelf-candidate | Distinct enough to justify a durable history trunk. |
+| `runtime-truth-lifecycle` | `4` | `execution` | boundary-watch | Sits between execution and proof; projection should expose whether one shelf is enough. |
+| `capability-registry` | `3` | `instruction` | boundary-watch | May stay a shelf or merge with capability surfaces after projection. |
+| `capability-boundary` | `3` | `instruction` | boundary-watch | Semantically close to registry and skill discovery, but risk posture is distinct. |
+| `skill-discovery` | `2` | `instruction` | small-boundary-watch | Keep visible without pretending two bundles define a large shelf. |
+| `ready-work-graphs` | `3` | `execution` | stable-shelf-candidate | Clear planning/graph neighborhood. |
+| `review-compaction` | `3` | `continuity` | projection-pilot-candidate | Small, coherent, recently reviewed; a good pilot candidate for tree projection pressure. |
+| `handoff-continuation` | `7` | `continuity` | projection-pilot-candidate | Strong continuity shelf; should remain distinct from generic workflow. |
+| `tool-gateway` | `1` | `tool-use` | singleton-hold | Keep as a trunk signal, not as proof that a mature shelf exists. |
+| `approval-evidence` | `2` | `governance` | small-boundary-watch | Approval semantics matter; avoid merging into general governance too early. |
+| `review-evidence` | `3` | `proof` | boundary-watch | Review narrowing is not proof authority; projection should preserve that stop-line. |
+| `media-ingest` | `5` | `ingest` | projection-pilot-candidate | Clean ingest shelf and likely easy for readers to browse. |
+| `donor-harvest` | `4` | `continuity` | stable-shelf-candidate | Crosses lift, artifact, and handoff kinds without losing one neighborhood. |
+| `decision-routing` | `3` | `governance` | stable-shelf-candidate | Clear owner-routing shelf; keep separate from route policy ownership. |
+| `diagnosis-repair` | `4` | `recovery` | projection-pilot-candidate | Coherent bridge from assessment into recovery. |
+| `automation-governance` | `9` | `governance` | split-pressure | Largest scout family; likely needs split/merge review before pilot migration. |
+| `owner-truth-closeout` | `5` | `proof` | boundary-watch | Useful closeout shelf, but touches governance and publication posture. |
+| `antifragility-recovery` | `4` | `recovery` | stable-shelf-candidate | Distinct recovery shelf with validation-adjacent evidence. |
+
+## Stable Shelf Candidates
+
+These families are stable enough to appear as shelves in the next projection:
+
+- `agent-workflows-core`
+- `docs-boundary`
+- `instruction-surface`
+- `evaluation-chain`
+- `published-summary`
+- `skill-support`
+- `kag-source-lift`
+- `history-artifacts`
+- `ready-work-graphs`
+- `review-compaction`
+- `handoff-continuation`
+- `media-ingest`
+- `donor-harvest`
+- `decision-routing`
+- `diagnosis-repair`
+- `antifragility-recovery`
+
+This means "use as projection evidence", not "promote to frontmatter".
+
+## Boundary Watch
+
+These families should remain visible but require extra care in projection:
+
+- `runtime-truth-lifecycle` crosses execution, validation, and runtime posture.
+- `capability-registry`, `capability-boundary`, and `skill-discovery` may
+  become separate shelves or a tighter capability district after direct review.
+- `approval-evidence`, `review-evidence`, and `owner-truth-closeout` touch
+  proof, governance, approval, and publication semantics; they need stop-lines
+  kept explicit.
+- `intent-chain` is coherent but small.
+- `tool-gateway` is a singleton hold until more tool-use techniques land.
+
+## Split Pressure
+
+`automation-governance` should not be treated as a clean shelf just because it
+has the largest count.
+
+Its current `9` bundles include automation fit, seed routing, approval
+sensitivity, quest-unit promotion, wrong-target rejection, local adoption,
+skill-proposal handoff, retention, and obsolescence. Those are related, but the
+family may hide several future shelves:
+
+- automation fit and approval sensitivity
+- promotion boundary and nearest-wrong-target rejection
+- adoption, retention, and obsolescence
+- skill proposal handoff
+
+The next tree projection should mark this family as `hold` or
+`split-review-needed`, not as an accepted pilot shelf.
+
+## Trunk Readout
+
+The draft trunk map from the tree contract is still viable as a projection
+target.
+
+| trunk | likely shelves from this review | review posture |
+|---|---|---|
+| `execution` | `agent-workflows-core`, `intent-chain`, `ready-work-graphs`, `runtime-truth-lifecycle` | viable, with runtime boundary watch |
+| `instruction` | `docs-boundary`, `instruction-surface`, `capability-registry`, `capability-boundary`, `skill-discovery` | viable, with capability split/merge watch |
+| `proof` | `evaluation-chain`, `published-summary`, `skill-support`, `review-evidence`, `owner-truth-closeout` | viable, if review/proof/closeout stop-lines stay explicit |
+| `continuity` | `handoff-continuation`, `review-compaction`, `donor-harvest` | strong pilot trunk candidate |
+| `governance` | `approval-evidence`, `decision-routing`, `automation-governance` | viable, but automation needs split pressure |
+| `knowledge-lift` | `kag-source-lift` | viable as a narrow trunk if it stays technique-local |
+| `ingest` | `media-ingest` | viable as a narrow trunk |
+| `recovery` | `diagnosis-repair`, `antifragility-recovery` | viable and coherent |
+| `history` | `history-artifacts` | viable as a narrow trunk |
+| `tool-use` | `tool-gateway` | hold as a trunk signal until more shelves exist |
+
+## Projection Pilot Set
+
+The first tree projection should cover all `107` bundles, but the first
+human-read pilot after projection should probably come from one of these
+shelves:
+
+- `review-compaction`, because it is small, coherent, and recently touched by
+  the kind-audit closeout
+- `handoff-continuation`, because it has enough bundles to test a real shelf
+  without swallowing execution as a whole
+- `media-ingest`, because its current bundles are unusually clean as one ingest
+  neighborhood
+- `diagnosis-repair`, because it tests the assessment-to-recovery boundary
+- `instruction-surface`, because it tests a larger documentation/instruction
+  shelf without making `docs` a junk drawer
+
+Do not choose the pilot before the generated projection shows every bundle's
+current source path, proposed trunk, proposed shelf, proposed future path, and
+review status.
+
+## Stop Lines
+
+- Do not add `family` frontmatter from this review.
+- Do not move bundle directories from this review.
+- Do not make `tree_path` required frontmatter.
+- Do not treat stable shelf candidates as canonical status or quality score.
+- Do not collapse `domain`, `kind`, capability, substrate, execution profile,
+  risk posture, and relations into the tree.
+- Do not copy the mechanics package shape into technique leaves.
+- Do not let generated family assignment overrule direct bundle reading.
+
+## Next Honest Move
+
+Add a non-authoritative tree projection over all current bundles.
+
+That projection should map technique ID, current source path, proposed `trunk`,
+proposed `shelf`, proposed future path, and review status such as `candidate`,
+`hold`, `split-review-needed`, or `pilot-candidate`.
+
+Only after that projection is reviewed should the repo choose one bounded pilot
+shelf or trunk for direct-read migration review.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -90,6 +90,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/second-kind-ambiguity-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/0054-kind-destination-check.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -740,6 +741,80 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("post-0054-kind-audit-hold-review", reviews_index)
         self.assertIn("Post-0054 Kind Audit Hold Review", ingress)
         self.assertIn("family shelf review", roadmap)
+
+    def test_family_shelf_review_pack_prepares_tree_projection_without_migration(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "first-family-shelf-review-pack.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("First Family Shelf Review Pack", review)
+        self.assertIn("review-pack-landed", review)
+        self.assertIn("not frontmatter truth", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("`26` scout families", review)
+        self.assertIn("Stable Shelf Candidates", review)
+        self.assertIn("Boundary Watch", review)
+        self.assertIn("Split Pressure", review)
+        self.assertIn("singleton-hold", review)
+        self.assertIn("`automation-governance`", review)
+        self.assertIn("split-review-needed", review)
+        self.assertIn("non-authoritative tree projection", review)
+        self.assertIn("Do not add `family` frontmatter", review)
+        self.assertIn("Do not move bundle directories", review)
+        self.assertIn("proposed `trunk`", review)
+        self.assertIn("proposed `shelf`", review)
+        for trunk in (
+            "`execution`",
+            "`instruction`",
+            "`proof`",
+            "`continuity`",
+            "`governance`",
+            "`knowledge-lift`",
+            "`ingest`",
+            "`recovery`",
+            "`history`",
+            "`tool-use`",
+        ):
+            with self.subTest(trunk=trunk):
+                self.assertIn(trunk, review)
+
+        self.assertIn("first-family-shelf-review-pack", reviews_index)
+        self.assertIn("family shelf review: landed", ingress)
+        self.assertIn("non-authoritative tree projection", ingress)
+        self.assertIn("First Family Shelf Review Pack", ingress)
+        self.assertIn("family shelf review pack is also landed", distillation_roadmap)
+        self.assertIn("landed family shelf review pack", root_roadmap)
+        self.assertIn("landed kind-audit hold review and family shelf review", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary

- add the first family shelf review pack over all 26 scout families
- classify families as stable shelf candidates, boundary watch, split pressure, singleton hold, and projection pilot candidates
- update reform ingress, roadmaps, tree contract next path, landing log, and distillation topology coverage

## Validation

- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py

## Notes

No technique bundle paths, frontmatter, schema, generated authority, or status values changed.