### PR TITLE
Accept media-ingest migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `handoff-continuation` pilot review and selected
   `media-ingest` for the next direct-read migration review while repairing
   staging links in `incoming/` to current authored paths
+- accepted the `media-ingest` direct-read migration review over `AOA-T-0070`
+  through `AOA-T-0074` as the third tree pilot while keeping the review itself
+  non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/` without changing frontmatter, and the landed second-pilot review chooses `media-ingest` for the next direct-read review. |
-| Next honest move | Directly read `AOA-T-0070` through `AOA-T-0074` before deciding whether the third tree wave should move them into `techniques/ingest/media-ingest/`. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing frontmatter, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/` without changing frontmatter, and the `media-ingest` direct-read review accepts the first non-continuity pilot. |
+| Next honest move | Move exactly `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/` with an `ingest/` route card, root legacy receipt, generated rebuilds, and unchanged frontmatter. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -199,15 +199,21 @@ The landed second pilot review is
 It validates the `handoff-continuation` migration and chooses `media-ingest`
 for the next direct-read migration review.
 
+The third migration review is
+[Media-Ingest Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md).
+It accepts `media-ingest` as the first non-continuity migration pilot after
+directly reading `AOA-T-0070` through `AOA-T-0074`.
+
 The next reform slice should:
 
-1. directly read `AOA-T-0070` through `AOA-T-0074`
-2. test whether `ingest/media-ingest` is clearer than the old broad
-   `agent-workflows` placement
-3. decide whether OCR staging, post-OCR field extraction, perceptual dedupe,
-   semantic media bucketing, and Telegram normalization belong in one shelf
-4. keep any later path move separate from the review, with no `tree_path`
-   frontmatter or bulk migration
+1. move exactly `AOA-T-0070` through `AOA-T-0074` into
+   `techniques/ingest/media-ingest/`
+2. add a minimal `techniques/ingest/AGENTS.md` route card for the first
+   non-continuity migrated trunk
+3. repair authored links, incoming staging links, generated surfaces, and root
+   legacy receipt accounting in the same wave
+4. keep `domain`, `kind`, status, evidence, and `tree_path` frontmatter
+   unchanged
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,34 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Media-ingest direct-read migration review
+
+Changed:
+
+- added
+  [media-ingest-direct-read-migration-review](parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0070` through `AOA-T-0074`
+- accepted `media-ingest` as the third bounded tree migration pilot and the
+  first non-continuity trunk test
+- recorded the exact next migration scope:
+  `techniques/ingest/media-ingest/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `telegram-account-auth-and-session-bridge` outside the accepted shelf
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no third shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed handoff-continuation pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -48,8 +48,10 @@
    `techniques/continuity/handoff-continuation/`, with link repair, root
    legacy receipt accounting, generated rebuilds, and release-check validation
    in the same wave. The landed `handoff-continuation` pilot review is also
-   landed as `pilot-validated`, and `media-ingest` is now the next direct-read
-   migration review target before any third path move.
+   landed as `pilot-validated`. The `media-ingest` direct-read review is now
+   landed as `accepted-for-third-migration-pilot`, and the next tree move is
+   the third pilot migration for exactly `AOA-T-0070` through `AOA-T-0074`
+   before any other shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -44,6 +44,8 @@ permission slip to remap techniques automatically.
   without frontmatter changes
 - landed handoff-continuation pilot review: landed as `pilot-validated`, with
   `media-ingest` chosen for the next direct-read migration review
+- media-ingest direct-read review: landed as
+  `accepted-for-third-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -72,6 +74,7 @@ permission slip to remap techniques automatically.
 | [Landed Review-Compaction Pilot Review](reviews/landed-review-compaction-pilot-review.md) | confirms the first migrated shelf stayed clearer, validated, and bounded after landing | movement of `handoff-continuation`, `tree_path` frontmatter, or proof that all continuity shelves are safe |
 | [Handoff-Continuation Direct-Read Migration Review](reviews/handoff-continuation-direct-read-migration-review.md) | reads `AOA-T-0056` through `AOA-T-0062` directly and accepts the shelf as the second migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move any other shelf |
 | [Landed Handoff-Continuation Pilot Review](reviews/landed-handoff-continuation-pilot-review.md) | confirms the second migrated shelf stayed clearer, validates the continuity trunk machinery, and chooses `media-ingest` for the next direct-read review | movement of `media-ingest`, `tree_path` frontmatter, or proof that every trunk is ready |
+| [Media-Ingest Direct-Read Migration Review](reviews/media-ingest-direct-read-migration-review.md) | reads `AOA-T-0070` through `AOA-T-0074` directly and accepts the shelf as the third migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -135,11 +138,10 @@ The second pilot migration moved exactly `AOA-T-0056` through `AOA-T-0062`
 into `techniques/continuity/handoff-continuation/` without changing
 frontmatter or adding `tree_path`.
 
-The landed `handoff-continuation` shelf review is now complete and chooses
-`media-ingest` as the next tree candidate.
+The `media-ingest` direct-read review is now landed and accepts exactly
+`AOA-T-0070` through `AOA-T-0074` as the third migration pilot.
 
-The next move is to run a direct-read migration review for `media-ingest`.
-Read `AOA-T-0070` through `AOA-T-0074`, inspect whether OCR staging, post-OCR
-field extraction, perceptual dedupe, semantic media bucketing, and Telegram
-normalization belong in one `ingest/media-ingest` shelf, and only then decide
-whether those exact bundles should move.
+The next move is the third pilot migration: move those five bundles into
+`techniques/ingest/media-ingest/`, add the minimal `ingest/` route card, repair
+authored and staging links, preserve a root legacy receipt, rebuild generated
+surfaces, and keep frontmatter unchanged.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -16,5 +16,6 @@ Current reviews:
 - [landed-review-compaction-pilot-review](landed-review-compaction-pilot-review.md)
 - [handoff-continuation-direct-read-migration-review](handoff-continuation-direct-read-migration-review.md)
 - [landed-handoff-continuation-pilot-review](landed-handoff-continuation-pilot-review.md)
+- [media-ingest-direct-read-migration-review](media-ingest-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md
@@ -1,0 +1,179 @@
+# Media-Ingest Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[First Tree Projection Review Pack](first-tree-projection-review-pack.md)
+
+Prior pilot review:
+[Landed Handoff-Continuation Pilot Review](landed-handoff-continuation-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-third-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `media-ingest` as the third migration pilot.
+
+The move is clearer than current placement because the five bundles share one
+ingest problem: external media, documents, or message exports must become a
+bounded reviewable object before later extraction, routing, cleanup, memory, or
+automation begins. `agent-workflows` remains true as their current `domain`,
+but it is too broad as a browsing neighborhood for OCR handoff, post-OCR field
+extraction, perceptual duplicate grouping, semantic bucketing, and Telegram
+normalization.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if route cards, root legacy receipts, link repair,
+generated surfaces, and validation move together.
+
+## Sources Read
+
+- [AOA-T-0070 two-stage-document-ocr-pipeline](../../../../../techniques/agent-workflows/two-stage-document-ocr-pipeline/TECHNIQUE.md)
+- [AOA-T-0071 template-backed-field-extraction-after-ocr](../../../../../techniques/agent-workflows/template-backed-field-extraction-after-ocr/TECHNIQUE.md)
+- [AOA-T-0072 perceptual-media-dedupe-with-threshold-review](../../../../../techniques/agent-workflows/perceptual-media-dedupe-with-threshold-review/TECHNIQUE.md)
+- [AOA-T-0073 semantic-media-bucketing-with-vision-plus-ocr](../../../../../techniques/agent-workflows/semantic-media-bucketing-with-vision-plus-ocr/TECHNIQUE.md)
+- [AOA-T-0074 telegram-export-normalization-to-local-store](../../../../../techniques/agent-workflows/telegram-export-normalization-to-local-store/TECHNIQUE.md)
+- supporting `checks/`, `examples/`, and `notes/` files for the five bundles,
+  scanned for invariant, adjacency, public-safety, and drift-pressure cues
+- [Personal Ingest Wave 2](../../../../../incoming/personal-ingest-wave-2/README.md)
+- [External Technique Candidates - Personal Ingest Wave 2](../../../../../incoming/personal-ingest-wave-2/docs/EXTERNAL_TECHNIQUE_CANDIDATES_PERSONAL_INGEST_WAVE_2.md)
+- [Personal Ingest Wave 2 - Planting Order](../../../../../incoming/personal-ingest-wave-2/docs/PERSONAL_INGEST_WAVE_2_PLANTING_ORDER.md)
+- [Personal Ingest Wave 2 Donor Sources](../../../../../incoming/personal-ingest-wave-2/support/DONOR_SOURCES.md)
+- `reports/technique_tree_projection.md` rows for `AOA-T-0070` through
+  `AOA-T-0074`
+- `reports/technique_topology_scout.md` rows for `AOA-T-0070` through
+  `AOA-T-0074`
+
+## Direct Read
+
+| technique | current kind | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0070` `two-stage-document-ocr-pipeline` | `ingest` | detect/layout plus recognize stages emit one structured OCR handoff with confidence and region references | document/image intake before extraction, not OCR serving or field parsing |
+| `AOA-T-0071` `template-backed-field-extraction-after-ocr` | `ingest` | explicit templates or heuristics turn OCR handoff text into bounded fields with missing/conflict markers | post-OCR intake into a reviewable field object, not bookkeeping or parser implementation |
+| `AOA-T-0072` `perceptual-media-dedupe-with-threshold-review` | `ingest` | perceptual similarity groups near-duplicates and separates borderline matches into review | media set intake and cleanup preparation, not deletion policy or semantic taxonomy |
+| `AOA-T-0073` `semantic-media-bucketing-with-vision-plus-ocr` | `ingest` | bounded visual taxonomy plus optional OCR side text creates confidence-aware media buckets | media intake routing before action, not moderation, identity inference, or open-ended multimodal automation |
+| `AOA-T-0074` `telegram-export-normalization-to-local-store` | `ingest` | Telegram-derived messages and media become stable local objects with provenance, reply edges, media refs, and resumable storage | source-specific data intake, not auth/session bridge, memory writeback, or general history canon |
+
+The shelf is not merely "media tools." It is the narrower intake seam where raw
+or semi-raw external material becomes a visible intermediate object that later
+techniques or systems can inspect without inheriting donor runtime behavior.
+
+## Boundary Read
+
+The shelf remains useful only if the bundle boundaries stay sharp:
+
+- `AOA-T-0070` owns OCR handoff, not downstream field semantics.
+- `AOA-T-0071` owns bounded post-OCR field extraction, not OCR staging or
+  accounting automation.
+- `AOA-T-0072` owns duplicate grouping, not cleanup policy.
+- `AOA-T-0073` owns bounded media bucketing, not dedupe, OCR handoff, field
+  extraction, moderation, or identity inference.
+- `AOA-T-0074` owns Telegram-source normalization, not credentials, session
+  conversion, live agent control, memory writeback, or general history capture.
+
+Those boundaries are strong enough for a pilot shelf because the techniques are
+adjacent but not substitutable.
+
+## Telegram Edge
+
+`AOA-T-0074` is the stress case.
+
+It should stay in the pilot because it is still an ingest technique: it turns a
+bounded external source into a local reviewable store with source provenance,
+media references, reply edges, and resume state. The held sibling
+`telegram-account-auth-and-session-bridge` proves the right boundary: auth,
+secret handling, session conversion, and live control-plane behavior are not
+part of this shelf.
+
+The migration should still preserve a watch line: if future source-specific
+normalization techniques grow beyond media/document/message intake, a later
+tree review may split `media-ingest` into a wider `source-ingest` shelf. That
+future pressure does not block this pilot because the current five-bundle shelf
+is coherent enough and already projected as `media-ingest`.
+
+## Why Not Keep This As Agent Workflows
+
+`agent-workflows` remains true as `domain`: all five bundles are reusable
+agent-facing workflow techniques.
+
+The directory tree now answers a browsing and placement question. On that
+question, `ingest/media-ingest` is tighter than the old broad folder:
+
+- all five bundles transform incoming external material into bounded
+  intermediate objects
+- all five are `kind: ingest`, unlike the previous continuity shelves that had
+  cross-kind stress cases
+- the Personal Ingest Wave 2 staging packet already groups the five landed
+  bundles and keeps the auth/session bridge out
+- direct links between these bundles become easier to read if they are shelf
+  siblings
+- the shelf tests a non-continuity trunk without touching boundary-watch or
+  split-review-needed families
+
+## Pilot Scope
+
+Move exactly these five bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0070` | `techniques/agent-workflows/two-stage-document-ocr-pipeline/` | `techniques/ingest/media-ingest/two-stage-document-ocr-pipeline/` |
+| `AOA-T-0071` | `techniques/agent-workflows/template-backed-field-extraction-after-ocr/` | `techniques/ingest/media-ingest/template-backed-field-extraction-after-ocr/` |
+| `AOA-T-0072` | `techniques/agent-workflows/perceptual-media-dedupe-with-threshold-review/` | `techniques/ingest/media-ingest/perceptual-media-dedupe-with-threshold-review/` |
+| `AOA-T-0073` | `techniques/agent-workflows/semantic-media-bucketing-with-vision-plus-ocr/` | `techniques/ingest/media-ingest/semantic-media-bucketing-with-vision-plus-ocr/` |
+| `AOA-T-0074` | `techniques/agent-workflows/telegram-export-normalization-to-local-store/` | `techniques/ingest/media-ingest/telegram-export-normalization-to-local-store/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored sibling links inside the five moved bundles, especially relative
+  links among `AOA-T-0070`, `AOA-T-0071`, `AOA-T-0072`, and `AOA-T-0073`
+- links from incoming Personal Ingest Wave 2 candidate and planting surfaces
+- links from Audit promotion-readiness matrix rows for `AOA-T-0070` through
+  `AOA-T-0074`
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated reports for family, topology, and tree projection
+- a new `techniques/ingest/AGENTS.md` route card, because `ingest/` would
+  become the first non-continuity migrated trunk
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, and repo-doc surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move another `pilot-candidate` shelf in the same wave.
+- Do not rename `media-ingest` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not absorb `telegram-account-auth-and-session-bridge`; it remains outside
+  the landed shelf because auth/session/control behavior is not the normalized
+  local-store technique.
+- Do not widen ingest into KAG, memory, moderation, deletion, account auth, or
+  downstream automation doctrine.
+
+## Next Honest Move
+
+Run the third pilot migration.
+
+Move exactly `AOA-T-0070` through `AOA-T-0074` into
+`techniques/ingest/media-ingest/`, add the minimal `ingest/` route card, repair
+authored links, preserve a root legacy receipt, rebuild generated surfaces, and
+run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -96,6 +96,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-review-compaction-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-handoff-continuation-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1112,8 +1113,8 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("handoff-continuation migration: landed", ingress)
         self.assertIn("techniques/continuity/handoff-continuation/", ingress)
         self.assertIn("without frontmatter changes", ingress)
-        self.assertIn("The landed `handoff-continuation` shelf review is now complete", ingress)
-        self.assertIn("`media-ingest` as the next tree candidate", ingress)
+        self.assertIn("media-ingest direct-read review: landed", ingress)
+        self.assertIn("accepted-for-third-migration-pilot", ingress)
         self.assertIn("second pilot migration is", distillation_roadmap)
         self.assertIn("Handoff-continuation tree pilot migration", landing_log)
         self.assertIn("legacy/receipts/2026-05-04-handoff-continuation-tree-pilot.md", landing_log)
@@ -1197,10 +1198,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("landed-handoff-continuation-pilot-review", reviews_index)
         self.assertIn("landed handoff-continuation pilot review: landed", ingress)
         self.assertIn("media-ingest", ingress)
-        self.assertIn("media-ingest` is now the next direct-read", distillation_roadmap)
+        self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("landed second-pilot review chooses `media-ingest`", root_roadmap)
+        self.assertIn("`media-ingest` direct-read review accepts", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1212,6 +1213,88 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             "techniques/agent-workflows/episode-bounded-agent-loop/TECHNIQUE.md",
             incoming_wave3,
         )
+
+    def test_media_ingest_direct_read_review_accepts_third_pilot_without_migration(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "media-ingest-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Media-Ingest Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-third-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `media-ingest` as the third migration pilot", review)
+        for technique_id in (
+            "AOA-T-0070",
+            "AOA-T-0071",
+            "AOA-T-0072",
+            "AOA-T-0073",
+            "AOA-T-0074",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Telegram Edge", review)
+        self.assertIn("telegram-account-auth-and-session-bridge", review)
+        self.assertIn("Move exactly these five bundles", review)
+        self.assertIn("techniques/ingest/media-ingest/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Run the third pilot migration", review)
+
+        self.assertIn("media-ingest-direct-read-migration-review", reviews_index)
+        self.assertIn("media-ingest direct-read review: landed", ingress)
+        self.assertIn("accepted-for-third-migration-pilot", ingress)
+        self.assertIn("third pilot migration", ingress)
+        self.assertIn("media-ingest` direct-read review is now", distillation_roadmap)
+        self.assertIn("Media-ingest direct-read migration review", landing_log)
+        self.assertIn("accepted the `media-ingest` direct-read migration review", changelog)
+        self.assertIn("first non-continuity pilot", root_roadmap)
+        self.assertIn("Media-Ingest Direct-Read Migration Review", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "agent-workflows"
+                / "two-stage-document-ocr-pipeline"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse((REPO_ROOT / "techniques" / "ingest").exists())
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the direct-read migration review for AOA-T-0070 through AOA-T-0074
- accept media-ingest as the third tree migration pilot without moving files or changing frontmatter
- update technique reform ingress, tree contract, roadmap, landing log, changelog, and topology tests

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py