### PR TITLE
Review landed diagnosis-repair tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ The format is intentionally simple and human-first.
 - moved `AOA-T-0080` through `AOA-T-0083` into
   `techniques/recovery/diagnosis-repair/` while keeping `domain`, `kind`, IDs,
   status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `diagnosis-repair` pilot review and selected
+  `instruction-surface` for the next direct-read migration review without
+  moving a fifth shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, and the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`; all four kept frontmatter unchanged. |
-| Next honest move | Review the landed `diagnosis-repair` shelf before choosing any fifth migration candidate. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, and the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`; all four kept frontmatter unchanged, and `instruction-surface` is chosen for the next direct-read review. |
+| Next honest move | Run a direct-read migration review for `instruction-surface` before moving any fifth shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -185,8 +185,8 @@ trigger is real.
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
-  and `diagnosis-repair` pilots as precedents while reviewing the fourth shelf
-  before considering any broader corpus move.
+  and `diagnosis-repair` pilots as precedents while direct-reading
+  `instruction-surface` before considering any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -225,8 +225,13 @@ The fourth pilot migration moves `AOA-T-0080` through `AOA-T-0083` into
 `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-diagnosis-repair-tree-pilot.md`](../legacy/receipts/2026-05-04-diagnosis-repair-tree-pilot.md).
 
-The next reform slice should review the landed `diagnosis-repair` shelf before
-choosing any fifth migration candidate.
+The landed fourth pilot review is
+[Landed Diagnosis-Repair Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md).
+It validates the `diagnosis-repair` migration as the first successful recovery
+trunk test and chooses `instruction-surface` for the next direct-read review.
+
+The next reform slice should direct-read `instruction-surface` before moving
+any fifth migration candidate.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,35 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed diagnosis-repair pilot review
+
+Changed:
+
+- added
+  [landed-diagnosis-repair-pilot-review](parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md)
+  as the post-migration review over the fourth tree pilot
+- accepted the landed `diagnosis-repair` shelf as clearer after validation and
+  as the first successful recovery trunk test
+- chose `instruction-surface` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `kag-source-lift`, boundary-watch proof shelves, and
+  `automation-governance` outside the next move
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no fifth shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Diagnosis-repair tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -61,8 +61,10 @@
    landed exactly for `AOA-T-0080` through `AOA-T-0083` under
    `techniques/recovery/diagnosis-repair/`, with the recovery route card,
    root legacy receipt accounting, link repair, generated rebuilds, and
-   release-check validation in the same wave. The next tree move is a landed
-   `diagnosis-repair` pilot review before any fifth shelf is chosen.
+   release-check validation in the same wave. The landed `diagnosis-repair`
+   pilot review is also landed as `pilot-validated`, and
+   `instruction-surface` is now chosen for the next direct-read migration
+   review before any fifth shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -54,6 +54,8 @@ permission slip to remap techniques automatically.
   `accepted-for-fourth-migration-pilot`; still not path movement
 - diagnosis-repair migration: landed exactly `AOA-T-0080` through `AOA-T-0083`
   under `techniques/recovery/diagnosis-repair/` without frontmatter changes
+- landed diagnosis-repair pilot review: landed as `pilot-validated`, with
+  `instruction-surface` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -83,6 +85,9 @@ permission slip to remap techniques automatically.
 | [Handoff-Continuation Direct-Read Migration Review](reviews/handoff-continuation-direct-read-migration-review.md) | reads `AOA-T-0056` through `AOA-T-0062` directly and accepts the shelf as the second migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move any other shelf |
 | [Landed Handoff-Continuation Pilot Review](reviews/landed-handoff-continuation-pilot-review.md) | confirms the second migrated shelf stayed clearer, validates the continuity trunk machinery, and chooses `media-ingest` for the next direct-read review | movement of `media-ingest`, `tree_path` frontmatter, or proof that every trunk is ready |
 | [Media-Ingest Direct-Read Migration Review](reviews/media-ingest-direct-read-migration-review.md) | reads `AOA-T-0070` through `AOA-T-0074` directly and accepts the shelf as the third migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
+| [Landed Media-Ingest Pilot Review](reviews/landed-media-ingest-pilot-review.md) | confirms the third migrated shelf stayed clearer, validates the first non-continuity trunk test, and chooses `diagnosis-repair` for the next direct-read review | movement of `diagnosis-repair`, `tree_path` frontmatter, or proof that every non-continuity trunk is safe |
+| [Diagnosis-Repair Direct-Read Migration Review](reviews/diagnosis-repair-direct-read-migration-review.md) | reads `AOA-T-0080` through `AOA-T-0083` directly and accepts the shelf as the fourth migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
+| [Landed Diagnosis-Repair Pilot Review](reviews/landed-diagnosis-repair-pilot-review.md) | confirms the fourth migrated shelf stayed clearer, validates the recovery trunk machinery, and chooses `instruction-surface` for the next direct-read review | movement of `instruction-surface`, `tree_path` frontmatter, or proof that every docs-domain shelf is safe |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -161,5 +166,8 @@ The fourth pilot migration is now landed: those four bundles live under
 legacy receipt are in place, authored links were repaired, generated surfaces
 were rebuilt, and frontmatter stayed unchanged.
 
-The next move is a landed-pilot review over `diagnosis-repair` before choosing
-any fifth candidate shelf.
+The landed `diagnosis-repair` pilot review is now landed as `pilot-validated`
+and chooses `instruction-surface` for the next direct-read migration review.
+
+The next move is a direct-read migration review for `instruction-surface`
+before any fifth shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -19,5 +19,6 @@ Current reviews:
 - [media-ingest-direct-read-migration-review](media-ingest-direct-read-migration-review.md)
 - [landed-media-ingest-pilot-review](landed-media-ingest-pilot-review.md)
 - [diagnosis-repair-direct-read-migration-review](diagnosis-repair-direct-read-migration-review.md)
+- [landed-diagnosis-repair-pilot-review](landed-diagnosis-repair-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md
@@ -1,0 +1,146 @@
+# Landed Diagnosis-Repair Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Diagnosis-Repair Direct-Read Migration Review](diagnosis-repair-direct-read-migration-review.md)
+
+Migration receipt:
+[Diagnosis-Repair Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-diagnosis-repair-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `instruction-surface` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `diagnosis-repair` pilot as a successful fourth tree
+migration and the first recovery trunk test.
+
+The shelf stayed legible after landing: four separate promoted techniques now
+sit under one recovery neighborhood, while their IDs, `domain`, `kind`, status,
+evidence, notes, examples, checks, and public-safety posture stayed unchanged.
+The move improved browsing without collapsing taxonomy, diagnosis, repair-shape
+selection, and checkpoint-bound repair posture into one self-repair workflow.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should run a direct-read review for `instruction-surface`, because the
+tree has now tested continuity, ingest, and recovery. The next pressure should
+test a docs-rooted instruction district before the more derived
+`kag-source-lift` shelf risks sounding like KAG owner authority.
+
+## Sources Read
+
+- [AOA-T-0080 session-drift-taxonomy](../../../../../techniques/recovery/diagnosis-repair/session-drift-taxonomy/TECHNIQUE.md)
+- [AOA-T-0081 diagnosis-from-reviewed-evidence](../../../../../techniques/recovery/diagnosis-repair/diagnosis-from-reviewed-evidence/TECHNIQUE.md)
+- [AOA-T-0082 repair-shape-from-diagnosis](../../../../../techniques/recovery/diagnosis-repair/repair-shape-from-diagnosis/TECHNIQUE.md)
+- [AOA-T-0083 checkpoint-bound-self-repair](../../../../../techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/TECHNIQUE.md)
+- [Recovery route card](../../../../../techniques/recovery/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Diagnosis-repair tree pilot receipt](../../../../../legacy/receipts/2026-05-04-diagnosis-repair-tree-pilot.md)
+- [Technique tree projection rows for `diagnosis-repair`,
+  `instruction-surface`, and `kag-source-lift`](../../../../../reports/technique_tree_projection.md)
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/recovery/diagnosis-repair/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | `domain` still carries owner lane and `kind` still carries move shape |
+| route card | present | `techniques/recovery/AGENTS.md` names recovery boundaries without turning `recovery` into a frontmatter domain |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, sections, examples, checklists, evidence notes, family/topology reports, and tree projection point at current paths |
+| mechanics links | repaired | Audit, Growth-cycle, Checkpoint, Agon gate overlaps, and reform review links point at current authored paths |
+| validation | green | release check covered unit tests, nested AGENTS coverage, repository parity, and regenerated surfaces |
+
+## What The Fourth Pilot Proved
+
+- A recovery trunk can land without changing `domain`, `kind`, or technique
+  meaning.
+- A single shelf can hold both `assessment` and `recovery` kinds when the
+  browsing question is the reviewed diagnosis-to-repair arc.
+- `recovery/` can name a placement district without importing checkpoint law,
+  proof law, role law, incident-response doctrine, or self-improvement rhetoric.
+- Root `legacy/receipts/` remains enough for path-migration accounting; active
+  bundles did not need to pass through legacy.
+- Repairing mechanics links matters even when mechanics are not canon, because
+  those surfaces are active route anchors for future agents.
+
+## Remaining Weaknesses
+
+- The generated projection still labels landed shelves as `pilot-candidate`.
+  That is tolerable while the projection remains non-authoritative, but later
+  generated status language may need a separate review.
+- `recovery/` currently has one landed shelf, so the trunk is validated as a
+  pilot district, not as a complete recovery taxonomy.
+- `antifragility-recovery` has not been direct-read in this tree context; it
+  should not be assumed to fit the same shelf or migration shape.
+- No instruction, knowledge-lift, governance, proof, execution, or history
+  trunk has moved yet.
+
+## Fifth Shelf Choice
+
+Choose `instruction-surface` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0012` | `techniques/docs/deterministic-context-composition/` | `techniques/instruction/instruction-surface/deterministic-context-composition/` |
+| `AOA-T-0013` | `techniques/docs/single-source-rule-distribution/` | `techniques/instruction/instruction-surface/single-source-rule-distribution/` |
+| `AOA-T-0024` | `techniques/docs/upstream-mirroring-with-provenance/` | `techniques/instruction/instruction-surface/upstream-mirroring-with-provenance/` |
+| `AOA-T-0027` | `techniques/docs/cross-agent-skill-propagation/` | `techniques/instruction/instruction-surface/cross-agent-skill-propagation/` |
+| `AOA-T-0029` | `techniques/docs/nested-rule-loading/` | `techniques/instruction/instruction-surface/nested-rule-loading/` |
+| `AOA-T-0030` | `techniques/docs/fragmented-agent-context/` | `techniques/instruction/instruction-surface/fragmented-agent-context/` |
+| `AOA-T-0035` | `techniques/docs/profile-preset-composition/` | `techniques/instruction/instruction-surface/profile-preset-composition/` |
+
+Reason:
+
+`instruction-surface` is the next clean `pilot-candidate` shelf that tests a
+new trunk without immediately crossing into KAG owner semantics. It is larger
+than the previous pilots, but still bounded: seven docs-domain techniques
+around composing, distributing, loading, fragmenting, mirroring, and presetting
+agent-facing instruction surfaces.
+
+This is a useful stress case for the portable-library goal. The bundles should
+remain understandable to external builders as reusable instruction-surface
+techniques, while their `domain: docs` frontmatter continues to own the current
+review lane.
+
+Why not `kag-source-lift` first:
+
+`kag-source-lift` is strong and likely close behind, but it touches derived
+knowledge projection and should be reviewed after the instruction trunk proves
+that docs-rooted techniques can move without turning the tree into
+source-of-truth law or generated KAG authority.
+
+## Stop Lines
+
+- Do not move `instruction-surface` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `kag-source-lift`, `agent-workflows-core`,
+  `automation-governance`, `review-evidence`, `owner-truth-closeout`, or any
+  boundary-watch shelf in the same wave.
+- Do not treat `instruction` as AoA constitutional law, skill acceptance,
+  runtime behavior, generated context authority, or public source-of-truth
+  replacement.
+- Do not collapse instruction composition, distribution, mirroring, nested
+  loading, fragmentation, and profile presets into one mega-technique.
+
+## Next Honest Move
+
+Run a direct-read migration review for `instruction-surface`.
+
+Read `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`,
+`AOA-T-0030`, and `AOA-T-0035`; inspect their relation chain, docs-domain
+boundaries, source-of-truth risks, generated-surface blast radius, route-card
+needs, and whether `instruction/` is clearer than the old broad `docs/` folder.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -99,6 +99,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/media-ingest-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1203,7 +1204,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Review the landed `diagnosis-repair` shelf", root_roadmap)
+        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1368,7 +1369,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Review the landed `diagnosis-repair` shelf", root_roadmap)
+        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1445,7 +1446,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Review the landed `diagnosis-repair` shelf", root_roadmap)
+        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1459,6 +1460,81 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "TECHNIQUE.md"
             ).is_file()
         )
+
+    def test_landed_diagnosis_repair_pilot_review_selects_instruction_surface(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-diagnosis-repair-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Diagnosis-Repair Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("Accept the landed `diagnosis-repair` pilot", review)
+        self.assertIn("first recovery trunk test", review)
+        self.assertIn("Choose `instruction-surface`", review)
+        for technique_id in (
+            "AOA-T-0012",
+            "AOA-T-0013",
+            "AOA-T-0024",
+            "AOA-T-0027",
+            "AOA-T-0029",
+            "AOA-T-0030",
+            "AOA-T-0035",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Why not `kag-source-lift` first", review)
+        self.assertIn("Do not move `instruction-surface` from this review alone", review)
+        self.assertIn(
+            "Run a direct-read migration review for `instruction-surface`",
+            review,
+        )
+        self.assertIn("landed-diagnosis-repair-pilot-review", reviews_index)
+        self.assertIn("landed diagnosis-repair pilot review: landed", ingress)
+        self.assertIn("instruction-surface", ingress)
+        self.assertIn("Landed Diagnosis-Repair Pilot Review", ingress)
+        self.assertIn("`instruction-surface` is now chosen", distillation_roadmap)
+        self.assertIn("Landed diagnosis-repair pilot review", landing_log)
+        self.assertIn("selected\n  `instruction-surface`", changelog)
+        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
+        self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
+        self.assertIn("instruction-surface", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the landed diagnosis-repair pilot review after the fourth tree migration
- confirm the recovery trunk pilot stayed bounded and frontmatter-neutral
- choose instruction-surface for the next direct-read migration review without moving another shelf

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/validate_semantic_agents.py
- python scripts/release_check.py