### PR TITLE
Review landed instruction-surface tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ The format is intentionally simple and human-first.
   `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into
   `techniques/instruction/instruction-surface/` while keeping `domain`, `kind`,
   IDs, status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `instruction-surface` pilot review and selected
+  `kag-source-lift` for the next direct-read migration review without moving a
+  sixth shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, and the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`; all five kept frontmatter unchanged. |
-| Next honest move | Run the landed `instruction-surface` pilot review before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, and the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`; all five kept frontmatter unchanged, and the landed `instruction-surface` review selected `kag-source-lift` as the next direct-read review target. |
+| Next honest move | Run the `kag-source-lift` direct-read migration review before moving any sixth shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,7 +186,7 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, and `instruction-surface` pilots as precedents while
-  reviewing the fifth landed shelf before considering any broader corpus move.
+  direct-reading `kag-source-lift` before any sixth shelf moves.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -242,8 +242,14 @@ The fifth pilot migration moves `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`,
 `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-instruction-surface-tree-pilot.md`](../legacy/receipts/2026-05-04-instruction-surface-tree-pilot.md).
 
-The next reform slice should review the landed `instruction-surface` pilot
-before moving another shelf.
+The landed fifth pilot review is
+[Landed Instruction-Surface Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md).
+It validates the `instruction-surface` migration as the first successful
+instruction trunk test and chooses `kag-source-lift` for the next direct-read
+migration review.
+
+The next reform slice should run the `kag-source-lift` direct-read review before
+moving another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,37 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed instruction-surface pilot review
+
+Changed:
+
+- added
+  [landed-instruction-surface-pilot-review](parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md)
+  as the post-migration review over the fifth tree pilot
+- accepted the landed `instruction-surface` shelf as clearer after validation
+  and as the first successful instruction trunk test
+- chose `kag-source-lift` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `docs-boundary`, capability, skill-discovery, proof, governance, and
+  runtime-authority shelves outside the next move
+- kept `knowledge-lift` bounded to technique-local source-lift rather than KAG
+  owner authority, graph truth, scoring, policy, or automatic verdicts
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no sixth shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Instruction-surface tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -70,7 +70,10 @@
    `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` under
    `techniques/instruction/instruction-surface/`, with the instruction route
    card, root legacy receipt accounting, link repair, generated rebuilds, and
-   release-check validation in the same wave.
+   release-check validation in the same wave. The landed
+   `instruction-surface` pilot review is also landed as `pilot-validated`, and
+   `kag-source-lift` is now chosen for the next direct-read migration review
+   without moving a sixth shelf yet.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -62,6 +62,8 @@ permission slip to remap techniques automatically.
   `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035`
   under `techniques/instruction/instruction-surface/` without frontmatter
   changes
+- landed instruction-surface pilot review: landed as `pilot-validated`, with
+  `kag-source-lift` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -95,6 +97,7 @@ permission slip to remap techniques automatically.
 | [Diagnosis-Repair Direct-Read Migration Review](reviews/diagnosis-repair-direct-read-migration-review.md) | reads `AOA-T-0080` through `AOA-T-0083` directly and accepts the shelf as the fourth migration pilot | path movement, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Landed Diagnosis-Repair Pilot Review](reviews/landed-diagnosis-repair-pilot-review.md) | confirms the fourth migrated shelf stayed clearer, validates the recovery trunk machinery, and chooses `instruction-surface` for the next direct-read review | movement of `instruction-surface`, `tree_path` frontmatter, or proof that every docs-domain shelf is safe |
 | [Instruction-Surface Direct-Read Migration Review](reviews/instruction-surface-direct-read-migration-review.md) | reads `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` directly and accepts the shelf as the fifth migration pilot | path movement by review alone, `tree_path` frontmatter, domain change, or permission to move another shelf |
+| [Landed Instruction-Surface Pilot Review](reviews/landed-instruction-surface-pilot-review.md) | confirms the fifth migrated shelf stayed clearer, validates the first instruction trunk machinery, and chooses `kag-source-lift` for the next direct-read review | movement of `kag-source-lift`, `tree_path` frontmatter, KAG owner authority, or proof that every docs-lift shelf is safe |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -185,5 +188,9 @@ The fifth pilot migration is now landed: those seven bundles live under
 and root legacy receipt are in place, authored links were repaired, generated
 surfaces were rebuilt, and frontmatter stayed unchanged.
 
-The next move is the landed `instruction-surface` pilot review before any
-other shelf moves.
+The landed `instruction-surface` pilot review is now landed as
+`pilot-validated` and chooses `kag-source-lift` for the next direct-read
+migration review.
+
+The next move is the `kag-source-lift` direct-read migration review before any
+sixth shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -21,5 +21,6 @@ Current reviews:
 - [diagnosis-repair-direct-read-migration-review](diagnosis-repair-direct-read-migration-review.md)
 - [landed-diagnosis-repair-pilot-review](landed-diagnosis-repair-pilot-review.md)
 - [instruction-surface-direct-read-migration-review](instruction-surface-direct-read-migration-review.md)
+- [landed-instruction-surface-pilot-review](landed-instruction-surface-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md
@@ -1,0 +1,173 @@
+# Landed Instruction-Surface Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Instruction-Surface Direct-Read Migration Review](instruction-surface-direct-read-migration-review.md)
+
+Migration receipt:
+[Instruction-Surface Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-instruction-surface-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `kag-source-lift` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `instruction-surface` pilot as a successful fifth tree
+migration and the first instruction trunk test.
+
+The shelf stayed legible after landing: seven separate docs-domain techniques
+now sit under one instruction neighborhood, while their IDs, `domain`, `kind`,
+status, evidence, notes, examples, checks, relations, and public-safety posture
+stayed unchanged. The move improved browsing without collapsing context
+composition, rule distribution, upstream mirroring, cross-agent propagation,
+nested loading, fragmented context, and profile/preset composition into one
+instruction framework.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should run a direct-read review for `kag-source-lift`, because the tree
+has now tested continuity, ingest, recovery, and instruction. The next pressure
+should test the `knowledge-lift` trunk while keeping source-lift techniques
+subordinate to authored markdown and outside KAG owner authority.
+
+## Sources Read
+
+- [AOA-T-0012 deterministic-context-composition](../../../../../techniques/instruction/instruction-surface/deterministic-context-composition/TECHNIQUE.md)
+- [AOA-T-0013 single-source-rule-distribution](../../../../../techniques/instruction/instruction-surface/single-source-rule-distribution/TECHNIQUE.md)
+- [AOA-T-0024 upstream-mirroring-with-provenance](../../../../../techniques/instruction/instruction-surface/upstream-mirroring-with-provenance/TECHNIQUE.md)
+- [AOA-T-0027 cross-agent-skill-propagation](../../../../../techniques/instruction/instruction-surface/cross-agent-skill-propagation/TECHNIQUE.md)
+- [AOA-T-0029 nested-rule-loading](../../../../../techniques/instruction/instruction-surface/nested-rule-loading/TECHNIQUE.md)
+- [AOA-T-0030 fragmented-agent-context](../../../../../techniques/instruction/instruction-surface/fragmented-agent-context/TECHNIQUE.md)
+- [AOA-T-0035 profile-preset-composition](../../../../../techniques/instruction/instruction-surface/profile-preset-composition/TECHNIQUE.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Instruction-surface tree pilot receipt](../../../../../legacy/receipts/2026-05-04-instruction-surface-tree-pilot.md)
+- [Technique tree projection rows for `instruction-surface`,
+  `kag-source-lift`, `docs-boundary`, and boundary-watch instruction
+  shelves](../../../../../reports/technique_tree_projection.md)
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- initial direct-read headers and section maps for `AOA-T-0018`, `AOA-T-0019`,
+  `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and
+  `AOA-T-0048`
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/instruction/instruction-surface/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | `domain` still carries owner lane and `kind` still carries move shape |
+| route card | present | `techniques/instruction/AGENTS.md` names instruction boundaries without turning `instruction` into a frontmatter domain |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, manifests, reports, feat-card examples, and semantic route surfaces point at current paths |
+| mechanics links | repaired | Audit, Distillation, generated examples, and reform review links point at current authored paths |
+| validation | green | release check covered unit tests, nested AGENTS coverage, semantic agents, repository parity, and regenerated surfaces |
+
+## What The Fifth Pilot Proved
+
+- An instruction trunk can land without changing `domain`, `kind`, or technique
+  meaning.
+- A single shelf can hold both `composition` and `distribution` kinds when the
+  browsing question is instruction/context surface management.
+- `instruction/` can name a placement district without importing AoA
+  constitutional law, skill acceptance, runtime role semantics, generated
+  context authority, deployment detail, or public source-of-truth replacement.
+- Profile and preset language can stay bounded when the bundle remains at the
+  reviewable surface-definition layer.
+- Root `legacy/receipts/` remains enough for path-migration accounting; active
+  bundles did not need to pass through legacy.
+- Link repair matters outside the moved bundles because review packets,
+  generated examples, and semantic docs are active route anchors for later
+  agents.
+
+## Remaining Weaknesses
+
+- The generated projection still labels landed shelves as `pilot-candidate`.
+  That is tolerable while the projection remains non-authoritative, but later
+  generated status language may need a separate review.
+- `instruction/` currently has one landed shelf, so the trunk is validated as a
+  pilot district, not as a complete instruction taxonomy.
+- `docs-boundary` has not been direct-read in this tree context; it should not
+  be assumed to share the same pilot shape as `instruction-surface`.
+- `capability-registry`, `capability-boundary`, and `skill-discovery` remain
+  boundary-watch instruction shelves because they touch skill and capability
+  authority.
+- No `knowledge-lift` shelf has moved yet, so derived source-lift placement is
+  still untested.
+
+## Sixth Shelf Choice
+
+Choose `kag-source-lift` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0018` | `techniques/docs/markdown-technique-section-lift/` | `techniques/knowledge-lift/kag-source-lift/markdown-technique-section-lift/` |
+| `AOA-T-0019` | `techniques/docs/frontmatter-metadata-spine/` | `techniques/knowledge-lift/kag-source-lift/frontmatter-metadata-spine/` |
+| `AOA-T-0021` | `techniques/docs/bounded-relation-lift-for-kag/` | `techniques/knowledge-lift/kag-source-lift/bounded-relation-lift-for-kag/` |
+| `AOA-T-0020` | `techniques/docs/evidence-note-provenance-lift/` | `techniques/knowledge-lift/kag-source-lift/evidence-note-provenance-lift/` |
+| `AOA-T-0022` | `techniques/docs/risk-and-negative-effect-lift/` | `techniques/knowledge-lift/kag-source-lift/risk-and-negative-effect-lift/` |
+| `AOA-T-0046` | `techniques/docs/repo-doc-surface-lift/` | `techniques/knowledge-lift/kag-source-lift/repo-doc-surface-lift/` |
+| `AOA-T-0047` | `techniques/docs/github-review-template-lift/` | `techniques/knowledge-lift/kag-source-lift/github-review-template-lift/` |
+| `AOA-T-0048` | `techniques/docs/semantic-review-surface-lift/` | `techniques/knowledge-lift/kag-source-lift/semantic-review-surface-lift/` |
+
+Reason:
+
+`kag-source-lift` is the strongest remaining clean `pilot-candidate` shelf after
+the instruction trunk landed. It is large enough to test a new trunk and narrow
+enough to stay legible: all eight bundles are `domain: docs`, `kind: lift`, and
+center on derived reader surfaces that preserve authored source authority.
+
+This shelf also tests the repository's standalone-library promise. External
+builders should be able to adopt section lift, metadata spine, provenance lift,
+relation hints, caution lookup, repo-doc routing, review-template intake, or
+semantic-review lookup without deploying OS Abyss or accepting AoA KAG doctrine.
+
+Why not `docs-boundary` first:
+
+`docs-boundary` is useful and likely stable, but it is currently only a
+`candidate` shelf and mixes source-of-truth layout, status snapshots, public
+sanitization, and decision notes. It should be direct-read after the next wave
+proves whether `instruction/` remains the right home for document-role
+techniques.
+
+Why not capability or skill-discovery shelves first:
+
+`capability-registry`, `capability-boundary`, and `skill-discovery` remain
+`boundary-watch` because they touch skill, capability, marketplace, and
+upstream-health authority. They need owner-boundary review before any path
+movement.
+
+## Stop Lines
+
+- Do not move `kag-source-lift` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `docs-boundary`, `capability-registry`,
+  `capability-boundary`, `skill-discovery`, proof, governance, or
+  runtime-authority shelves in the same wave.
+- Do not treat `knowledge-lift` as `aoa-kag` owner doctrine, graph semantics,
+  generated source of truth, scoring, policy, or automatic verdict authority.
+- Do not collapse section lift, metadata spine, evidence-note provenance,
+  relation hints, caution lookup, repo-doc routing, review-template intake, and
+  semantic-review lookup into one derived-knowledge framework bundle.
+- Keep authored markdown and bundle frontmatter stronger than generated
+  manifests, catalogs, graphs, or reader exports.
+
+## Next Honest Move
+
+Run a direct-read migration review for `kag-source-lift`.
+
+Read `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`,
+`AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048`; inspect their relation chain,
+source-authority boundaries, generated-surface blast radius, route-card needs,
+KAG-owner stop-lines, and whether `knowledge-lift/kag-source-lift` is clearer
+than the old broad `docs/` folder.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -101,6 +101,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/diagnosis-repair-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1205,7 +1206,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Run the landed `instruction-surface` pilot review", root_roadmap)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1370,7 +1371,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Run the landed `instruction-surface` pilot review", root_roadmap)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1447,7 +1448,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Run the landed `instruction-surface` pilot review", root_roadmap)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1535,7 +1536,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("Run the landed `instruction-surface` pilot review", root_roadmap)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
 
@@ -1617,7 +1618,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
-        self.assertIn("Run the landed `instruction-surface` pilot review", root_roadmap)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
         self.assertIn("2026-05-04-instruction-surface-tree-pilot.md", tree_contract)
@@ -1639,6 +1640,82 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "deterministic-context-composition"
             ).exists()
         )
+
+    def test_landed_instruction_surface_pilot_review_selects_kag_source_lift(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-instruction-surface-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Instruction-Surface Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("Accept the landed `instruction-surface` pilot", review)
+        self.assertIn("first instruction trunk test", review)
+        self.assertIn("Choose `kag-source-lift`", review)
+        for technique_id in (
+            "AOA-T-0018",
+            "AOA-T-0019",
+            "AOA-T-0020",
+            "AOA-T-0021",
+            "AOA-T-0022",
+            "AOA-T-0046",
+            "AOA-T-0047",
+            "AOA-T-0048",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Why not `docs-boundary` first", review)
+        self.assertIn("Do not move `kag-source-lift` from this review alone", review)
+        self.assertIn("Do not treat `knowledge-lift` as `aoa-kag`", review)
+        self.assertIn("Run a direct-read migration review for `kag-source-lift`", review)
+
+        self.assertIn("landed-instruction-surface-pilot-review", reviews_index)
+        self.assertIn("landed instruction-surface pilot review: landed", ingress)
+        self.assertIn("kag-source-lift", ingress)
+        self.assertIn("next direct-read migration review", ingress)
+        self.assertIn("`kag-source-lift` is now chosen", distillation_roadmap)
+        self.assertIn("Landed instruction-surface pilot review", landing_log)
+        self.assertIn("selected\n  `kag-source-lift`", changelog)
+        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
+        self.assertIn("knowledge-lift", tree_contract)
+        self.assertIn("kag-source-lift", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the landed instruction-surface pilot review as the fifth tree-pilot closeout
- update reform ingress, roadmap, tree contract, landing log, and changelog to select kag-source-lift as the next direct-read review target
- extend distillation topology coverage for the reviewed state

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_semantic_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py
- public-share scan for secrets/private markers