### PR TITLE
Review landed review-compaction tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ The format is intentionally simple and human-first.
   tree pilot shelf at `techniques/continuity/review-compaction/` while keeping
   `domain`, `kind`, IDs, status, evidence, and `tree_path` frontmatter
   unchanged
+- accepted the landed `review-compaction` pilot review and selected
+  `handoff-continuation` for the next direct-read migration review without
+  moving a second shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter. |
-| Next honest move | Review the landed `review-compaction` pilot after validation, then choose one next bounded shelf only if the new tree path proves clearer than the old broad domain placement. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter, and the landed-pilot review accepted the result as clearer after validation. |
+| Next honest move | Run a direct-read migration review for `handoff-continuation` over `AOA-T-0056` through `AOA-T-0062`; move nothing until that review proves the shelf is clearer than broad `agent-workflows` placement. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -184,8 +184,9 @@ trigger is real.
 
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
-- Use the landed `review-compaction` pilot as the review target before any
-  second tree migration wave.
+- Use the landed `review-compaction` pilot review as the precedent for the
+  `handoff-continuation` direct-read review before any second tree migration
+  wave.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -185,15 +185,17 @@ The first pilot migration moves `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054`
 into `techniques/continuity/review-compaction/` without changing `domain`,
 `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-review-compaction-tree-pilot.md`](../legacy/receipts/2026-05-04-review-compaction-tree-pilot.md).
+The landed pilot review is
+[Landed Review-Compaction Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md).
 
 The next reform slice should:
 
-1. inspect the landed `review-compaction` pilot after validation
-2. confirm whether the new path is easier to read than the old broad domain
-   placement
-3. choose one next shelf only through projection-first review
-4. preserve a root legacy receipt and run the release check before considering
-   any broader tree migration
+1. read `AOA-T-0056` through `AOA-T-0062` directly
+2. decide whether `handoff-continuation` is clearer than the old broad
+   `agent-workflows` placement
+3. move nothing from the review pack alone
+4. if accepted, migrate only that shelf, preserve a root legacy receipt, and
+   run the release check before considering any broader tree migration
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,32 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed review-compaction pilot review
+
+Changed:
+
+- added
+  [landed-review-compaction-pilot-review](parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md)
+  as the post-migration review over the first tree pilot
+- accepted the landed `review-compaction` shelf as clearer after validation
+- chose `handoff-continuation` for the next direct-read migration review
+  without moving any new bundles
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no second shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Review-compaction tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -39,7 +39,9 @@
    exactly `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` is now landed under
    `techniques/continuity/review-compaction/`, with root legacy receipt
    accounting and no `tree_path` frontmatter or schema migration. The next
-   honest pass is a landed-pilot review before choosing any second shelf.
+   landed-pilot review is also landed as `pilot-validated`: the
+   `review-compaction` migration held its shape after validation, and
+   `handoff-continuation` is the next direct-read migration review target.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -35,6 +35,8 @@ permission slip to remap techniques automatically.
   direct-read migration review, not path movement
 - review-compaction direct-read review: landed as
   `accepted-for-first-migration-pilot`; still not path movement
+- landed review-compaction pilot review: landed as `pilot-validated`, with
+  `handoff-continuation` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -60,6 +62,7 @@ permission slip to remap techniques automatically.
 | [First Family Shelf Review Pack](reviews/first-family-shelf-review-pack.md) | reviews all `26` scout families for stable shelf candidates, boundary watch, split pressure, singleton holds, and trunk fitness | `family` frontmatter truth, path migration, schema change, or proof that the draft tree is final |
 | [First Tree Projection Review Pack](reviews/first-tree-projection-review-pack.md) | accepts the generated projection as a review surface and chooses `review-compaction` for direct-read pilot review | path movement, `tree_path` frontmatter, bulk migration, or trunk finality |
 | [Review-Compaction Direct-Read Migration Review](reviews/review-compaction-direct-read-migration-review.md) | reads `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` directly and accepts the shelf as the first migration pilot | `tree_path` frontmatter, domain change, or permission to move any other shelf |
+| [Landed Review-Compaction Pilot Review](reviews/landed-review-compaction-pilot-review.md) | confirms the first migrated shelf stayed clearer, validated, and bounded after landing | movement of `handoff-continuation`, `tree_path` frontmatter, or proof that all continuity shelves are safe |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -119,6 +122,10 @@ The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing
 frontmatter, adding `tree_path`, or moving another shelf.
 
-The next move is to review the landed pilot results after release validation,
-then choose the next bounded shelf only if the new tree path proves clearer
-than the old broad domain placement.
+The landed pilot review accepted the first migrated shelf as clearer after
+validation and chose `handoff-continuation` for the next direct-read migration
+review.
+
+The next move is to read `AOA-T-0056` through `AOA-T-0062` directly and decide
+whether `techniques/continuity/handoff-continuation/` should become the second
+bounded tree migration wave.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -13,5 +13,6 @@ Current reviews:
 - [first-family-shelf-review-pack](first-family-shelf-review-pack.md)
 - [first-tree-projection-review-pack](first-tree-projection-review-pack.md)
 - [review-compaction-direct-read-migration-review](review-compaction-direct-read-migration-review.md)
+- [landed-review-compaction-pilot-review](landed-review-compaction-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md
@@ -1,0 +1,122 @@
+# Landed Review-Compaction Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Review-Compaction Direct-Read Migration Review](review-compaction-direct-read-migration-review.md)
+
+Migration receipt:
+[Review-Compaction Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-review-compaction-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `handoff-continuation` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `review-compaction` pilot as a successful first tree
+migration.
+
+The pilot improved browsability without changing bundle meaning. The three
+bundles now live where the generated projection says they should live, while
+their IDs, `domain`, `kind`, status, evidence, notes, checklists, examples, and
+public-safety posture stayed unchanged.
+
+This review does not move more files. It confirms that the next honest tree
+slice may be a direct-read migration review for `handoff-continuation`, because
+that shelf is the nearest continuity sibling and will test whether
+`continuity/` is a real trunk rather than a one-shelf exception.
+
+## Sources Read
+
+- [AOA-T-0051 commit-triggered-background-review](../../../../../techniques/continuity/review-compaction/commit-triggered-background-review/TECHNIQUE.md)
+- [AOA-T-0052 review-findings-compaction](../../../../../techniques/continuity/review-compaction/review-findings-compaction/TECHNIQUE.md)
+- [AOA-T-0054 compaction-resilient-skill-loading](../../../../../techniques/continuity/review-compaction/compaction-resilient-skill-loading/TECHNIQUE.md)
+- [Continuity route card](../../../../../techniques/continuity/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Review-compaction tree pilot receipt](../../../../../legacy/receipts/2026-05-04-review-compaction-tree-pilot.md)
+- [Technique tree projection rows for `review-compaction` and
+  `handoff-continuation`](../../../../../reports/technique_tree_projection.md)
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/continuity/review-compaction/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | `domain` still carries owner lane; `kind` still carries move shape |
+| route card | present | `techniques/continuity/AGENTS.md` names the trunk boundary without pretending to be a new domain |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, sections, examples, checklists, evidence notes, and projection surfaces point at current paths |
+| validation | green | release check covered unit tests, nested AGENTS coverage, and repository parity |
+
+## What The Pilot Proved
+
+- A tree trunk can organize techniques by placement question without replacing
+  `domain`.
+- A shelf can hold different `kind` values when the shared browse question is
+  real: two workflows and one recovery technique can still belong together.
+- Root `legacy/receipts/` is the right accounting surface for path migration
+  history, while active bundles remain in `techniques/`.
+- The validator can support both the old domain layout and the new tree layout
+  during the reform period.
+- Generated projection can remain a review aid even after one shelf lands,
+  because current paths and proposed paths are now equal for the landed shelf.
+
+## Remaining Weaknesses
+
+- `review-compaction` alone does not prove that `continuity/` is a stable trunk.
+- `techniques/continuity/AGENTS.md` still names only the first accepted pilot
+  shelf; it should be updated when another continuity shelf lands.
+- No `boundary-watch` or `split-review-needed` shelf has been moved, so the
+  current success applies only to clear pilot candidates.
+- The corpus still has many broad-domain folders; this pilot proves the route,
+  not the full tree.
+
+## Next Shelf Choice
+
+Choose `handoff-continuation` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0056` | `techniques/agent-workflows/channelized-agent-mailbox/` | `techniques/continuity/handoff-continuation/channelized-agent-mailbox/` |
+| `AOA-T-0057` | `techniques/agent-workflows/structured-handoff-before-compaction/` | `techniques/continuity/handoff-continuation/structured-handoff-before-compaction/` |
+| `AOA-T-0058` | `techniques/agent-workflows/receipt-confirmed-handoff-packet/` | `techniques/continuity/handoff-continuation/receipt-confirmed-handoff-packet/` |
+| `AOA-T-0059` | `techniques/agent-workflows/git-verified-handoff-claims/` | `techniques/continuity/handoff-continuation/git-verified-handoff-claims/` |
+| `AOA-T-0060` | `techniques/agent-workflows/session-opening-ritual-before-work/` | `techniques/continuity/handoff-continuation/session-opening-ritual-before-work/` |
+| `AOA-T-0061` | `techniques/agent-workflows/cross-repo-resource-map-bootstrap/` | `techniques/continuity/handoff-continuation/cross-repo-resource-map-bootstrap/` |
+| `AOA-T-0062` | `techniques/agent-workflows/episode-bounded-agent-loop/` | `techniques/continuity/handoff-continuation/episode-bounded-agent-loop/` |
+
+Reason:
+
+`handoff-continuation` is the closest real pressure test after
+`review-compaction`. It stays inside `continuity`, but it shifts the central
+object from review/capability context after compression to handoff state,
+resume posture, and continuation packets across session or agent boundaries.
+
+## Stop Lines
+
+- Do not move `handoff-continuation` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `media-ingest`, `diagnosis-repair`, `instruction-surface`, or
+  `kag-source-lift` in the same wave.
+- Do not treat `continuity` as final trunk truth for all future shelves until
+  at least one more continuity shelf lands cleanly.
+- Do not move `boundary-watch`, `split-review-needed`, or `singleton-hold`
+  shelves without a separate direct-read review.
+
+## Next Honest Move
+
+Run a direct-read migration review for `handoff-continuation`.
+
+Read `AOA-T-0056` through `AOA-T-0062`, decide whether the shelf is clearer
+than the broad `agent-workflows` folder, and only then choose whether to move
+those exact bundles into `techniques/continuity/handoff-continuation/`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -942,6 +942,65 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("landed `review-compaction` pilot", root_roadmap)
         self.assertIn("current landed pilot review", tree_contract)
 
+    def test_landed_review_compaction_pilot_review_selects_next_direct_read_shelf(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-review-compaction-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("Landed Review-Compaction Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("The pilot improved browsability", review)
+        self.assertIn("Root `legacy/receipts/`", review)
+        self.assertIn("Choose `handoff-continuation`", review)
+        self.assertIn("AOA-T-0056", review)
+        self.assertIn("AOA-T-0062", review)
+        self.assertIn("Do not move `handoff-continuation` from this review alone", review)
+        self.assertIn("Run a direct-read migration review for `handoff-continuation`", review)
+
+        self.assertIn("landed-review-compaction-pilot-review", reviews_index)
+        self.assertIn("landed review-compaction pilot review: landed", ingress)
+        self.assertIn("pilot-validated", ingress)
+        self.assertIn("handoff-continuation", ingress)
+        self.assertIn("direct-read migration review", distillation_roadmap)
+        self.assertIn("Landed review-compaction pilot review", landing_log)
+        self.assertIn("handoff-continuation", root_roadmap)
+        self.assertIn("Landed Review-Compaction Pilot Review", tree_contract)
+
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (
             REPO_ROOT


### PR DESCRIPTION
## Summary
- add a landed review-compaction pilot review after the first technique tree migration
- accept the first migrated shelf as validated and clearer after release validation
- select handoff-continuation for the next direct-read migration review without moving another shelf

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py
- git diff --check
