### PR TITLE
Accept handoff-continuation migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `review-compaction` pilot review and selected
   `handoff-continuation` for the next direct-read migration review without
   moving a second shelf yet
+- accepted the `handoff-continuation` direct-read migration review over
+  `AOA-T-0056` through `AOA-T-0062` as the second tree pilot while keeping the
+  review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter, and the landed-pilot review accepted the result as clearer after validation. |
-| Next honest move | Run a direct-read migration review for `handoff-continuation` over `AOA-T-0056` through `AOA-T-0062`; move nothing until that review proves the shelf is clearer than broad `agent-workflows` placement. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter, and the second direct-read review accepted `handoff-continuation` over `AOA-T-0056` through `AOA-T-0062` as the next bounded migration pilot. |
+| Next honest move | Move exactly `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, repair authored links, preserve root legacy receipt accounting, rebuild generated surfaces, and then review the landed second pilot before choosing a broader tree wave. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -184,9 +184,9 @@ trigger is real.
 
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
-- Use the landed `review-compaction` pilot review as the precedent for the
-  `handoff-continuation` direct-read review before any second tree migration
-  wave.
+- Use the landed `review-compaction` pilot review and the accepted
+  `handoff-continuation` direct-read review as the precedent for a second tree
+  migration wave before considering any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -177,25 +177,27 @@ links, do not add `tree_path` frontmatter, and do not authorize path movement.
 
 ## Next Honest Build Path
 
-The current landed pilot review is
-[Review-Compaction Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md).
-The review-compaction direct-read review accepted the first pilot shelf.
-
 The first pilot migration moves `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054`
 into `techniques/continuity/review-compaction/` without changing `domain`,
 `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-review-compaction-tree-pilot.md`](../legacy/receipts/2026-05-04-review-compaction-tree-pilot.md).
-The landed pilot review is
+The current landed pilot review is
 [Landed Review-Compaction Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md).
+
+The current migration review is
+[Handoff-Continuation Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md).
+It accepts `handoff-continuation` as the second bounded migration pilot after
+directly reading `AOA-T-0056` through `AOA-T-0062`.
 
 The next reform slice should:
 
-1. read `AOA-T-0056` through `AOA-T-0062` directly
-2. decide whether `handoff-continuation` is clearer than the old broad
-   `agent-workflows` placement
-3. move nothing from the review pack alone
-4. if accepted, migrate only that shelf, preserve a root legacy receipt, and
-   run the release check before considering any broader tree migration
+1. move exactly `AOA-T-0056` through `AOA-T-0062` into
+   `techniques/continuity/handoff-continuation/`
+2. update the continuity trunk route card and repair authored links
+3. preserve a root legacy receipt without passing active bundles through root
+   `legacy/`
+4. rebuild generated surfaces and run the release check
+5. review the landed second pilot before choosing any broader tree migration
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,33 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Handoff-continuation direct-read migration review
+
+Changed:
+
+- added
+  [handoff-continuation-direct-read-migration-review](parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0056` through `AOA-T-0062`
+- accepted `handoff-continuation` as the second bounded tree migration pilot
+  while keeping the review itself non-mutating
+- recorded the exact next migration scope:
+  `techniques/continuity/handoff-continuation/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no second shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed review-compaction pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -41,7 +41,13 @@
    accounting and no `tree_path` frontmatter or schema migration. The next
    landed-pilot review is also landed as `pilot-validated`: the
    `review-compaction` migration held its shape after validation, and
-   `handoff-continuation` is the next direct-read migration review target.
+   `handoff-continuation` became the next direct-read migration review target.
+   The `handoff-continuation` direct-read migration review is now landed as
+   `accepted-for-second-migration-pilot`: the next tree move is exactly
+   `AOA-T-0056` through `AOA-T-0062` into
+   `techniques/continuity/handoff-continuation/`, with link repair, root
+   legacy receipt accounting, generated rebuilds, and release-check validation
+   in the same wave.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -37,6 +37,8 @@ permission slip to remap techniques automatically.
   `accepted-for-first-migration-pilot`; still not path movement
 - landed review-compaction pilot review: landed as `pilot-validated`, with
   `handoff-continuation` chosen for the next direct-read migration review
+- handoff-continuation direct-read review: landed as
+  `accepted-for-second-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -63,6 +65,7 @@ permission slip to remap techniques automatically.
 | [First Tree Projection Review Pack](reviews/first-tree-projection-review-pack.md) | accepts the generated projection as a review surface and chooses `review-compaction` for direct-read pilot review | path movement, `tree_path` frontmatter, bulk migration, or trunk finality |
 | [Review-Compaction Direct-Read Migration Review](reviews/review-compaction-direct-read-migration-review.md) | reads `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` directly and accepts the shelf as the first migration pilot | `tree_path` frontmatter, domain change, or permission to move any other shelf |
 | [Landed Review-Compaction Pilot Review](reviews/landed-review-compaction-pilot-review.md) | confirms the first migrated shelf stayed clearer, validated, and bounded after landing | movement of `handoff-continuation`, `tree_path` frontmatter, or proof that all continuity shelves are safe |
+| [Handoff-Continuation Direct-Read Migration Review](reviews/handoff-continuation-direct-read-migration-review.md) | reads `AOA-T-0056` through `AOA-T-0062` directly and accepts the shelf as the second migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move any other shelf |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -122,10 +125,11 @@ The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing
 frontmatter, adding `tree_path`, or moving another shelf.
 
-The landed pilot review accepted the first migrated shelf as clearer after
-validation and chose `handoff-continuation` for the next direct-read migration
-review.
+The handoff-continuation direct-read review accepted `AOA-T-0056` through
+`AOA-T-0062` as the second bounded migration pilot while keeping the review
+itself non-mutating.
 
-The next move is to read `AOA-T-0056` through `AOA-T-0062` directly and decide
-whether `techniques/continuity/handoff-continuation/` should become the second
-bounded tree migration wave.
+The next move is to move exactly those seven bundles into
+`techniques/continuity/handoff-continuation/`, repair authored links, preserve a
+root legacy receipt, rebuild generated surfaces, and run the release check
+before choosing any broader tree migration.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -14,5 +14,6 @@ Current reviews:
 - [first-tree-projection-review-pack](first-tree-projection-review-pack.md)
 - [review-compaction-direct-read-migration-review](review-compaction-direct-read-migration-review.md)
 - [landed-review-compaction-pilot-review](landed-review-compaction-pilot-review.md)
+- [handoff-continuation-direct-read-migration-review](handoff-continuation-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md
@@ -1,0 +1,166 @@
+# Handoff-Continuation Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[First Tree Projection Review Pack](first-tree-projection-review-pack.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Prior pilot review:
+[Landed Review-Compaction Pilot Review](landed-review-compaction-pilot-review.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-second-migration-pilot, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept `handoff-continuation` as the second migration pilot.
+
+The move is clearer than current placement because the seven bundles share one
+continuity problem: work, communication, or reviewable state must cross a
+session, agent, repo, compaction, or episode boundary without depending on
+hidden memory, stale narration, or a broad orchestration stack.
+`agent-workflows` remains true as their current `domain`, but it is too broad
+as a browsing neighborhood now that the corpus is growing toward a larger tree.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if links, generated surfaces, validation, route cards,
+and root legacy receipts move together.
+
+## Sources Read
+
+- [AOA-T-0056 channelized-agent-mailbox](../../../../../techniques/agent-workflows/channelized-agent-mailbox/TECHNIQUE.md)
+- [AOA-T-0057 structured-handoff-before-compaction](../../../../../techniques/agent-workflows/structured-handoff-before-compaction/TECHNIQUE.md)
+- [AOA-T-0058 receipt-confirmed-handoff-packet](../../../../../techniques/agent-workflows/receipt-confirmed-handoff-packet/TECHNIQUE.md)
+- [AOA-T-0059 git-verified-handoff-claims](../../../../../techniques/agent-workflows/git-verified-handoff-claims/TECHNIQUE.md)
+- [AOA-T-0060 session-opening-ritual-before-work](../../../../../techniques/agent-workflows/session-opening-ritual-before-work/TECHNIQUE.md)
+- [AOA-T-0061 cross-repo-resource-map-bootstrap](../../../../../techniques/agent-workflows/cross-repo-resource-map-bootstrap/TECHNIQUE.md)
+- [AOA-T-0062 episode-bounded-agent-loop](../../../../../techniques/agent-workflows/episode-bounded-agent-loop/TECHNIQUE.md)
+- supporting `checks/`, `examples/`, and `notes/` files for the seven bundles,
+  scanned for invariant, adjacency, validation, and drift-pressure cues
+- current references found by `rg` across the seven source bundles
+- `reports/technique_tree_projection.md` rows for `AOA-T-0056` through
+  `AOA-T-0062`
+
+## Direct Read
+
+| technique | current kind | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0056` `channelized-agent-mailbox` | `handoff` | durable named mailbox channels with ordered replay and explicit ack state | continuity of communication transport across session gaps, not handoff authorization |
+| `AOA-T-0057` `structured-handoff-before-compaction` | `handoff` | one explicit continuation packet written before compaction or rollover | continuity of work state across context loss, not transcript packaging or phase governance |
+| `AOA-T-0058` `receipt-confirmed-handoff-packet` | `handoff` | visible receipt state after a handoff packet exists and before continuation trusts delivery | continuity of receiver acceptance across the delivery/continuation boundary |
+| `AOA-T-0059` `git-verified-handoff-claims` | `handoff` | concrete handoff claims checked against visible git evidence before resuming | continuity of trust from packet narration to repo-backed current state |
+| `AOA-T-0060` `session-opening-ritual-before-work` | `handoff` | pre-mutation session start that rereads context and checks one visible baseline | continuity from inherited context into current reality before action |
+| `AOA-T-0061` `cross-repo-resource-map-bootstrap` | `handoff` | one task-bounded map of repos and resource surfaces needed for continuation | continuity of first-look routing across repo boundaries, not a full bounded-context model |
+| `AOA-T-0062` `episode-bounded-agent-loop` | `handoff` | longer work split into episodes with checkpoints and continue, stop, or escalate decisions | continuity of multi-episode work through visible checkpoint state, not a whole orchestrator |
+
+The shared shelf is not "handoff" as a vague theme. It is the narrower
+continuation seam where a later actor, later session, or later episode can
+resume from visible state rather than from memory, platform magic, or broad
+process doctrine.
+
+## Boundary Read
+
+The shelf remains useful only if the bundle boundaries stay sharp:
+
+- `AOA-T-0056` owns mailbox transport, not continuation permission.
+- `AOA-T-0057` owns the packet, not receipt, git verdict, transcript export, or
+  phase policy.
+- `AOA-T-0058` owns receipt state, not delivery mechanics or approval
+  governance.
+- `AOA-T-0059` owns repo-backed claim verification, not generic code review or
+  full provenance.
+- `AOA-T-0060` owns the opening ritual, not the whole change loop or startup
+  doctrine.
+- `AOA-T-0061` owns the task-bounded cross-repo first-look map, not bounded
+  context architecture.
+- `AOA-T-0062` owns episode segmentation, not runtime supervision, budgets,
+  task trackers, or autonomous-agent doctrine.
+
+Those boundaries are exactly why the shelf works. It keeps sibling techniques
+near each other without merging them into one handoff framework.
+
+## Why Not Keep This As Agent Workflows
+
+`agent-workflows` remains true as `domain`: these are still reusable
+agent-session practices, and their first review lane remains in this
+repository's workflow corpus.
+
+The directory tree is now answering a different question. It should help a
+human or small agent find the nearest usable leaf. On that question,
+`continuity/handoff-continuation` is tighter than the old broad folder:
+
+- all seven bundles already describe explicit state transfer, receipt,
+  verification, startup, routing, or checkpoint seams
+- several bundles cite each other as adjacency boundaries, which means the
+  reader benefits from local shelf proximity
+- the shelf preserves atom boundaries instead of hiding a total handoff chain
+  in one overgrown technique
+- the path reinforces the corpus tree without changing `domain`, `kind`,
+  status, owners, evidence, or bundle meaning
+
+## Pilot Scope
+
+Move exactly these seven bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0056` | `techniques/agent-workflows/channelized-agent-mailbox/` | `techniques/continuity/handoff-continuation/channelized-agent-mailbox/` |
+| `AOA-T-0057` | `techniques/agent-workflows/structured-handoff-before-compaction/` | `techniques/continuity/handoff-continuation/structured-handoff-before-compaction/` |
+| `AOA-T-0058` | `techniques/agent-workflows/receipt-confirmed-handoff-packet/` | `techniques/continuity/handoff-continuation/receipt-confirmed-handoff-packet/` |
+| `AOA-T-0059` | `techniques/agent-workflows/git-verified-handoff-claims/` | `techniques/continuity/handoff-continuation/git-verified-handoff-claims/` |
+| `AOA-T-0060` | `techniques/agent-workflows/session-opening-ritual-before-work/` | `techniques/continuity/handoff-continuation/session-opening-ritual-before-work/` |
+| `AOA-T-0061` | `techniques/agent-workflows/cross-repo-resource-map-bootstrap/` | `techniques/continuity/handoff-continuation/cross-repo-resource-map-bootstrap/` |
+| `AOA-T-0062` | `techniques/agent-workflows/episode-bounded-agent-loop/` | `techniques/continuity/handoff-continuation/episode-bounded-agent-loop/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored cross-links inside the seven moved bundles, including their
+  `TECHNIQUE.md` adjacency paragraphs and `notes/second-context-adaptation.md`
+  / `notes/canonical-readiness.md` references
+- adjacent links from already-migrated continuity bundles, especially
+  `compaction-resilient-skill-loading`
+- historical mechanics review links that currently point at the old paths
+- `techniques/continuity/AGENTS.md`, because the trunk would have two accepted
+  shelves after the move
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated reports for family, topology, and tree projection
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, and repo-doc surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move other `pilot-candidate` shelves in the same wave.
+- Do not rename `continuity` or `handoff-continuation` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not merge the seven techniques into one handoff framework.
+- Do not claim `handoff-continuation` is canonical shelf truth for every future
+  handoff-like technique until one actual migration validates the shape.
+
+## Next Honest Move
+
+Run the second pilot migration.
+
+Move exactly `AOA-T-0056` through `AOA-T-0062` into
+`techniques/continuity/handoff-continuation/`, update the continuity trunk route
+card, repair authored links, preserve a root legacy receipt, rebuild generated
+surfaces, and run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -93,6 +93,8 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-family-shelf-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/first-tree-projection-review-pack.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/review-compaction-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1000,6 +1002,90 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed review-compaction pilot review", landing_log)
         self.assertIn("handoff-continuation", root_roadmap)
         self.assertIn("Landed Review-Compaction Pilot Review", tree_contract)
+
+    def test_handoff_continuation_direct_read_review_accepts_second_pilot_without_migration(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "handoff-continuation-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Handoff-Continuation Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-second-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        for technique_id in (
+            "AOA-T-0056",
+            "AOA-T-0057",
+            "AOA-T-0058",
+            "AOA-T-0059",
+            "AOA-T-0060",
+            "AOA-T-0061",
+            "AOA-T-0062",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+        for slug in (
+            "channelized-agent-mailbox",
+            "structured-handoff-before-compaction",
+            "receipt-confirmed-handoff-packet",
+            "git-verified-handoff-claims",
+            "session-opening-ritual-before-work",
+            "cross-repo-resource-map-bootstrap",
+            "episode-bounded-agent-loop",
+        ):
+            with self.subTest(slug=slug):
+                self.assertIn(slug, review)
+
+        self.assertIn("The move is clearer than current placement", review)
+        self.assertIn("Move exactly these seven bundles", review)
+        self.assertIn("techniques/continuity/handoff-continuation/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Run the second pilot migration", review)
+        self.assertIn("run `python scripts/release_check.py`", review)
+
+        self.assertIn("handoff-continuation-direct-read-migration-review", reviews_index)
+        self.assertIn("handoff-continuation direct-read review: landed", ingress)
+        self.assertIn("accepted-for-second-migration-pilot", ingress)
+        self.assertIn("exactly those seven bundles", ingress)
+        self.assertIn("handoff-continuation` direct-read migration review is now landed", distillation_roadmap)
+        self.assertIn("Handoff-continuation direct-read migration review", landing_log)
+        self.assertIn("second direct-read review accepted `handoff-continuation`", root_roadmap)
+        self.assertIn("Handoff-Continuation Direct-Read Migration Review", tree_contract)
+        self.assertIn("accepted the `handoff-continuation` direct-read migration review", changelog)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the handoff-continuation direct-read migration review over AOA-T-0056 through AOA-T-0062
- update technique reform, tree contract, roadmap, changelog, and distillation landing surfaces with the accepted second-pilot scope
- add topology coverage that keeps the review non-mutating and not tree_path/frontmatter authority

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py
- git diff --check