### PR TITLE
Review landed media-ingest tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ The format is intentionally simple and human-first.
 - moved `AOA-T-0070` through `AOA-T-0074` into
   `techniques/ingest/media-ingest/` while keeping `domain`, `kind`, IDs,
   status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `media-ingest` pilot review and selected
+  `diagnosis-repair` for the next direct-read migration review without moving
+  a fourth shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 | Field | Direction |
 |---|---|
 | Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, and the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`; all three kept frontmatter unchanged. |
-| Next honest move | Review the landed `media-ingest` shelf against its direct-read review, route card, root legacy receipt, link repairs, and generated rebuilds before choosing a fourth tree wave. |
+| Next honest move | Run a direct-read migration review for `diagnosis-repair` before moving any fourth tree shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -184,9 +184,9 @@ trigger is real.
 
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
-- Use the landed `review-compaction` and `handoff-continuation` pilots as
-  precedents while testing `media-ingest` as the first non-continuity direct-read
-  shelf review before considering any broader corpus move.
+- Use the landed `review-compaction`, `handoff-continuation`, and
+  `media-ingest` pilots as precedents while testing `diagnosis-repair` as the
+  next direct-read shelf review before considering any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -209,15 +209,20 @@ The third pilot migration moves `AOA-T-0070` through `AOA-T-0074` into
 `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-media-ingest-tree-pilot.md`](../legacy/receipts/2026-05-04-media-ingest-tree-pilot.md).
 
+The landed third pilot review is
+[Landed Media-Ingest Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md).
+It validates the `media-ingest` migration as the first successful
+non-continuity trunk test and chooses `diagnosis-repair` for the next
+direct-read migration review.
+
 The next reform slice should:
 
-1. review the landed `media-ingest` shelf against its direct-read migration
-   review
-2. confirm generated surfaces, root legacy receipt accounting, the `ingest/`
-   route card, and authored links stayed coherent after the move
-3. choose a fourth tree candidate only after the landed third pilot review
-   proves the first non-continuity shelf remained clearer than the old broad
-   placement
+1. read `AOA-T-0080` through `AOA-T-0083` directly
+2. decide whether `diagnosis-repair` is clearer under
+   `techniques/recovery/diagnosis-repair/` than under the broad
+   `agent-workflows` folder
+3. preserve frontmatter, generated-surface parity, and root legacy accounting
+   if a fourth migration later lands
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,34 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed media-ingest pilot review
+
+Changed:
+
+- added
+  [landed-media-ingest-pilot-review](parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md)
+  as the post-migration review over the third tree pilot
+- accepted the landed `media-ingest` shelf as clearer after validation and as
+  the first successful non-continuity trunk test
+- chose `diagnosis-repair` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `telegram-account-auth-and-session-bridge` outside the migrated shelf
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no fourth shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Media-ingest tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -53,9 +53,10 @@
    migration is landed exactly for `AOA-T-0070` through `AOA-T-0074` under
    `techniques/ingest/media-ingest/`, with the first non-continuity route card,
    root legacy receipt accounting, link repair, generated rebuilds, and
-   release-check validation in the same wave. The next tree move is a
-   landed-pilot review over `media-ingest` before choosing any fourth
-   candidate.
+   release-check validation in the same wave. The landed `media-ingest` pilot
+   review is also landed as `pilot-validated`, and `diagnosis-repair` is now
+   chosen for the next direct-read migration review before any fourth shelf
+   moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -48,6 +48,8 @@ permission slip to remap techniques automatically.
   `accepted-for-third-migration-pilot`; still not path movement
 - media-ingest migration: landed exactly `AOA-T-0070` through `AOA-T-0074`
   under `techniques/ingest/media-ingest/` without frontmatter changes
+- landed media-ingest pilot review: landed as `pilot-validated`, with
+  `diagnosis-repair` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -144,7 +146,9 @@ The third pilot migration moved exactly `AOA-T-0070` through `AOA-T-0074`
 into `techniques/ingest/media-ingest/` without changing frontmatter or adding
 `tree_path`.
 
-The next move is to review the landed `media-ingest` shelf against the
-direct-read review, generated rebuilds, root legacy receipt, new `ingest/`
-route card, and link repair before choosing any fourth tree migration
-candidate.
+The landed `media-ingest` pilot review is now landed as `pilot-validated` and
+chooses `diagnosis-repair` for the next direct-read migration review.
+
+The next move is to read `AOA-T-0080` through `AOA-T-0083` directly and decide
+whether those four bundles should move into
+`techniques/recovery/diagnosis-repair/` without changing frontmatter.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -17,5 +17,6 @@ Current reviews:
 - [handoff-continuation-direct-read-migration-review](handoff-continuation-direct-read-migration-review.md)
 - [landed-handoff-continuation-pilot-review](landed-handoff-continuation-pilot-review.md)
 - [media-ingest-direct-read-migration-review](media-ingest-direct-read-migration-review.md)
+- [landed-media-ingest-pilot-review](landed-media-ingest-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md
@@ -1,0 +1,137 @@
+# Landed Media-Ingest Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Media-Ingest Direct-Read Migration Review](media-ingest-direct-read-migration-review.md)
+
+Migration receipt:
+[Media-Ingest Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-media-ingest-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `diagnosis-repair` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `media-ingest` pilot as a successful third tree migration
+and the first non-continuity trunk test.
+
+The shelf stayed legible after landing: five separate promoted ingest
+techniques now sit under one intake neighborhood, while their IDs, `domain`,
+`kind`, status, evidence, notes, examples, checks, and public-safety posture
+stayed unchanged. The move improved browsing without collapsing OCR staging,
+post-OCR extraction, perceptual duplicate grouping, semantic bucketing, and
+Telegram-source normalization into one oversized media pipeline.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should test `recovery/diagnosis-repair`, because the tree has now proved
+one continuity trunk and one ingest trunk. The next pressure should check a
+small recovery shelf with both `assessment` and `recovery` kinds before larger
+instruction or knowledge-lift shelves move.
+
+## Sources Read
+
+- [AOA-T-0070 two-stage-document-ocr-pipeline](../../../../../techniques/ingest/media-ingest/two-stage-document-ocr-pipeline/TECHNIQUE.md)
+- [AOA-T-0071 template-backed-field-extraction-after-ocr](../../../../../techniques/ingest/media-ingest/template-backed-field-extraction-after-ocr/TECHNIQUE.md)
+- [AOA-T-0072 perceptual-media-dedupe-with-threshold-review](../../../../../techniques/ingest/media-ingest/perceptual-media-dedupe-with-threshold-review/TECHNIQUE.md)
+- [AOA-T-0073 semantic-media-bucketing-with-vision-plus-ocr](../../../../../techniques/ingest/media-ingest/semantic-media-bucketing-with-vision-plus-ocr/TECHNIQUE.md)
+- [AOA-T-0074 telegram-export-normalization-to-local-store](../../../../../techniques/ingest/media-ingest/telegram-export-normalization-to-local-store/TECHNIQUE.md)
+- [Ingest route card](../../../../../techniques/ingest/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Media-ingest tree pilot receipt](../../../../../legacy/receipts/2026-05-04-media-ingest-tree-pilot.md)
+- [Technique tree projection rows for `media-ingest` and
+  `diagnosis-repair`](../../../../../reports/technique_tree_projection.md)
+- `incoming/personal-ingest-wave-2/docs/EXTERNAL_TECHNIQUE_CANDIDATES_PERSONAL_INGEST_WAVE_2.md`
+- `incoming/personal-ingest-wave-2/docs/TELEGRAM_ACCOUNT_AUTH_AND_SESSION_BRIDGE_NARROWING_MEMO.md`
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/ingest/media-ingest/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | `domain` still carries owner lane and `kind` still carries move shape |
+| route card | present | `techniques/ingest/AGENTS.md` names the trunk boundary without turning `ingest` into a frontmatter domain |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, sections, examples, checklists, evidence notes, family/topology reports, and tree projection point at current paths |
+| staging links | repaired | Personal Ingest Wave 2 candidate docs and the Telegram auth hold memo point at current authored paths |
+| validation | green | release check covered unit tests, nested AGENTS coverage, and repository parity |
+
+## What The Third Pilot Proved
+
+- A non-continuity trunk can land without changing frontmatter or technique
+  meaning.
+- `ingest/` is useful as a placement district because it names the intake
+  object before downstream extraction, routing, cleanup, memory, moderation, or
+  automation begins.
+- `media-ingest` can hold both document/image intake and Telegram-source
+  normalization when the shared center is a bounded reviewable intermediate
+  object.
+- The Telegram edge remained bounded: `telegram-account-auth-and-session-bridge`
+  stayed outside the shelf, and auth/session/control behavior stayed out of
+  the normalized local-store technique.
+- Incoming staging docs are not canon, but their links to landed bundles should
+  still follow current authored homes after a path migration.
+
+## Remaining Weaknesses
+
+- The generated projection still labels landed shelves as `pilot-candidate`.
+  That is tolerable while the projection remains non-authoritative, but later
+  generated status language may need a separate review.
+- `ingest/` currently has one shelf, so the trunk is validated as a pilot
+  district, not as final complete ingest taxonomy.
+- The shelf does not prove that source-specific normalization can always share
+  space with media/document intake; future growth may still split
+  `source-ingest` or message-ingest shelves.
+- No recovery, instruction, knowledge-lift, boundary-watch, split-review-needed,
+  or singleton shelf has moved yet.
+
+## Fourth Shelf Choice
+
+Choose `diagnosis-repair` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0080` | `techniques/agent-workflows/session-drift-taxonomy/` | `techniques/recovery/diagnosis-repair/session-drift-taxonomy/` |
+| `AOA-T-0081` | `techniques/agent-workflows/diagnosis-from-reviewed-evidence/` | `techniques/recovery/diagnosis-repair/diagnosis-from-reviewed-evidence/` |
+| `AOA-T-0082` | `techniques/agent-workflows/repair-shape-from-diagnosis/` | `techniques/recovery/diagnosis-repair/repair-shape-from-diagnosis/` |
+| `AOA-T-0083` | `techniques/agent-workflows/checkpoint-bound-self-repair/` | `techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/` |
+
+Reason:
+
+`diagnosis-repair` is the smallest remaining clean `pilot-candidate` shelf that
+tests a new trunk. It is smaller than `instruction-surface` and
+`kag-source-lift`, more mature than the singleton `tool-gateway`, and less
+owner-sensitive than `boundary-watch` proof/governance shelves. It also gives a
+useful tree-versus-facets stress case: two techniques are `kind: assessment`,
+two are `kind: recovery`, yet all four share the recovery district because the
+browse question is diagnosis and repair after reviewed friction.
+
+## Stop Lines
+
+- Do not move `diagnosis-repair` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `instruction-surface`, `kag-source-lift`, `agent-workflows-core`,
+  or any `boundary-watch` shelf in the same wave.
+- Do not treat `recovery` as a final trunk until direct reading confirms the
+  four bundles are clearer there than in `agent-workflows`.
+- Do not widen diagnosis-repair into general self-improvement, role-law,
+  proof-law, or scenario-rollout doctrine.
+
+## Next Honest Move
+
+Run a direct-read migration review for `diagnosis-repair`.
+
+Read `AOA-T-0080` through `AOA-T-0083`, inspect their relation chain, owner
+boundary notes, recovery trunk needs, generated-surface blast radius, and
+route-card needs, then decide whether those exact bundles should move into
+`techniques/recovery/diagnosis-repair/`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -97,6 +97,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/handoff-continuation-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-handoff-continuation-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1201,7 +1202,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Review the landed `media-ingest` shelf", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `diagnosis-repair`", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1301,6 +1302,74 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "TECHNIQUE.md"
             ).is_file()
         )
+
+    def test_landed_media_ingest_pilot_review_selects_diagnosis_repair(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-media-ingest-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Media-Ingest Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("Accept the landed `media-ingest` pilot", review)
+        self.assertIn("first non-continuity trunk test", review)
+        self.assertIn("Telegram edge remained bounded", review)
+        self.assertIn("Choose `diagnosis-repair`", review)
+        for technique_id in (
+            "AOA-T-0080",
+            "AOA-T-0081",
+            "AOA-T-0082",
+            "AOA-T-0083",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Do not move `diagnosis-repair` from this review alone", review)
+        self.assertIn("Run a direct-read migration review for `diagnosis-repair`", review)
+        self.assertIn("landed-media-ingest-pilot-review", reviews_index)
+        self.assertIn("landed media-ingest pilot review: landed", ingress)
+        self.assertIn("diagnosis-repair", ingress)
+        self.assertIn("diagnosis-repair` is now", distillation_roadmap)
+        self.assertIn("Landed media-ingest pilot review", landing_log)
+        self.assertIn("selected\n  `diagnosis-repair`", changelog)
+        self.assertIn("Run a direct-read migration review for `diagnosis-repair`", root_roadmap)
+        self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
+        self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the landed media-ingest pilot review as the post-migration check for the third tree pilot
- validate media-ingest as the first non-continuity trunk landing and choose diagnosis-repair for the next direct-read review
- update technique tree route surfaces, roadmap/changelog, landing log, reviews index, and topology tests

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py