### PR TITLE
Accept instruction-surface migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ The format is intentionally simple and human-first.
 - accepted the landed `diagnosis-repair` pilot review and selected
   `instruction-surface` for the next direct-read migration review without
   moving a fifth shelf yet
+- accepted the `instruction-surface` direct-read migration review over
+  `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`,
+  `AOA-T-0030`, and `AOA-T-0035` as the fifth tree pilot while keeping the
+  review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, and the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`; all four kept frontmatter unchanged, and `instruction-surface` is chosen for the next direct-read review. |
-| Next honest move | Run a direct-read migration review for `instruction-surface` before moving any fifth shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, and the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`; all four kept frontmatter unchanged, and `instruction-surface` is accepted for the fifth pilot migration. |
+| Next honest move | Land the fifth pilot migration for exactly `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -185,8 +185,9 @@ trigger is real.
 - Promote `family` from scout-only to optional reviewed frontmatter only after
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
-  and `diagnosis-repair` pilots as precedents while direct-reading
-  `instruction-surface` before considering any broader corpus move.
+  and `diagnosis-repair` pilots as precedents while landing
+  `instruction-surface` as the next bounded shelf migration before considering
+  any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -230,8 +230,20 @@ The landed fourth pilot review is
 It validates the `diagnosis-repair` migration as the first successful recovery
 trunk test and chooses `instruction-surface` for the next direct-read review.
 
-The next reform slice should direct-read `instruction-surface` before moving
-any fifth migration candidate.
+The fifth migration review is
+[Instruction-Surface Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md).
+It accepts `instruction-surface` as the fifth migration pilot after directly
+reading `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`,
+`AOA-T-0030`, and `AOA-T-0035`.
+
+The next reform slice should:
+
+1. move exactly `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`,
+   `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into
+   `techniques/instruction/instruction-surface/`
+2. add the minimal `instruction/` route card and root legacy receipt
+3. repair authored links, rebuild generated surfaces, and keep frontmatter
+   unchanged
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,36 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Instruction-surface direct-read migration review
+
+Changed:
+
+- added
+  [instruction-surface-direct-read-migration-review](parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`,
+  `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035`
+- accepted `instruction-surface` as the fifth bounded tree migration pilot and
+  the next instruction trunk test
+- recorded the exact next migration scope:
+  `techniques/instruction/instruction-surface/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `kag-source-lift`, docs-boundary, capability, proof, governance, and
+  runtime-authority shelves outside the accepted move
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no fifth shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed diagnosis-repair pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -64,7 +64,11 @@
    release-check validation in the same wave. The landed `diagnosis-repair`
    pilot review is also landed as `pilot-validated`, and
    `instruction-surface` is now chosen for the next direct-read migration
-   review before any fifth shelf moves.
+   review. The `instruction-surface` direct-read review is now landed as
+   `accepted-for-fifth-migration-pilot`, and the next tree move is the fifth
+   pilot migration for exactly `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`,
+   `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` before any
+   other shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -56,6 +56,8 @@ permission slip to remap techniques automatically.
   under `techniques/recovery/diagnosis-repair/` without frontmatter changes
 - landed diagnosis-repair pilot review: landed as `pilot-validated`, with
   `instruction-surface` chosen for the next direct-read migration review
+- instruction-surface direct-read review: landed as
+  `accepted-for-fifth-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -88,6 +90,7 @@ permission slip to remap techniques automatically.
 | [Landed Media-Ingest Pilot Review](reviews/landed-media-ingest-pilot-review.md) | confirms the third migrated shelf stayed clearer, validates the first non-continuity trunk test, and chooses `diagnosis-repair` for the next direct-read review | movement of `diagnosis-repair`, `tree_path` frontmatter, or proof that every non-continuity trunk is safe |
 | [Diagnosis-Repair Direct-Read Migration Review](reviews/diagnosis-repair-direct-read-migration-review.md) | reads `AOA-T-0080` through `AOA-T-0083` directly and accepts the shelf as the fourth migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Landed Diagnosis-Repair Pilot Review](reviews/landed-diagnosis-repair-pilot-review.md) | confirms the fourth migrated shelf stayed clearer, validates the recovery trunk machinery, and chooses `instruction-surface` for the next direct-read review | movement of `instruction-surface`, `tree_path` frontmatter, or proof that every docs-domain shelf is safe |
+| [Instruction-Surface Direct-Read Migration Review](reviews/instruction-surface-direct-read-migration-review.md) | reads `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` directly and accepts the shelf as the fifth migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -169,5 +172,11 @@ were rebuilt, and frontmatter stayed unchanged.
 The landed `diagnosis-repair` pilot review is now landed as `pilot-validated`
 and chooses `instruction-surface` for the next direct-read migration review.
 
-The next move is a direct-read migration review for `instruction-surface`
-before any fifth shelf moves.
+The `instruction-surface` direct-read review is now landed and accepts exactly
+`AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`,
+`AOA-T-0030`, and `AOA-T-0035` as the fifth migration pilot.
+
+The next move is the fifth pilot migration: move those seven bundles into
+`techniques/instruction/instruction-surface/`, add the minimal `instruction/`
+route card, repair authored links, preserve a root legacy receipt, rebuild
+generated surfaces, and keep frontmatter unchanged.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -20,5 +20,6 @@ Current reviews:
 - [landed-media-ingest-pilot-review](landed-media-ingest-pilot-review.md)
 - [diagnosis-repair-direct-read-migration-review](diagnosis-repair-direct-read-migration-review.md)
 - [landed-diagnosis-repair-pilot-review](landed-diagnosis-repair-pilot-review.md)
+- [instruction-surface-direct-read-migration-review](instruction-surface-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md
@@ -1,0 +1,201 @@
+# Instruction-Surface Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Prior pilot review:
+[Landed Diagnosis-Repair Pilot Review](landed-diagnosis-repair-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-fifth-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `instruction-surface` as the fifth migration pilot.
+
+The move is clearer than current placement because the seven bundles share one
+instruction-surface question: how agent-facing context, rules, mirrored
+sources, nested layers, fragments, and profile/preset surfaces stay explicit,
+managed, reviewable, and subordinate to their real source of truth. `docs`
+remains true as their current `domain`, but it is too broad as a browsing
+neighborhood for this instruction-surface cluster.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if route cards, root legacy receipts, link repair,
+generated surfaces, and validation move together.
+
+## Sources Read
+
+- [AOA-T-0012 deterministic-context-composition](../../../../../techniques/docs/deterministic-context-composition/TECHNIQUE.md)
+- [AOA-T-0013 single-source-rule-distribution](../../../../../techniques/docs/single-source-rule-distribution/TECHNIQUE.md)
+- [AOA-T-0024 upstream-mirroring-with-provenance](../../../../../techniques/docs/upstream-mirroring-with-provenance/TECHNIQUE.md)
+- [AOA-T-0027 cross-agent-skill-propagation](../../../../../techniques/docs/cross-agent-skill-propagation/TECHNIQUE.md)
+- [AOA-T-0029 nested-rule-loading](../../../../../techniques/docs/nested-rule-loading/TECHNIQUE.md)
+- [AOA-T-0030 fragmented-agent-context](../../../../../techniques/docs/fragmented-agent-context/TECHNIQUE.md)
+- [AOA-T-0035 profile-preset-composition](../../../../../techniques/docs/profile-preset-composition/TECHNIQUE.md)
+- canonical-readiness notes for `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`,
+  `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035`
+- checklists for all seven bundles
+- `reports/technique_tree_projection.md` rows for `instruction-surface`
+- `reports/technique_topology_scout.md` rows for `instruction-surface`
+- `reports/technique_family_scout.md` `instruction-surface` family section
+- `mechanics/audit/parts/promotion-readiness-matrix/README.md` rows for the
+  promoted instruction-surface siblings
+
+## Direct Read
+
+| technique | current kind | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0012` `deterministic-context-composition` | `composition` | composes many source fragments into one deterministic generated context artifact | one-output instruction context composition, not multi-target rule distribution |
+| `AOA-T-0013` `single-source-rule-distribution` | `distribution` | keeps one canonical rule source and fans it out to managed instruction targets | local source-to-target instruction distribution, not fragment composition or nested precedence |
+| `AOA-T-0024` `upstream-mirroring-with-provenance` | `distribution` | mirrors externally owned content with manifest and attribution preserved | upstream-owned instruction/source mirroring, not local canonical rule fan-out |
+| `AOA-T-0027` `cross-agent-skill-propagation` | `distribution` | propagates one shared skill or rule core to multiple agent-facing targets | shared skill/rule propagation, not marketplace policy or runtime role semantics |
+| `AOA-T-0029` `nested-rule-loading` | `composition` | loads parent and nested rule layers with explicit precedence | hierarchical instruction loading, not broad multi-target distribution |
+| `AOA-T-0030` `fragmented-agent-context` | `composition` | keeps agent context authored in bounded fragments before any generated aggregate | fragment-first instruction authoring, not deterministic assembly itself |
+| `AOA-T-0035` `profile-preset-composition` | `composition` | composes modules, profiles, and presets into reviewable runtime posture definitions | profile/preset surface composition, not render truth, lifecycle control, or runtime authority |
+
+The shelf is not "all docs techniques." It is the narrower cluster where
+agent-facing instruction and context surfaces are authored, composed,
+distributed, mirrored, loaded, or named in a reviewable way without letting the
+derived or target surface become hidden primary truth.
+
+## Boundary Read
+
+The shelf remains useful only if the bundle boundaries stay sharp:
+
+- `AOA-T-0012` owns many fragments into one deterministic output, not one source
+  into many targets.
+- `AOA-T-0013` owns one canonical local rule source fanning out to many managed
+  targets, not nested loading or upstream mirroring.
+- `AOA-T-0024` owns upstream-owned mirroring with provenance, not local source
+  ownership.
+- `AOA-T-0027` owns shared skill/rule propagation, not marketplace curation,
+  MCP propagation, runtime role semantics, or nested loading.
+- `AOA-T-0029` owns hierarchical precedence, not multi-target distribution.
+- `AOA-T-0030` owns fragment-first authoring, not final deterministic assembly.
+- `AOA-T-0035` owns reviewable profile/preset composition, not rendered runtime
+  truth, readiness verdicts, lifecycle commands, or deployment detail.
+
+These seven techniques are adjacent and composition-friendly, but they are not
+one instruction framework bundle. Keeping them as separate leaves is what makes
+the future `instruction-surface` shelf legible.
+
+## Mixed Kind Stress
+
+`instruction-surface` is a useful fifth pilot because it tests
+tree-versus-facets after four smaller migrations:
+
+- `AOA-T-0012`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` are
+  `kind: composition`
+- `AOA-T-0013`, `AOA-T-0024`, and `AOA-T-0027` are `kind: distribution`
+- all seven belong in an instruction district because the browsing question is
+  agent-facing instruction/context surface management, not the local operation
+  shape
+
+This preserves the point of the tree: the path groups a practice neighborhood,
+while `kind` still tells a small agent whether it is composing or distributing.
+
+## Profile Edge
+
+`AOA-T-0035` is the sharpest edge in the shelf because it came from
+`abyss-stack` profile/preset composition and touches runtime posture language.
+It still belongs in the pilot because the bundle itself keeps the reusable move
+at the reviewable surface-definition layer: modules, profiles, presets, and
+read-only inspection before launch.
+
+It must stay out of runtime truth, readiness checks, lifecycle control,
+deployment roots, host details, and one-command service behavior. If a future
+direct migration cannot keep that line crisp, `AOA-T-0035` should be held back
+rather than forcing the shelf.
+
+## Why Not Keep This As Docs
+
+`docs` remains true as `domain`: all seven bundles are
+documentation/source-surface techniques.
+
+The directory tree now answers a browsing and placement question. On that
+question, `instruction/instruction-surface` is tighter than the old broad
+folder:
+
+- the seven bundles all protect source/target/fragment/layer/preset boundaries
+  for agent-facing instruction or context surfaces
+- the two canonical anchors, `AOA-T-0012` and `AOA-T-0013`, already define the
+  main composition-vs-distribution seam
+- the promoted siblings have explicit canonical-readiness gaps without
+  undermining their shelf placement
+- the shelf tests a docs-rooted trunk after continuity, ingest, and recovery
+  have already landed
+- it stays away from `kag-source-lift`, `capability-*`, `skill-discovery`,
+  proof-boundary, governance, and singleton shelves
+
+## Pilot Scope
+
+Move exactly these seven bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0012` | `techniques/docs/deterministic-context-composition/` | `techniques/instruction/instruction-surface/deterministic-context-composition/` |
+| `AOA-T-0013` | `techniques/docs/single-source-rule-distribution/` | `techniques/instruction/instruction-surface/single-source-rule-distribution/` |
+| `AOA-T-0024` | `techniques/docs/upstream-mirroring-with-provenance/` | `techniques/instruction/instruction-surface/upstream-mirroring-with-provenance/` |
+| `AOA-T-0027` | `techniques/docs/cross-agent-skill-propagation/` | `techniques/instruction/instruction-surface/cross-agent-skill-propagation/` |
+| `AOA-T-0029` | `techniques/docs/nested-rule-loading/` | `techniques/instruction/instruction-surface/nested-rule-loading/` |
+| `AOA-T-0030` | `techniques/docs/fragmented-agent-context/` | `techniques/instruction/instruction-surface/fragmented-agent-context/` |
+| `AOA-T-0035` | `techniques/docs/profile-preset-composition/` | `techniques/instruction/instruction-surface/profile-preset-composition/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored sibling links inside the seven moved bundles
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated reports for family, topology, and tree projection
+- a new `techniques/instruction/AGENTS.md` route card, because `instruction/`
+  would become the next migrated trunk
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- docs-domain active references such as selection patterns, audit readiness
+  anchors, and any current authored links that still point to old homes
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, and repo-doc surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move another `pilot-candidate` shelf in the same wave.
+- Do not rename `instruction-surface` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not move `kag-source-lift`, `docs-boundary`, `capability-registry`,
+  `capability-boundary`, `skill-discovery`, or any proof/governance shelf in
+  the same wave.
+- Do not widen instruction into AoA constitutional law, skill acceptance,
+  runtime authority, generated context authority, or public source-of-truth
+  replacement.
+- Do not collapse the seven leaves into one instruction framework bundle.
+
+## Next Honest Move
+
+Run the fifth pilot migration.
+
+Move exactly `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`,
+`AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into
+`techniques/instruction/instruction-surface/`, add the minimal `instruction/`
+route card, repair authored links, preserve a root legacy receipt, rebuild
+generated surfaces, and run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -100,6 +100,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-media-ingest-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1204,7 +1205,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
+        self.assertIn("Land the fifth pilot migration", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1369,7 +1370,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
+        self.assertIn("Land the fifth pilot migration", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1446,7 +1447,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
+        self.assertIn("Land the fifth pilot migration", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1528,13 +1529,102 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("landed-diagnosis-repair-pilot-review", reviews_index)
         self.assertIn("landed diagnosis-repair pilot review: landed", ingress)
         self.assertIn("instruction-surface", ingress)
+        self.assertIn("instruction-surface direct-read review: landed", ingress)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", ingress)
         self.assertIn("`instruction-surface` is now chosen", distillation_roadmap)
+        self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("direct-read migration review for `instruction-surface`", root_roadmap)
+        self.assertIn("Land the fifth pilot migration", root_roadmap)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
+
+    def test_instruction_surface_direct_read_review_accepts_fifth_pilot(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "instruction-surface-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Instruction-Surface Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-fifth-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `instruction-surface` as the fifth migration pilot", review)
+        for technique_id in (
+            "AOA-T-0012",
+            "AOA-T-0013",
+            "AOA-T-0024",
+            "AOA-T-0027",
+            "AOA-T-0029",
+            "AOA-T-0030",
+            "AOA-T-0035",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Profile Edge", review)
+        self.assertIn("Move exactly these seven bundles", review)
+        self.assertIn("techniques/instruction/instruction-surface/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Run the fifth pilot migration", review)
+
+        self.assertIn("instruction-surface-direct-read-migration-review", reviews_index)
+        self.assertIn("instruction-surface direct-read review: landed", ingress)
+        self.assertIn("accepted-for-fifth-migration-pilot", ingress)
+        self.assertIn("fifth pilot migration", ingress)
+        self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
+        self.assertIn("Instruction-surface direct-read migration review", landing_log)
+        self.assertIn(
+            "accepted the `instruction-surface` direct-read migration review",
+            changelog,
+        )
+        self.assertIn("Land the fifth pilot migration", root_roadmap)
+        self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "docs"
+                / "deterministic-context-composition"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse((REPO_ROOT / "techniques" / "instruction").exists())
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the instruction-surface direct-read migration review
- accept AOA-T-0012, AOA-T-0013, AOA-T-0024, AOA-T-0027, AOA-T-0029, AOA-T-0030, and AOA-T-0035 as the fifth tree pilot scope
- update reform ingress, roadmaps, tree contract, changelog, landing log, and topology tests without moving files

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/validate_semantic_agents.py
- python scripts/release_check.py