### PR TITLE
Accept kag-source-lift migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ The format is intentionally simple and human-first.
 - accepted the landed `instruction-surface` pilot review and selected
   `kag-source-lift` for the next direct-read migration review without moving a
   sixth shelf yet
+- accepted the `kag-source-lift` direct-read migration review over
+  `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`,
+  `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` as the sixth tree pilot while
+  keeping the review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, and the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`; all five kept frontmatter unchanged, and the landed `instruction-surface` review selected `kag-source-lift` as the next direct-read review target. |
-| Next honest move | Run the `kag-source-lift` direct-read migration review before moving any sixth shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, and the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`; all five kept frontmatter unchanged, and the `kag-source-lift` direct-read review accepted the sixth pilot without moving files yet. |
+| Next honest move | Run the sixth pilot migration for `kag-source-lift` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,7 +186,8 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, and `instruction-surface` pilots as precedents while
-  direct-reading `kag-source-lift` before any sixth shelf moves.
+  moving only the accepted `kag-source-lift` sixth pilot before any broader
+  corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -248,8 +248,14 @@ It validates the `instruction-surface` migration as the first successful
 instruction trunk test and chooses `kag-source-lift` for the next direct-read
 migration review.
 
-The next reform slice should run the `kag-source-lift` direct-read review before
-moving another shelf.
+The sixth migration review is
+[Kag-Source-Lift Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md).
+It accepts `kag-source-lift` as the first `knowledge-lift` migration pilot after
+directly reading `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`,
+`AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048`.
+
+The next reform slice should run the sixth pilot migration before moving
+another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,38 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Kag-source-lift direct-read migration review
+
+Changed:
+
+- added
+  [kag-source-lift-direct-read-migration-review](parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`,
+  `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048`
+- accepted `kag-source-lift` as the sixth bounded tree migration pilot and the
+  first `knowledge-lift` trunk test
+- recorded the exact next migration scope:
+  `techniques/knowledge-lift/kag-source-lift/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `docs-boundary`, capability, skill-discovery, proof, governance,
+  runtime, and owner-closeout shelves outside the accepted move
+- kept `knowledge-lift` bounded to source-lift technique placement rather than
+  KAG owner doctrine, graph semantics, scoring, policy, or automatic verdicts
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no sixth shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed instruction-surface pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -73,7 +73,12 @@
    release-check validation in the same wave. The landed
    `instruction-surface` pilot review is also landed as `pilot-validated`, and
    `kag-source-lift` is now chosen for the next direct-read migration review
-   without moving a sixth shelf yet.
+   without moving a sixth shelf yet. The `kag-source-lift` direct-read review
+   is now landed as `accepted-for-sixth-migration-pilot`; it accepts exactly
+   `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`,
+   `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` for the sixth pilot while
+   keeping KAG owner authority, graph semantics, scoring, policy, and
+   automatic verdicts outside the move.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -64,6 +64,8 @@ permission slip to remap techniques automatically.
   changes
 - landed instruction-surface pilot review: landed as `pilot-validated`, with
   `kag-source-lift` chosen for the next direct-read migration review
+- kag-source-lift direct-read review: landed as
+  `accepted-for-sixth-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -98,6 +100,7 @@ permission slip to remap techniques automatically.
 | [Landed Diagnosis-Repair Pilot Review](reviews/landed-diagnosis-repair-pilot-review.md) | confirms the fourth migrated shelf stayed clearer, validates the recovery trunk machinery, and chooses `instruction-surface` for the next direct-read review | movement of `instruction-surface`, `tree_path` frontmatter, or proof that every docs-domain shelf is safe |
 | [Instruction-Surface Direct-Read Migration Review](reviews/instruction-surface-direct-read-migration-review.md) | reads `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` directly and accepts the shelf as the fifth migration pilot | path movement by review alone, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Landed Instruction-Surface Pilot Review](reviews/landed-instruction-surface-pilot-review.md) | confirms the fifth migrated shelf stayed clearer, validates the first instruction trunk machinery, and chooses `kag-source-lift` for the next direct-read review | movement of `kag-source-lift`, `tree_path` frontmatter, KAG owner authority, or proof that every docs-lift shelf is safe |
+| [Kag-Source-Lift Direct-Read Migration Review](reviews/kag-source-lift-direct-read-migration-review.md) | reads `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` directly and accepts the shelf as the sixth migration pilot | path movement by review alone, `tree_path` frontmatter, KAG owner doctrine, graph authority, scoring, policy, or generated verdicts |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -192,5 +195,8 @@ The landed `instruction-surface` pilot review is now landed as
 `pilot-validated` and chooses `kag-source-lift` for the next direct-read
 migration review.
 
-The next move is the `kag-source-lift` direct-read migration review before any
-sixth shelf moves.
+The `kag-source-lift` direct-read review is now landed and accepts exactly
+`AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`,
+`AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` as the sixth migration pilot.
+
+The next move is the sixth pilot migration before any other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -22,5 +22,6 @@ Current reviews:
 - [landed-diagnosis-repair-pilot-review](landed-diagnosis-repair-pilot-review.md)
 - [instruction-surface-direct-read-migration-review](instruction-surface-direct-read-migration-review.md)
 - [landed-instruction-surface-pilot-review](landed-instruction-surface-pilot-review.md)
+- [kag-source-lift-direct-read-migration-review](kag-source-lift-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md
@@ -1,0 +1,228 @@
+# Kag-Source-Lift Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Prior pilot review:
+[Landed Instruction-Surface Pilot Review](landed-instruction-surface-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-sixth-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `kag-source-lift` as the sixth migration pilot.
+
+The move is clearer than current placement because the eight bundles share one
+derived-source question: how authored markdown, frontmatter, sections, notes,
+relations, risks, repo docs, review templates, and semantic-review docs can be
+lifted into bounded reader surfaces without replacing the authored source.
+`docs` remains true as their current `domain`, but it is too broad as a
+browsing neighborhood for this source-lift cluster.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if route cards, root legacy receipts, link repair,
+generated surfaces, and validation move together.
+
+## Sources Read
+
+- [AOA-T-0018 markdown-technique-section-lift](../../../../../techniques/docs/markdown-technique-section-lift/TECHNIQUE.md)
+- [AOA-T-0019 frontmatter-metadata-spine](../../../../../techniques/docs/frontmatter-metadata-spine/TECHNIQUE.md)
+- [AOA-T-0020 evidence-note-provenance-lift](../../../../../techniques/docs/evidence-note-provenance-lift/TECHNIQUE.md)
+- [AOA-T-0021 bounded-relation-lift-for-kag](../../../../../techniques/docs/bounded-relation-lift-for-kag/TECHNIQUE.md)
+- [AOA-T-0022 risk-and-negative-effect-lift](../../../../../techniques/docs/risk-and-negative-effect-lift/TECHNIQUE.md)
+- [AOA-T-0046 repo-doc-surface-lift](../../../../../techniques/docs/repo-doc-surface-lift/TECHNIQUE.md)
+- [AOA-T-0047 github-review-template-lift](../../../../../techniques/docs/github-review-template-lift/TECHNIQUE.md)
+- [AOA-T-0048 semantic-review-surface-lift](../../../../../techniques/docs/semantic-review-surface-lift/TECHNIQUE.md)
+- [Docs domain route card](../../../../../techniques/docs/AGENTS.md)
+- `reports/technique_tree_projection.md` rows for `kag-source-lift`,
+  `docs-boundary`, `instruction-surface`, `capability-registry`,
+  `capability-boundary`, and `skill-discovery`
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- [Landed instruction-surface pilot review](landed-instruction-surface-pilot-review.md)
+
+## Direct Read
+
+| technique | status | center of gravity | pilot reading |
+|---|---|---|---|
+| `AOA-T-0018` `markdown-technique-section-lift` | `canonical` | stable markdown headings into derived section units | section-level lookup after bundle metadata, not authored section files or graph behavior |
+| `AOA-T-0019` `frontmatter-metadata-spine` | `canonical` | shallow frontmatter and catalog routing | bundle-level metadata spine, not metadata-first authorship |
+| `AOA-T-0020` `evidence-note-provenance-lift` | `promoted` | note kind and note path handles into provenance lookup | supporting-note handles, not note graph or proof objects |
+| `AOA-T-0021` `bounded-relation-lift-for-kag` | `canonical` | direct typed relations into one-step adjacency hints | bounded edge hints, not rationale, weighting, traversal, or graph truth |
+| `AOA-T-0022` `risk-and-negative-effect-lift` | `promoted` | authored `Risks` language into caution lookup | caution-oriented read surface, not scoring, metadata, or generated policy |
+| `AOA-T-0046` `repo-doc-surface-lift` | `promoted` | public repo docs/status set into routing knowledge | bounded repo-doc routing, not docs taxonomy or status policy |
+| `AOA-T-0047` `github-review-template-lift` | `promoted` | authored GitHub templates into intake lookup | prompt-shape inventory, not workflow automation, approval, or triage state |
+| `AOA-T-0048` `semantic-review-surface-lift` | `promoted` | authored semantic-review docs into cluster lookup | boundary-review lookup, not scoring, status transitions, or machine judgment |
+
+The shelf is not "all KAG work" and not "all docs lifts." It is the narrower
+cluster where authored source surfaces become bounded derived reader surfaces
+while source authority stays in markdown, frontmatter, notes, or templates.
+
+## Source-Lift Chain
+
+The shelf has an internal chain, not a single mega-technique:
+
+- `AOA-T-0019` is the bundle-level entrypoint: shallow metadata answers the
+  first routing question.
+- `AOA-T-0018` opens section-level lookup after bundle metadata is no longer
+  enough.
+- `AOA-T-0020` carries provenance handles from explicit evidence notes.
+- `AOA-T-0021` carries direct relation hints once one-step adjacency helps
+  navigation.
+- `AOA-T-0022` carries caution language from authored `Risks` without turning
+  it into policy.
+- `AOA-T-0046` applies the same derived-source discipline to public repo-doc
+  routing.
+- `AOA-T-0047` applies it to GitHub review prompt shapes.
+- `AOA-T-0048` applies it to authored semantic-review clusters.
+
+Together they form a `knowledge-lift` shelf because the shared operation is a
+bounded lift from source-owned markdown or template surfaces into derived
+reader knowledge. They should still remain eight separate leaves because each
+leaf has a different source object, consumer question, and misuse boundary.
+
+## Boundary Read
+
+The shelf remains useful only if the source boundary stays sharp:
+
+- section lift keeps section meaning in markdown and does not create authored
+  section files, section IDs, or graph semantics.
+- metadata spine keeps frontmatter shallow and does not carry full section
+  meaning, caution language, or provenance interpretation.
+- evidence-note lift preserves note meaning in authored notes and does not
+  create proof objects or cross-note graph truth.
+- relation lift keeps edges direct and does not infer transitive truth,
+  rankings, or traversal policy.
+- risk lift keeps caution in authored `Risks` and does not become scoring,
+  policy, shadow metadata, or generated caution output.
+- repo-doc lift routes to a bounded public docs/status source set and does not
+  become a docs taxonomy, local planning map, status policy, or release policy.
+- GitHub template lift routes to prompt shape and does not become workflow
+  automation, approval policy, triage logic, or review-state storage.
+- semantic-review lift routes to authored review docs and does not become a
+  scoring system, status driver, graph engine, or machine judge.
+
+## KAG Name Edge
+
+The shelf keeps the historical `kag-source-lift` name because the bundles were
+shaped around KAG/source-lift reader pressure, but the path trunk should be
+`knowledge-lift`, not `kag`.
+
+That distinction matters. `aoa-techniques` owns reusable source-lift practice.
+It does not own `aoa-kag` substrate semantics, graph authority, retrieval
+policy, scoring, or automatic verdict behavior. The future route card should
+name this stop-line tersely rather than importing KAG doctrine into the
+technique tree.
+
+## Mixed Status Stress
+
+`kag-source-lift` is larger than the first five pilots and mixes canonical and
+promoted maturity:
+
+- `AOA-T-0018`, `AOA-T-0019`, and `AOA-T-0021` are canonical anchors.
+- `AOA-T-0020`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048`
+  are promoted source-lift siblings.
+- all eight are `domain: docs` and `kind: lift`.
+
+The shared `lift` kind makes this a cleaner tree-versus-facets case than
+`instruction-surface`: the stress is not mixed kind, but authority pressure.
+The pilot should prove whether a `knowledge-lift` trunk can stay portable and
+source-bound without becoming a generated-knowledge owner.
+
+## Why Not Keep This As Docs
+
+`docs` remains true as `domain`: all eight bundles are documentation/source
+surface techniques.
+
+The directory tree now answers a browsing and placement question. On that
+question, `knowledge-lift/kag-source-lift` is tighter than the old broad
+folder:
+
+- all eight bundles protect authored source authority while making a derived
+  reader surface useful
+- the three canonical anchors already define the metadata, section, and
+  relation backbone
+- the promoted siblings extend the same source-lift discipline to notes, risks,
+  repo docs, templates, and semantic-review docs
+- the shelf tests a new `knowledge-lift` trunk after continuity, ingest,
+  recovery, and instruction have already landed
+- it stays away from `docs-boundary`, `capability-*`, `skill-discovery`, proof,
+  governance, runtime, and owner-closeout shelves
+
+## Pilot Scope
+
+Move exactly these eight bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0018` | `techniques/docs/markdown-technique-section-lift/` | `techniques/knowledge-lift/kag-source-lift/markdown-technique-section-lift/` |
+| `AOA-T-0019` | `techniques/docs/frontmatter-metadata-spine/` | `techniques/knowledge-lift/kag-source-lift/frontmatter-metadata-spine/` |
+| `AOA-T-0020` | `techniques/docs/evidence-note-provenance-lift/` | `techniques/knowledge-lift/kag-source-lift/evidence-note-provenance-lift/` |
+| `AOA-T-0021` | `techniques/docs/bounded-relation-lift-for-kag/` | `techniques/knowledge-lift/kag-source-lift/bounded-relation-lift-for-kag/` |
+| `AOA-T-0022` | `techniques/docs/risk-and-negative-effect-lift/` | `techniques/knowledge-lift/kag-source-lift/risk-and-negative-effect-lift/` |
+| `AOA-T-0046` | `techniques/docs/repo-doc-surface-lift/` | `techniques/knowledge-lift/kag-source-lift/repo-doc-surface-lift/` |
+| `AOA-T-0047` | `techniques/docs/github-review-template-lift/` | `techniques/knowledge-lift/kag-source-lift/github-review-template-lift/` |
+| `AOA-T-0048` | `techniques/docs/semantic-review-surface-lift/` | `techniques/knowledge-lift/kag-source-lift/semantic-review-surface-lift/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored sibling links inside the eight moved bundles
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated KAG export paths while keeping the export derived and
+  source-owned
+- generated reports for family, topology, and tree projection
+- a new `techniques/knowledge-lift/AGENTS.md` route card, because
+  `knowledge-lift/` would become the next migrated trunk
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- docs-domain active references such as selection patterns, source-lift guides,
+  repo-doc surface readers, semantic review readers, and any current authored
+  links that still point to old homes
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, source-owned KAG export, and repo-doc
+  surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move another `pilot-candidate` shelf in the same wave.
+- Do not rename `kag-source-lift` during the pilot move.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not move `docs-boundary`, `capability-registry`,
+  `capability-boundary`, `skill-discovery`, proof, governance, runtime, or
+  owner-closeout shelves in the same wave.
+- Do not treat `knowledge-lift` as `aoa-kag` owner doctrine, graph semantics,
+  generated source of truth, retrieval policy, scoring, or automatic verdict
+  authority.
+- Do not collapse the eight leaves into one source-lift framework bundle.
+
+## Next Honest Move
+
+Run the sixth pilot migration.
+
+Move exactly `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`,
+`AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into
+`techniques/knowledge-lift/kag-source-lift/`, add the minimal
+`knowledge-lift/` route card, repair authored links, preserve a root legacy
+receipt, rebuild generated surfaces, and run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -102,6 +102,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-diagnosis-repair-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1206,7 +1207,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1371,7 +1372,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1448,7 +1449,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1536,7 +1537,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
 
@@ -1618,7 +1619,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
         self.assertIn("2026-05-04-instruction-surface-tree-pilot.md", tree_contract)
@@ -1712,10 +1713,87 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`kag-source-lift` is now chosen", distillation_roadmap)
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
-        self.assertIn("Run the `kag-source-lift` direct-read migration review", root_roadmap)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
         self.assertIn("knowledge-lift", tree_contract)
         self.assertIn("kag-source-lift", tree_contract)
+
+    def test_kag_source_lift_direct_read_review_accepts_sixth_pilot(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "kag-source-lift-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Kag-Source-Lift Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-sixth-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `kag-source-lift` as the sixth migration pilot", review)
+        for technique_id in (
+            "AOA-T-0018",
+            "AOA-T-0019",
+            "AOA-T-0020",
+            "AOA-T-0021",
+            "AOA-T-0022",
+            "AOA-T-0046",
+            "AOA-T-0047",
+            "AOA-T-0048",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Source-Lift Chain", review)
+        self.assertIn("KAG Name Edge", review)
+        self.assertIn("Move exactly these eight bundles", review)
+        self.assertIn("techniques/knowledge-lift/kag-source-lift/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Do not treat `knowledge-lift` as `aoa-kag`", review)
+        self.assertIn("Run the sixth pilot migration", review)
+
+        self.assertIn("kag-source-lift-direct-read-migration-review", reviews_index)
+        self.assertIn("kag-source-lift direct-read review: landed", ingress)
+        self.assertIn("accepted-for-sixth-migration-pilot", ingress)
+        self.assertIn("The next move is the sixth pilot migration", ingress)
+        self.assertIn("accepted-for-sixth-migration-pilot", distillation_roadmap)
+        self.assertIn("Kag-source-lift direct-read migration review", landing_log)
+        self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
+        self.assertIn("Run the sixth pilot migration for `kag-source-lift`", root_roadmap)
+        self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0018`, `AOA-T-0019", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the direct-read migration review for the kag-source-lift shelf
- accept exactly AOA-T-0018, AOA-T-0019, AOA-T-0020, AOA-T-0021, AOA-T-0022, AOA-T-0046, AOA-T-0047, and AOA-T-0048 as the sixth tree pilot without moving files
- update reform ingress, roadmaps, tree contract, landing log, changelog, and topology tests for the next migration step

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_semantic_agents.py
- python scripts/validate_repo.py
- python scripts/release_check.py
- public-share scan for secrets/private markers