### PR TITLE
[codex] Add review-compaction migration review

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 | Field | Direction |
 |---|---|
 | Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles while leaving the current domain-folder layout in place; `reports/technique_tree_projection.md` now gives a non-authoritative full-corpus placement projection. |
-| Next honest move | Run a direct-read migration review for the `review-compaction` shelf before moving any bundle paths. |
+| Next honest move | Run the first pilot migration for the accepted `review-compaction` shelf: move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, repair links, regenerate derived surfaces, and keep `tree_path` out of frontmatter. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -184,8 +184,9 @@ trigger is real.
 
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
-- Use the generated tree projection and first tree projection review pack to
-  review `review-compaction` as the first possible migration pilot.
+- Use the generated tree projection, first tree projection review pack, and
+  direct-read review to migrate `review-compaction` as the first pilot
+  migration before any broader tree move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -170,13 +170,22 @@ links, do not add `tree_path` frontmatter, and do not authorize path movement.
 
 ## Next Honest Build Path
 
+The current pilot review is
+[Review-Compaction Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md).
+The review-compaction direct-read review accepts the first pilot shelf.
+
+It accepts `review-compaction` as the first migration pilot without moving files
+or adding `tree_path` frontmatter.
+
 The next reform slice should:
 
 1. use the landed kind-audit hold review, family shelf review, generated tree
-   projection, and first tree projection review pack as input
-2. run a direct-read migration review for the `review-compaction` shelf
-3. only then move files, update links, and regenerate derived surfaces if the
-   pilot review proves the move is clearer than current placement
+   projection, first tree projection review pack, and review-compaction
+   direct-read review as input
+2. move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into
+   `techniques/continuity/review-compaction/`
+3. repair authored links, regenerate derived surfaces, and run the release
+   check before considering any broader tree migration
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,33 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Review-compaction direct-read migration review
+
+Changed:
+
+- added
+  [review-compaction-direct-read-migration-review](parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054`
+- accepted `review-compaction` as the first migration pilot while keeping the
+  review itself non-mutating
+- recorded the migration blast radius and the next exact pilot scope:
+  `techniques/continuity/review-compaction/`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python -m unittest discover -s tests
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no technique frontmatter changed
+- no `tree_path`, `family`, or scout topology axis became schema truth
+- no generated future path became a current valid link
+
 ## 2026-05-04 - Tree projection and first review pack
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -32,10 +32,12 @@
    post-`AOA-T-0054` kind-audit hold review are now landed; `AOA-T-0054` moved
    from `handoff` to `recovery`, and the remaining generated kind pressure is
    held as stale false-positive or calibration evidence.
-   The first family shelf review pack, generated tree projection, and first
-   tree projection review pack are also landed. The next honest pass is a
-   direct-read migration review for the `review-compaction` shelf before any
-   path migration, `tree_path` frontmatter, or schema migration.
+   The first family shelf review pack, generated tree projection, first tree
+   projection review pack, and review-compaction direct-read migration review
+   are also landed. The review-compaction direct-read migration review is landed
+   as `accepted-for-first-migration-pilot`. The next honest pass is the
+   first pilot migration for exactly `AOA-T-0051`, `AOA-T-0052`, and
+   `AOA-T-0054`, with no `tree_path` frontmatter or schema migration.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -33,6 +33,8 @@ permission slip to remap techniques automatically.
   and placement review over all `107` bundles
 - first tree projection review: landed with `review-compaction` selected for
   direct-read migration review, not path movement
+- review-compaction direct-read review: landed as
+  `accepted-for-first-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -57,6 +59,7 @@ permission slip to remap techniques automatically.
 | [Post-0054 Kind Audit Hold Review](reviews/post-0054-kind-audit-hold-review.md) | closes the current kind-audit remap lane and classifies remaining generated pressure as holds or calibration | frontmatter mutation, family promotion, tree migration, or proof of generated correctness |
 | [First Family Shelf Review Pack](reviews/first-family-shelf-review-pack.md) | reviews all `26` scout families for stable shelf candidates, boundary watch, split pressure, singleton holds, and trunk fitness | `family` frontmatter truth, path migration, schema change, or proof that the draft tree is final |
 | [First Tree Projection Review Pack](reviews/first-tree-projection-review-pack.md) | accepts the generated projection as a review surface and chooses `review-compaction` for direct-read pilot review | path movement, `tree_path` frontmatter, bulk migration, or trunk finality |
+| [Review-Compaction Direct-Read Migration Review](reviews/review-compaction-direct-read-migration-review.md) | reads `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` directly and accepts the shelf as the first migration pilot | file movement, `tree_path` frontmatter, domain change, or permission to move any other shelf |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -112,8 +115,7 @@ It should continue one bounded slice at a time:
 
 ## Next Honest Move
 
-Use the first tree projection review pack as the close of the projection pass.
-The generated projection covers all `107` bundles, keeps future paths
-non-authoritative, and selects `review-compaction` for direct-read pilot review.
-The next move is to read the three `review-compaction` bundles and decide
-whether that one shelf should become the first migration pilot.
+Use the review-compaction direct-read review as the close of the first pilot
+selection pass. The three target bundles have now been read directly, and the
+shelf is `accepted-for-first-migration-pilot` without moving files or changing
+frontmatter. The next move is the first pilot migration: Move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, repair links, regenerate derived surfaces, and validate the full release path.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -12,5 +12,6 @@ Current reviews:
 - [post-0054-kind-audit-hold-review](post-0054-kind-audit-hold-review.md)
 - [first-family-shelf-review-pack](first-family-shelf-review-pack.md)
 - [first-tree-projection-review-pack](first-tree-projection-review-pack.md)
+- [review-compaction-direct-read-migration-review](review-compaction-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/first-tree-projection-review-pack.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/first-tree-projection-review-pack.md
@@ -122,10 +122,13 @@ is easy for a human reader to understand. It tests a narrow trunk, while
 ## Next Honest Move
 
 Run a direct-read migration review for the `review-compaction` shelf.
+This has now landed as
+[Review-Compaction Direct-Read Migration Review](review-compaction-direct-read-migration-review.md).
 
 That review should open the three bundles, inspect local links, generated
 surface blast radius, capsule/catalog assumptions, and docs references, then
 decide whether the first pilot move is actually clearer than the current
 `techniques/agent-workflows/*` placement.
 
-Only after that review should a later wave move files.
+That review accepted `review-compaction` for the first pilot migration. Only
+the later migration wave should move files.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md
@@ -1,0 +1,128 @@
+# Review-Compaction Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[First Tree Projection Review Pack](first-tree-projection-review-pack.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-first-migration-pilot, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept `review-compaction` as the first migration pilot.
+
+The move is clearer than current placement because the three bundles share a
+single continuity problem: review or capability context must survive across a
+boundary where the original working surface can become stale, noisy, or
+compact. `agent-workflows` still describes their current owner lane, but it no
+longer helps a reader find the nearby techniques as directly as
+`techniques/continuity/review-compaction/`.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if links, generated surfaces, validation, and route
+cards move together.
+
+## Sources Read
+
+- [AOA-T-0051 commit-triggered-background-review](../../../../../techniques/agent-workflows/commit-triggered-background-review/TECHNIQUE.md)
+- [AOA-T-0051 checklist](../../../../../techniques/agent-workflows/commit-triggered-background-review/checks/commit-triggered-background-review-checklist.md)
+- [AOA-T-0051 example](../../../../../techniques/agent-workflows/commit-triggered-background-review/examples/minimal-commit-triggered-background-review.md)
+- [AOA-T-0051 canonical readiness](../../../../../techniques/agent-workflows/commit-triggered-background-review/notes/canonical-readiness.md)
+- [AOA-T-0052 review-findings-compaction](../../../../../techniques/agent-workflows/review-findings-compaction/TECHNIQUE.md)
+- [AOA-T-0052 checklist](../../../../../techniques/agent-workflows/review-findings-compaction/checks/review-findings-compaction-checklist.md)
+- [AOA-T-0052 example](../../../../../techniques/agent-workflows/review-findings-compaction/examples/minimal-review-findings-compaction.md)
+- [AOA-T-0052 canonical readiness](../../../../../techniques/agent-workflows/review-findings-compaction/notes/canonical-readiness.md)
+- [AOA-T-0054 compaction-resilient-skill-loading](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/TECHNIQUE.md)
+- [AOA-T-0054 checklist](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/checks/compaction-resilient-skill-loading-checklist.md)
+- [AOA-T-0054 example](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/examples/minimal-compaction-resilient-skill-loading.md)
+- [AOA-T-0054 canonical readiness](../../../../../techniques/agent-workflows/compaction-resilient-skill-loading/notes/canonical-readiness.md)
+- [AOA-T-0054 Kind Destination Check](0054-kind-destination-check.md)
+- current references found by `rg` across authored docs, generated docs,
+  reports, mechanics reviews, and related technique bundles
+
+## Direct Read
+
+| technique | current kind | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0051` `commit-triggered-background-review` | `workflow` | commit boundary produces an inspectable review artifact that may later become stale | continuity of review evidence across commit and async review timing |
+| `AOA-T-0052` `review-findings-compaction` | `workflow` | noisy or repeated findings are revalidated and compacted into one current review surface | continuity of current review truth across repeated runs and stale findings |
+| `AOA-T-0054` `compaction-resilient-skill-loading` | `recovery` | compaction weakens capability context and a bounded skill-availability surface is restored | continuity of capability discoverability across context compaction |
+
+The shared shelf is not "review" alone. It is continuity after a review,
+findings, or skill-loading surface crosses a state boundary.
+
+## Why Not Keep This As Agent Workflows
+
+`agent-workflows` remains true as `domain`: these techniques are still reusable
+agent-session practices, and their first owner lane stays in this repository's
+workflow corpus.
+
+The directory tree is now answering a different question. It should help a
+reader find nearby techniques. On that question, `review-compaction` is tighter
+than the current broad domain folder:
+
+- `AOA-T-0051` and `AOA-T-0052` are already explicit siblings.
+- `AOA-T-0054` is not a review technique, but the direct-read kind correction
+  already proved it belongs near compaction and continuity pressure.
+- keeping all three in a future continuity trunk preserves the distinction
+  between `kind` and path: two workflows plus one recovery technique can share
+  one shelf without falsifying frontmatter.
+
+## Pilot Scope
+
+Move exactly these three bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0051` | `techniques/agent-workflows/commit-triggered-background-review/` | `techniques/continuity/review-compaction/commit-triggered-background-review/` |
+| `AOA-T-0052` | `techniques/agent-workflows/review-findings-compaction/` | `techniques/continuity/review-compaction/review-findings-compaction/` |
+| `AOA-T-0054` | `techniques/agent-workflows/compaction-resilient-skill-loading/` | `techniques/continuity/review-compaction/compaction-resilient-skill-loading/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored cross-links from sibling bundles, including
+  `structured-handoff-before-compaction`, `audit-to-closeout-proof-loop`, and
+  `perceptual-media-dedupe-with-threshold-review`
+- historical mechanics review links that currently point at the old paths
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated reports for family, topology, and tree projection
+- validator expectations that derive paths from bundle discovery
+- any release-check output touched by regenerated catalogs, capsules,
+  sections, examples, checklists, evidence notes, and repo-doc surfaces
+
+Create a minimal `techniques/continuity/AGENTS.md` in the migration wave so the
+new trunk has local route guidance. Do not create mechanic-style `parts/`
+packages or shelf READMEs for technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move other `pilot-candidate` shelves in the same wave.
+- Do not rename `continuity` or `review-compaction` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not claim `review-compaction` is canonical shelf truth for the whole
+  future corpus until one actual migration validates the shape.
+
+## Next Honest Move
+
+Run the first pilot migration.
+
+Move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into
+`techniques/continuity/review-compaction/`, add the minimal trunk `AGENTS.md`,
+repair authored links, and rebuild generated surfaces.
+Run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -92,6 +92,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/post-0054-kind-audit-hold-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-tree-projection-review-pack.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -877,6 +878,67 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("direct-read migration review", distillation_roadmap)
         self.assertIn("review-compaction", root_roadmap)
         self.assertIn("reports/technique_tree_projection.md", tree_contract)
+
+    def test_review_compaction_direct_read_review_accepts_pilot_without_path_move(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "review-compaction-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Review-Compaction Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-first-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("AOA-T-0051", review)
+        self.assertIn("AOA-T-0052", review)
+        self.assertIn("AOA-T-0054", review)
+        self.assertIn("commit-triggered-background-review", review)
+        self.assertIn("review-findings-compaction", review)
+        self.assertIn("compaction-resilient-skill-loading", review)
+        self.assertIn("techniques/continuity/review-compaction/", review)
+        self.assertIn("The move is clearer than current placement", review)
+        self.assertIn("Move exactly these three bundles", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Create a minimal `techniques/continuity/AGENTS.md`", review)
+        self.assertIn("Run `python scripts/release_check.py`", review)
+
+        self.assertIn("review-compaction-direct-read-migration-review", reviews_index)
+        self.assertIn("review-compaction direct-read review: landed", ingress)
+        self.assertIn("accepted-for-first-migration-pilot", ingress)
+        self.assertIn("Move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054`", ingress)
+        self.assertIn("review-compaction direct-read migration review is landed", distillation_roadmap)
+        self.assertIn("pilot migration", root_roadmap)
+        self.assertIn("review-compaction direct-read review", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary

- add a direct-read migration review for the `review-compaction` shelf
- accept `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` as the first exact pilot migration scope
- update the reform ingress, tree contract, roadmaps, and landing log while keeping the review non-mutating

## Boundaries

No technique bundle paths moved in this slice. No `tree_path`, `family`, schema truth, domain, kind, status, evidence, relation, or generated path authority changed.

## Validation

- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- `python -m unittest discover -s tests`
- `python scripts/release_check.py`

## Next

Run the first pilot migration: move exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, add minimal continuity trunk guidance, repair links, rebuild generated surfaces, and validate the release path.