### PR TITLE
Review landed kag-source-lift technique tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ The format is intentionally simple and human-first.
   `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into
   `techniques/knowledge-lift/kag-source-lift/` while keeping `domain`, `kind`,
   IDs, status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `kag-source-lift` pilot review and selected
+  `docs-boundary` for the next direct-read migration review without moving a
+  seventh shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, and the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`; all six kept frontmatter unchanged. |
-| Next honest move | Run the landed `kag-source-lift` pilot review before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, and the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`; all six kept frontmatter unchanged, and the landed sixth pilot review validates the first `knowledge-lift` trunk test. |
+| Next honest move | Run a direct-read migration review for `docs-boundary` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,8 +186,7 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, and `kag-source-lift` pilots as
-  precedents while reviewing the sixth landed shelf before any broader corpus
-  move.
+  precedents while reviewing `docs-boundary` before any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -260,8 +260,13 @@ The sixth pilot migration moves `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`,
 `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md`](../legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md).
 
-The next reform slice should review the landed `kag-source-lift` pilot before
-moving another shelf.
+The landed sixth pilot review is
+[Landed Kag-Source-Lift Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md).
+It validates `kag-source-lift` as the first successful `knowledge-lift` trunk
+test and chooses `docs-boundary` for the next direct-read migration review.
+
+The next reform slice should run the `docs-boundary` direct-read migration
+review before moving another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,38 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed kag-source-lift pilot review
+
+Changed:
+
+- added
+  [landed-kag-source-lift-pilot-review](parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md)
+  as the post-migration review over the sixth tree pilot
+- accepted the landed `kag-source-lift` shelf as clearer after validation and
+  as the first successful knowledge-lift trunk test
+- chose `docs-boundary` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept capability, skill-discovery, proof, governance, runtime, and
+  owner-closeout shelves outside the next move
+- kept KAG owner authority, graph semantics, retrieval policy, scoring, proof
+  authority, status automation, and automatic verdicts outside
+  `knowledge-lift`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no seventh shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Kag-source-lift tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -82,7 +82,11 @@
    landed exactly for those eight bundles under
    `techniques/knowledge-lift/kag-source-lift/`, with the knowledge-lift route
    card, root legacy receipt accounting, link repair, generated rebuilds, and
-   release-check validation in the same wave.
+   release-check validation in the same wave. The landed `kag-source-lift`
+   pilot review is also landed as `pilot-validated`, keeps KAG owner
+   authority, graph semantics, scoring, proof authority, policy, and automatic
+   verdicts outside the shelf, and chooses `docs-boundary` for the next
+   direct-read migration review before any seventh shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -70,6 +70,8 @@ permission slip to remap techniques automatically.
   `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`,
   and `AOA-T-0048` under
   `techniques/knowledge-lift/kag-source-lift/` without frontmatter changes
+- landed kag-source-lift pilot review: landed as `pilot-validated`, with
+  `docs-boundary` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -105,6 +107,7 @@ permission slip to remap techniques automatically.
 | [Instruction-Surface Direct-Read Migration Review](reviews/instruction-surface-direct-read-migration-review.md) | reads `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` directly and accepts the shelf as the fifth migration pilot | path movement by review alone, `tree_path` frontmatter, domain change, or permission to move another shelf |
 | [Landed Instruction-Surface Pilot Review](reviews/landed-instruction-surface-pilot-review.md) | confirms the fifth migrated shelf stayed clearer, validates the first instruction trunk machinery, and chooses `kag-source-lift` for the next direct-read review | movement of `kag-source-lift`, `tree_path` frontmatter, KAG owner authority, or proof that every docs-lift shelf is safe |
 | [Kag-Source-Lift Direct-Read Migration Review](reviews/kag-source-lift-direct-read-migration-review.md) | reads `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` directly and accepts the shelf as the sixth migration pilot | path movement by review alone, `tree_path` frontmatter, KAG owner doctrine, graph authority, scoring, policy, or generated verdicts |
+| [Landed Kag-Source-Lift Pilot Review](reviews/landed-kag-source-lift-pilot-review.md) | confirms the sixth migrated shelf stayed clearer, validates the first knowledge-lift trunk machinery, and chooses `docs-boundary` for the next direct-read review | movement of `docs-boundary`, `tree_path` frontmatter, KAG owner authority, or proof that every instruction boundary shelf is safe |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -208,5 +211,8 @@ The sixth pilot migration is now landed: those eight bundles live under
 and root legacy receipt are in place, authored links were repaired, generated
 surfaces were rebuilt, and frontmatter stayed unchanged.
 
-The next move is a landed `kag-source-lift` pilot review before any other
-shelf moves.
+The landed `kag-source-lift` pilot review is now landed as `pilot-validated`
+and chooses `docs-boundary` for the next direct-read migration review.
+
+The next move is a direct-read migration review for `docs-boundary` before any
+other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -23,5 +23,6 @@ Current reviews:
 - [instruction-surface-direct-read-migration-review](instruction-surface-direct-read-migration-review.md)
 - [landed-instruction-surface-pilot-review](landed-instruction-surface-pilot-review.md)
 - [kag-source-lift-direct-read-migration-review](kag-source-lift-direct-read-migration-review.md)
+- [landed-kag-source-lift-pilot-review](landed-kag-source-lift-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md
@@ -1,0 +1,178 @@
+# Landed Kag-Source-Lift Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Kag-Source-Lift Direct-Read Migration Review](kag-source-lift-direct-read-migration-review.md)
+
+Migration receipt:
+[Kag-Source-Lift Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `docs-boundary` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `kag-source-lift` pilot as a successful sixth tree migration
+and the first `knowledge-lift` trunk test.
+
+The shelf stayed legible after landing. Eight docs-domain `lift` techniques now
+sit under one source-lift neighborhood, while IDs, `domain`, `kind`, status,
+evidence, notes, examples, checks, relations, and public-safety posture stayed
+unchanged. The move improved browsing without turning section lift, metadata
+spine, note provenance, relation hints, caution lookup, repo-doc routing,
+review-template intake, and semantic-review lookup into one derived-knowledge
+framework.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should run a direct-read review for `docs-boundary`, because the tree has
+now tested continuity, ingest, recovery, instruction, and knowledge-lift. The
+next pressure should return to the instruction trunk and test whether
+source-of-truth layout, status snapshots, public-safe sanitization, and
+decision rationale form a clean document-boundary shelf before any path move.
+
+## Sources Read
+
+- [AOA-T-0018 markdown-technique-section-lift](../../../../../techniques/knowledge-lift/kag-source-lift/markdown-technique-section-lift/TECHNIQUE.md)
+- [AOA-T-0019 frontmatter-metadata-spine](../../../../../techniques/knowledge-lift/kag-source-lift/frontmatter-metadata-spine/TECHNIQUE.md)
+- [AOA-T-0020 evidence-note-provenance-lift](../../../../../techniques/knowledge-lift/kag-source-lift/evidence-note-provenance-lift/TECHNIQUE.md)
+- [AOA-T-0021 bounded-relation-lift-for-kag](../../../../../techniques/knowledge-lift/kag-source-lift/bounded-relation-lift-for-kag/TECHNIQUE.md)
+- [AOA-T-0022 risk-and-negative-effect-lift](../../../../../techniques/knowledge-lift/kag-source-lift/risk-and-negative-effect-lift/TECHNIQUE.md)
+- [AOA-T-0046 repo-doc-surface-lift](../../../../../techniques/knowledge-lift/kag-source-lift/repo-doc-surface-lift/TECHNIQUE.md)
+- [AOA-T-0047 github-review-template-lift](../../../../../techniques/knowledge-lift/kag-source-lift/github-review-template-lift/TECHNIQUE.md)
+- [AOA-T-0048 semantic-review-surface-lift](../../../../../techniques/knowledge-lift/kag-source-lift/semantic-review-surface-lift/TECHNIQUE.md)
+- [AOA-T-0002 source-of-truth-layout](../../../../../techniques/docs/source-of-truth-layout/TECHNIQUE.md)
+- [AOA-T-0009 lightweight-status-snapshot](../../../../../techniques/docs/lightweight-status-snapshot/TECHNIQUE.md)
+- [AOA-T-0034 public-safe-artifact-sanitization](../../../../../techniques/docs/public-safe-artifact-sanitization/TECHNIQUE.md)
+- [AOA-T-0033 decision-rationale-recording](../../../../../techniques/docs/decision-rationale-recording/TECHNIQUE.md)
+- [Knowledge-lift route card](../../../../../techniques/knowledge-lift/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Kag-source-lift tree pilot receipt](../../../../../legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md)
+- [Technique tree projection rows for `kag-source-lift`,
+  `docs-boundary`, `instruction-surface`, and boundary-watch instruction
+  shelves](../../../../../reports/technique_tree_projection.md)
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- [Landed instruction-surface pilot review](landed-instruction-surface-pilot-review.md)
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/knowledge-lift/kag-source-lift/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | `domain: docs` and `kind: lift` stayed as the authoritative local axes |
+| route card | present | `techniques/knowledge-lift/AGENTS.md` names source-lift boundaries without importing KAG doctrine |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, manifests, reports, source-owned KAG exports, and reader surfaces point at current paths |
+| mechanics links | repaired | Distillation and Audit active references route to the current authored paths; legacy raw links remain historical receipts |
+| validation | green | release check covered unit tests, nested AGENTS coverage, semantic agents, repository parity, and regenerated surfaces |
+
+## What The Sixth Pilot Proved
+
+- `knowledge-lift/` can be a placement trunk without becoming a frontmatter
+  domain, generated source of truth, or `aoa-kag` owner surface.
+- A larger shelf can land cleanly when all leaves share the same operation:
+  authored source surfaces become bounded derived reader surfaces while source
+  authority stays in markdown, frontmatter, notes, templates, or review docs.
+- The `kag-source-lift` name can be preserved as historical shelf language
+  while the trunk remains `knowledge-lift`, not `kag`.
+- Canonical and promoted leaves can share a shelf when maturity differs but the
+  route question is the same.
+- Root `legacy/receipts/` remains enough for path-migration accounting; active
+  bundles did not need to pass through legacy.
+- Standalone portability is stronger after the move: external builders can
+  reuse one source-lift technique without deploying OS Abyss or accepting AoA
+  KAG substrate doctrine.
+
+## KAG Name Edge
+
+The landed shelf still carries `kag-source-lift` because the original pressure
+came from KAG/source-lift readers. That name is acceptable only while the
+boundary stays explicit: `aoa-techniques` owns reusable source-lift practice;
+it does not own `aoa-kag` substrate semantics, graph authority, retrieval
+policy, scoring, proof authority, status automation, or automatic verdicts.
+
+Future wording should keep this distinction light but present. The route card
+already does enough; the next passes should preserve that economy rather than
+adding law blocks to unrelated sections.
+
+## Remaining Weaknesses
+
+- `knowledge-lift/` has one landed shelf, so it is validated as a pilot
+  district, not as a complete knowledge-lift taxonomy.
+- The generated projection still labels landed shelves as `pilot-candidate`.
+  That is tolerable while the projection remains non-authoritative, but later
+  generated status language may need a separate review.
+- The KAG name remains a naming edge; future readers must still see that the
+  shelf is reusable source-lift practice, not KAG substrate ownership.
+- `docs-boundary`, `capability-registry`, `capability-boundary`, and
+  `skill-discovery` have not been direct-read in the landed tree context.
+- Public readers that see both source-lift guides and KAG-oriented language may
+  still need later wording review if they confuse derived reader surfaces with
+  generated authority.
+
+## Seventh Shelf Choice
+
+Choose `docs-boundary` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0002` | `techniques/docs/source-of-truth-layout/` | `techniques/instruction/docs-boundary/source-of-truth-layout/` |
+| `AOA-T-0009` | `techniques/docs/lightweight-status-snapshot/` | `techniques/instruction/docs-boundary/lightweight-status-snapshot/` |
+| `AOA-T-0034` | `techniques/docs/public-safe-artifact-sanitization/` | `techniques/instruction/docs-boundary/public-safe-artifact-sanitization/` |
+| `AOA-T-0033` | `techniques/docs/decision-rationale-recording/` | `techniques/instruction/docs-boundary/decision-rationale-recording/` |
+
+Reason:
+
+`docs-boundary` is now the cleanest next review target because it tests the
+document-role side of the instruction trunk after the broader
+`instruction-surface` shelf has already landed. Its four bundles share a
+boundary-maintenance question: how a repo keeps document truth, status,
+public-safe share surfaces, and decision rationale legible without turning
+those practices into governance taxonomy or owner-law machinery.
+
+Why not capability or skill-discovery shelves first:
+
+`capability-registry`, `capability-boundary`, and `skill-discovery` still touch
+skill, marketplace, capability, and upstream-health authority. They need a
+separate owner-boundary read before any path movement.
+
+Why not proof, governance, runtime, or owner-closeout shelves first:
+
+Those shelves test different trunks and stronger authority pressure. The next
+slice should finish the low-risk document-boundary read before the tree takes
+on proof, governance, runtime, or closeout semantics.
+
+## Stop Lines
+
+- Do not move `docs-boundary` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `capability-registry`, `capability-boundary`, `skill-discovery`,
+  proof, governance, runtime, or owner-closeout shelves in the same wave.
+- Do not treat `knowledge-lift` as `aoa-kag` owner doctrine, graph semantics,
+  generated source of truth, retrieval policy, scoring, proof authority, or
+  automatic verdict authority.
+- Do not collapse the eight landed `kag-source-lift` leaves into one
+  source-lift framework bundle.
+- Keep authored markdown and bundle frontmatter stronger than generated
+  manifests, catalogs, graphs, or reader exports.
+
+## Next Honest Move
+
+Run a direct-read migration review for `docs-boundary`.
+
+Read `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033`; inspect
+their document-role boundary, status-snapshot role, public-safety share
+boundary, decision-rationale boundary, route-card needs, owner-law stop-lines,
+and whether `techniques/instruction/docs-boundary/` is clearer than the old
+broad `docs/` folder.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -103,6 +103,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/instruction-surface-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1207,7 +1208,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1372,7 +1373,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1449,7 +1450,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1537,7 +1538,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
 
@@ -1619,7 +1620,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
         self.assertIn("2026-05-04-instruction-surface-tree-pilot.md", tree_contract)
@@ -1713,7 +1714,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`kag-source-lift` is now chosen", distillation_roadmap)
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
         self.assertIn("knowledge-lift", tree_contract)
         self.assertIn("kag-source-lift", tree_contract)
@@ -1795,7 +1796,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0018`, `AOA-T-0019", tree_contract)
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1830,7 +1831,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
-        self.assertIn("Run the landed `kag-source-lift` pilot review", root_roadmap)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertTrue(
@@ -1851,6 +1852,88 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "frontmatter-metadata-spine"
             ).exists()
         )
+
+    def test_landed_kag_source_lift_pilot_review_selects_docs_boundary(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-kag-source-lift-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Kag-Source-Lift Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("Accept the landed `kag-source-lift` pilot", review)
+        self.assertIn("first `knowledge-lift` trunk test", review)
+        self.assertIn("Choose `docs-boundary`", review)
+        for technique_id in (
+            "AOA-T-0018",
+            "AOA-T-0019",
+            "AOA-T-0020",
+            "AOA-T-0021",
+            "AOA-T-0022",
+            "AOA-T-0046",
+            "AOA-T-0047",
+            "AOA-T-0048",
+            "AOA-T-0002",
+            "AOA-T-0009",
+            "AOA-T-0034",
+            "AOA-T-0033",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("KAG Name Edge", review)
+        self.assertIn("Do not move `docs-boundary` from this review alone", review)
+        self.assertIn("Do not treat `knowledge-lift` as `aoa-kag`", review)
+        self.assertIn("Run a direct-read migration review for `docs-boundary`", review)
+
+        self.assertIn("landed-kag-source-lift-pilot-review", reviews_index)
+        self.assertIn("landed kag-source-lift pilot review: landed", ingress)
+        self.assertIn("docs-boundary", ingress)
+        self.assertIn("direct-read migration review", ingress)
+        self.assertIn("`docs-boundary` for the next", distillation_roadmap)
+        self.assertIn("Landed kag-source-lift pilot review", landing_log)
+        self.assertIn("selected\n  `docs-boundary`", changelog)
+        self.assertIn(
+            "Run a direct-read migration review for `docs-boundary`",
+            root_roadmap,
+        )
+        self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
+        self.assertIn("docs-boundary", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the landed kag-source-lift pilot review as the post-migration validation surface
- update reform ingress, tree contract, roadmaps, landing log, changelog, and tests so docs-boundary is the next direct-read shelf
- keep this wave non-mutating for technique bundles: no path moves, no frontmatter changes, no new tree_path axis

## Verification
- python -m unittest tests.test_distillation_mechanics_topology tests.test_kag_source_lift_tree_pilot
- python scripts/release_check.py
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/validate_semantic_agents.py
- python -m unittest discover -s tests
- public-share scan for changed authored surfaces