### PR TITLE
Accept diagnosis-repair migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `media-ingest` pilot review and selected
   `diagnosis-repair` for the next direct-read migration review without moving
   a fourth shelf yet
+- accepted the `diagnosis-repair` direct-read migration review over
+  `AOA-T-0080` through `AOA-T-0083` as the fourth tree pilot while keeping the
+  review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,7 +134,7 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 | Field | Direction |
 |---|---|
 | Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, and the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`; all three kept frontmatter unchanged. |
-| Next honest move | Run a direct-read migration review for `diagnosis-repair` before moving any fourth tree shelf. |
+| Next honest move | Land the fourth pilot migration for exactly `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -185,8 +185,8 @@ trigger is real.
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, and
-  `media-ingest` pilots as precedents while testing `diagnosis-repair` as the
-  next direct-read shelf review before considering any broader corpus move.
+  `media-ingest` pilots as precedents while landing `diagnosis-repair` as the
+  next bounded shelf migration before considering any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -215,14 +215,18 @@ It validates the `media-ingest` migration as the first successful
 non-continuity trunk test and chooses `diagnosis-repair` for the next
 direct-read migration review.
 
+The fourth migration review is
+[Diagnosis-Repair Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md).
+It accepts `diagnosis-repair` as the fourth migration pilot after directly
+reading `AOA-T-0080` through `AOA-T-0083`.
+
 The next reform slice should:
 
-1. read `AOA-T-0080` through `AOA-T-0083` directly
-2. decide whether `diagnosis-repair` is clearer under
-   `techniques/recovery/diagnosis-repair/` than under the broad
-   `agent-workflows` folder
-3. preserve frontmatter, generated-surface parity, and root legacy accounting
-   if a fourth migration later lands
+1. move exactly `AOA-T-0080` through `AOA-T-0083` into
+   `techniques/recovery/diagnosis-repair/`
+2. add the minimal `recovery/` route card and root legacy receipt
+3. repair authored links, rebuild generated surfaces, and keep frontmatter
+   unchanged
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,35 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Diagnosis-repair direct-read migration review
+
+Changed:
+
+- added
+  [diagnosis-repair-direct-read-migration-review](parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0080` through `AOA-T-0083`
+- accepted `diagnosis-repair` as the fourth bounded tree migration pilot and
+  the next recovery trunk test
+- recorded the exact next migration scope:
+  `techniques/recovery/diagnosis-repair/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept self-improvement, hidden doctrine edits, role-law, proof-law, and
+  scenario rollout outside the accepted shelf
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no fourth shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed media-ingest pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -55,8 +55,11 @@
    root legacy receipt accounting, link repair, generated rebuilds, and
    release-check validation in the same wave. The landed `media-ingest` pilot
    review is also landed as `pilot-validated`, and `diagnosis-repair` is now
-   chosen for the next direct-read migration review before any fourth shelf
-   moves.
+   chosen for the next direct-read migration review. The `diagnosis-repair`
+   direct-read review is now landed as
+   `accepted-for-fourth-migration-pilot`, and the next tree move is the fourth
+   pilot migration for exactly `AOA-T-0080` through `AOA-T-0083` before any
+   other shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -50,6 +50,8 @@ permission slip to remap techniques automatically.
   under `techniques/ingest/media-ingest/` without frontmatter changes
 - landed media-ingest pilot review: landed as `pilot-validated`, with
   `diagnosis-repair` chosen for the next direct-read migration review
+- diagnosis-repair direct-read review: landed as
+  `accepted-for-fourth-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -149,6 +151,10 @@ into `techniques/ingest/media-ingest/` without changing frontmatter or adding
 The landed `media-ingest` pilot review is now landed as `pilot-validated` and
 chooses `diagnosis-repair` for the next direct-read migration review.
 
-The next move is to read `AOA-T-0080` through `AOA-T-0083` directly and decide
-whether those four bundles should move into
-`techniques/recovery/diagnosis-repair/` without changing frontmatter.
+The `diagnosis-repair` direct-read review is now landed and accepts exactly
+`AOA-T-0080` through `AOA-T-0083` as the fourth migration pilot.
+
+The next move is the fourth pilot migration: move those four bundles into
+`techniques/recovery/diagnosis-repair/`, add the minimal `recovery/` route
+card, repair authored links, preserve a root legacy receipt, rebuild generated
+surfaces, and keep frontmatter unchanged.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -18,5 +18,6 @@ Current reviews:
 - [landed-handoff-continuation-pilot-review](landed-handoff-continuation-pilot-review.md)
 - [media-ingest-direct-read-migration-review](media-ingest-direct-read-migration-review.md)
 - [landed-media-ingest-pilot-review](landed-media-ingest-pilot-review.md)
+- [diagnosis-repair-direct-read-migration-review](diagnosis-repair-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md
@@ -1,0 +1,159 @@
+# Diagnosis-Repair Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Prior pilot review:
+[Landed Media-Ingest Pilot Review](landed-media-ingest-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-fourth-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `diagnosis-repair` as the fourth migration pilot.
+
+The move is clearer than current placement because the four bundles share one
+recovery question: reviewed friction must be classified, diagnosed, shaped into
+the smallest honest repair, and then kept behind explicit checkpoint posture
+before any meaningful self-repair happens. `agent-workflows` remains true as
+their current `domain`, but it is too broad as a browsing neighborhood for a
+post-review recovery chain.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if route cards, root legacy receipts, link repair,
+generated surfaces, and validation move together.
+
+## Sources Read
+
+- [AOA-T-0080 session-drift-taxonomy](../../../../../techniques/agent-workflows/session-drift-taxonomy/TECHNIQUE.md)
+- [AOA-T-0081 diagnosis-from-reviewed-evidence](../../../../../techniques/agent-workflows/diagnosis-from-reviewed-evidence/TECHNIQUE.md)
+- [AOA-T-0082 repair-shape-from-diagnosis](../../../../../techniques/agent-workflows/repair-shape-from-diagnosis/TECHNIQUE.md)
+- [AOA-T-0083 checkpoint-bound-self-repair](../../../../../techniques/agent-workflows/checkpoint-bound-self-repair/TECHNIQUE.md)
+- canonical-readiness notes for `AOA-T-0080` through `AOA-T-0083`
+- origin-evidence notes for `AOA-T-0080` through `AOA-T-0083`
+- checklists and minimal examples for `AOA-T-0080` through `AOA-T-0083`
+- `reports/technique_tree_projection.md` rows for `AOA-T-0080` through
+  `AOA-T-0083`
+- `reports/technique_topology_scout.md` rows for `AOA-T-0080` through
+  `AOA-T-0083`
+
+## Direct Read
+
+| technique | current kind | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0080` `session-drift-taxonomy` | `assessment` | classifies repeated reviewed friction into bounded drift types before causes or owner hints are named | recovery diagnosis starts with a read-only taxonomy layer, not blame or repair execution |
+| `AOA-T-0081` `diagnosis-from-reviewed-evidence` | `assessment` | turns reviewed evidence into one diagnosis packet with symptoms, probable causes, owner hints, and unknowns | read-only diagnosis before mutation, not repair planning or final verdict |
+| `AOA-T-0082` `repair-shape-from-diagnosis` | `recovery` | converts a reviewed diagnosis into the smallest honest owner-facing repair shape with validation and escalation cues | repair planning after diagnosis, not checkpoint policy or scenario rollout |
+| `AOA-T-0083` `checkpoint-bound-self-repair` | `recovery` | wraps a bounded repair shape in explicit approval, rollback, health-check, iteration-limit, and improvement-log posture | checkpoint posture for self-repair, not general approval doctrine or silent self-modification |
+
+The shelf is not merely "post-session cleanup." It is the narrower recovery
+seam where reviewed friction becomes a bounded diagnosis and repair path while
+mutation remains explicit, reviewable, and reversible.
+
+## Boundary Read
+
+The shelf remains useful only if the bundle boundaries stay sharp:
+
+- `AOA-T-0080` owns drift taxonomy, not probable cause or owner routing.
+- `AOA-T-0081` owns diagnosis from reviewed evidence, not repair execution.
+- `AOA-T-0082` owns repair-shape selection, not checkpoint posture itself.
+- `AOA-T-0083` owns checkpoint posture around bounded self-repair, not the
+  diagnosis or the chosen repair shape.
+
+These four techniques are adjacent and sequence-friendly, but they are not one
+combined workflow bundle. Keeping them as separate leaves is what makes the
+future `diagnosis-repair` shelf legible.
+
+## Mixed Kind Stress
+
+`diagnosis-repair` is a useful fourth pilot because it tests tree-versus-facets
+again:
+
+- `AOA-T-0080` and `AOA-T-0081` are `kind: assessment`
+- `AOA-T-0082` and `AOA-T-0083` are `kind: recovery`
+- all four belong in a recovery district because the browsing question is
+  post-review recovery, not the local operation shape
+
+This is exactly the kind of shelf that should be possible in the future tree:
+the path groups a practice neighborhood, while `kind` still tells a small agent
+which move shape it is executing.
+
+## Why Not Keep This As Agent Workflows
+
+`agent-workflows` remains true as `domain`: all four bundles are reusable
+agent-facing workflow techniques.
+
+The directory tree now answers a browsing and placement question. On that
+question, `recovery/diagnosis-repair` is tighter than the old broad folder:
+
+- the four bundles already form a visible relation chain from taxonomy to
+  diagnosis to repair shape to checkpoint posture
+- all four start from reviewed evidence or a reviewed diagnosis rather than
+  live improvisation
+- the shelf is small enough to direct-read and migrate in one wave
+- it tests a new trunk after continuity and ingest have both landed
+- it stays away from `boundary-watch`, `split-review-needed`, and singleton
+  shelves
+
+## Pilot Scope
+
+Move exactly these four bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0080` | `techniques/agent-workflows/session-drift-taxonomy/` | `techniques/recovery/diagnosis-repair/session-drift-taxonomy/` |
+| `AOA-T-0081` | `techniques/agent-workflows/diagnosis-from-reviewed-evidence/` | `techniques/recovery/diagnosis-repair/diagnosis-from-reviewed-evidence/` |
+| `AOA-T-0082` | `techniques/agent-workflows/repair-shape-from-diagnosis/` | `techniques/recovery/diagnosis-repair/repair-shape-from-diagnosis/` |
+| `AOA-T-0083` | `techniques/agent-workflows/checkpoint-bound-self-repair/` | `techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored sibling links inside the four moved bundles
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated reports for family, topology, and tree projection
+- a new `techniques/recovery/AGENTS.md` route card, because `recovery/` would
+  become the next migrated trunk
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, and repo-doc surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move another `pilot-candidate` shelf in the same wave.
+- Do not rename `diagnosis-repair` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not widen recovery into self-improvement rhetoric, hidden doctrine edits,
+  role-law changes, proof-law changes, or scenario-scale rollout.
+- Do not collapse the four leaves into one diagnosis-repair workflow bundle.
+
+## Next Honest Move
+
+Run the fourth pilot migration.
+
+Move exactly `AOA-T-0080` through `AOA-T-0083` into
+`techniques/recovery/diagnosis-repair/`, add the minimal `recovery/` route
+card, repair authored links, preserve a root legacy receipt, rebuild generated
+surfaces, and run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -98,6 +98,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-handoff-continuation-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1202,7 +1203,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Run a direct-read migration review for `diagnosis-repair`", root_roadmap)
+        self.assertIn("Land the fourth pilot migration", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1367,9 +1368,90 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Run a direct-read migration review for `diagnosis-repair`", root_roadmap)
+        self.assertIn("Land the fourth pilot migration", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
+
+    def test_diagnosis_repair_direct_read_review_accepts_fourth_pilot(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "diagnosis-repair-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Diagnosis-Repair Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-fourth-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `diagnosis-repair` as the fourth migration pilot", review)
+        for technique_id in (
+            "AOA-T-0080",
+            "AOA-T-0081",
+            "AOA-T-0082",
+            "AOA-T-0083",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Mixed Kind Stress", review)
+        self.assertIn("Move exactly these four bundles", review)
+        self.assertIn("techniques/recovery/diagnosis-repair/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Run the fourth pilot migration", review)
+
+        self.assertIn("diagnosis-repair-direct-read-migration-review", reviews_index)
+        self.assertIn("diagnosis-repair direct-read review: landed", ingress)
+        self.assertIn("accepted-for-fourth-migration-pilot", ingress)
+        self.assertIn("fourth pilot migration", ingress)
+        self.assertIn("accepted-for-fourth-migration-pilot", distillation_roadmap)
+        self.assertIn("Diagnosis-repair direct-read migration review", landing_log)
+        self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
+        self.assertIn("Land the fourth pilot migration", root_roadmap)
+        self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "agent-workflows"
+                / "session-drift-taxonomy"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse((REPO_ROOT / "techniques" / "recovery").exists())
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the diagnosis-repair direct-read migration review over AOA-T-0080 through AOA-T-0083
- accept diagnosis-repair as the fourth tree pilot without moving files or changing frontmatter
- update tree reform route surfaces, roadmap/changelog, landing log, reviews index, and topology tests

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py