### PR TITLE
Accept docs-boundary technique tree migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `kag-source-lift` pilot review and selected
   `docs-boundary` for the next direct-read migration review without moving a
   seventh shelf yet
+- accepted the `docs-boundary` direct-read migration review over `AOA-T-0002`,
+  `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` as the seventh tree pilot while
+  keeping the review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, and the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`; all six kept frontmatter unchanged, and the landed sixth pilot review validates the first `knowledge-lift` trunk test. |
-| Next honest move | Run a direct-read migration review for `docs-boundary` before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, and the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`; all six kept frontmatter unchanged, and the `docs-boundary` direct-read review now accepts the seventh pilot scope. |
+| Next honest move | Run the seventh `docs-boundary` pilot migration before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,7 +186,8 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, and `kag-source-lift` pilots as
-  precedents while reviewing `docs-boundary` before any broader corpus move.
+  precedents while landing the accepted `docs-boundary` pilot before any
+  broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -265,8 +265,13 @@ The landed sixth pilot review is
 It validates `kag-source-lift` as the first successful `knowledge-lift` trunk
 test and chooses `docs-boundary` for the next direct-read migration review.
 
-The next reform slice should run the `docs-boundary` direct-read migration
-review before moving another shelf.
+The seventh migration review is
+[Docs-Boundary Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md).
+It accepts `docs-boundary` as the seventh migration pilot after directly
+reading `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033`.
+
+The next reform slice should run the seventh pilot migration before moving
+another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,38 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Docs-boundary direct-read migration review
+
+Changed:
+
+- added
+  [docs-boundary-direct-read-migration-review](parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`,
+  and `AOA-T-0033`
+- accepted `docs-boundary` as the seventh bounded tree migration pilot and the
+  next instruction trunk shelf test
+- recorded the exact next migration scope:
+  `techniques/instruction/docs-boundary/`
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept capability, skill-discovery, proof, governance, runtime,
+  owner-closeout, and knowledge-lift shelves outside the accepted move
+- kept source-of-truth governance, approval policy, skill acceptance, proof
+  authority, runtime role law, and architecture taxonomy outside the shelf
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no seventh shelf migration happened before direct-read review
+
 ## 2026-05-04 - Landed kag-source-lift pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -86,7 +86,12 @@
    pilot review is also landed as `pilot-validated`, keeps KAG owner
    authority, graph semantics, scoring, proof authority, policy, and automatic
    verdicts outside the shelf, and chooses `docs-boundary` for the next
-   direct-read migration review before any seventh shelf moves.
+   direct-read migration review before any seventh shelf moves. The
+   `docs-boundary` direct-read review is now landed as
+   `accepted-for-seventh-migration-pilot`; it accepts exactly `AOA-T-0002`,
+   `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` for the seventh pilot while
+   keeping source-of-truth governance, approval policy, skill acceptance, proof
+   authority, runtime role law, and architecture taxonomy outside the move.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -72,6 +72,8 @@ permission slip to remap techniques automatically.
   `techniques/knowledge-lift/kag-source-lift/` without frontmatter changes
 - landed kag-source-lift pilot review: landed as `pilot-validated`, with
   `docs-boundary` chosen for the next direct-read migration review
+- docs-boundary direct-read review: landed as
+  `accepted-for-seventh-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -108,6 +110,7 @@ permission slip to remap techniques automatically.
 | [Landed Instruction-Surface Pilot Review](reviews/landed-instruction-surface-pilot-review.md) | confirms the fifth migrated shelf stayed clearer, validates the first instruction trunk machinery, and chooses `kag-source-lift` for the next direct-read review | movement of `kag-source-lift`, `tree_path` frontmatter, KAG owner authority, or proof that every docs-lift shelf is safe |
 | [Kag-Source-Lift Direct-Read Migration Review](reviews/kag-source-lift-direct-read-migration-review.md) | reads `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` directly and accepts the shelf as the sixth migration pilot | path movement by review alone, `tree_path` frontmatter, KAG owner doctrine, graph authority, scoring, policy, or generated verdicts |
 | [Landed Kag-Source-Lift Pilot Review](reviews/landed-kag-source-lift-pilot-review.md) | confirms the sixth migrated shelf stayed clearer, validates the first knowledge-lift trunk machinery, and chooses `docs-boundary` for the next direct-read review | movement of `docs-boundary`, `tree_path` frontmatter, KAG owner authority, or proof that every instruction boundary shelf is safe |
+| [Docs-Boundary Direct-Read Migration Review](reviews/docs-boundary-direct-read-migration-review.md) | reads `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` directly and accepts the shelf as the seventh migration pilot | path movement by review alone, `tree_path` frontmatter, source-of-truth governance, approval policy, skill acceptance, proof authority, runtime role law, or architecture taxonomy |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -214,5 +217,8 @@ surfaces were rebuilt, and frontmatter stayed unchanged.
 The landed `kag-source-lift` pilot review is now landed as `pilot-validated`
 and chooses `docs-boundary` for the next direct-read migration review.
 
-The next move is a direct-read migration review for `docs-boundary` before any
-other shelf moves.
+The `docs-boundary` direct-read review is now landed and accepts exactly
+`AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` as the seventh
+migration pilot.
+
+The next move is the seventh pilot migration before any other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -24,5 +24,6 @@ Current reviews:
 - [landed-instruction-surface-pilot-review](landed-instruction-surface-pilot-review.md)
 - [kag-source-lift-direct-read-migration-review](kag-source-lift-direct-read-migration-review.md)
 - [landed-kag-source-lift-pilot-review](landed-kag-source-lift-pilot-review.md)
+- [docs-boundary-direct-read-migration-review](docs-boundary-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md
@@ -1,0 +1,186 @@
+# Docs-Boundary Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Projection packet:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Prior pilot review:
+[Landed Kag-Source-Lift Pilot Review](landed-kag-source-lift-pilot-review.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-seventh-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `docs-boundary` as the seventh migration pilot.
+
+The move is clearer than current placement because the four bundles share one
+document-boundary question: how a repository keeps document truth, status
+snapshots, public-share artifacts, and decision rationale legible without
+turning any of those practices into governance doctrine, owner law, approval
+policy, execution workflow, or architecture taxonomy.
+
+`docs` remains true as their current `domain`, but it is too broad as a
+browsing neighborhood for this boundary-maintenance cluster. The proposed path
+under `techniques/instruction/docs-boundary/` fits the instruction trunk
+because these techniques shape how authored document surfaces instruct humans
+and agents where truth, status, shareability, and rationale live.
+
+This review does not move files. It only decides that the next bounded wave may
+move exactly this shelf if route-card update, root legacy receipt, link repair,
+generated surfaces, and validation move together.
+
+## Sources Read
+
+- [AOA-T-0002 source-of-truth-layout](../../../../../techniques/docs/source-of-truth-layout/TECHNIQUE.md)
+- [AOA-T-0009 lightweight-status-snapshot](../../../../../techniques/docs/lightweight-status-snapshot/TECHNIQUE.md)
+- [AOA-T-0034 public-safe-artifact-sanitization](../../../../../techniques/docs/public-safe-artifact-sanitization/TECHNIQUE.md)
+- [AOA-T-0033 decision-rationale-recording](../../../../../techniques/docs/decision-rationale-recording/TECHNIQUE.md)
+- [Docs domain route card](../../../../../techniques/docs/AGENTS.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- `reports/technique_tree_projection.md` rows for `docs-boundary`,
+  `instruction-surface`, `capability-registry`, `capability-boundary`, and
+  `skill-discovery`
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- [Landed kag-source-lift pilot review](landed-kag-source-lift-pilot-review.md)
+
+## Direct Read
+
+| technique | status | kind | center of gravity | pilot reading |
+|---|---|---|---|---|
+| `AOA-T-0002` `source-of-truth-layout` | `canonical` | `artifact` | document role map and update routing | canonical-home discipline, not governance constitution or architecture taxonomy |
+| `AOA-T-0009` `lightweight-status-snapshot` | `canonical` | `artifact` | short entrypoint status that links to canonical detail | snapshot discipline, not status authority or long history storage |
+| `AOA-T-0034` `public-safe-artifact-sanitization` | `canonical` | `guardrail` | public-safe share-prep for sensitive technical artifacts | shareable artifact boundary, not approval gating, execution planning, incident response, or proof that the underlying action is safe |
+| `AOA-T-0033` `decision-rationale-recording` | `promoted` | `artifact` | one compact decision note with context, options, rationale, and consequences | decision rationale, not source-of-truth governance, boundary mapping, or architecture classification |
+
+The shelf is not "all docs hygiene" and not "all governance-adjacent
+documentation." It is the narrower cluster where the technique teaches a reader
+or agent where document truth stops, where compact status belongs, what may be
+shared, or why one decision was made.
+
+## Boundary Chain
+
+The shelf has a useful internal sequence without becoming one workflow:
+
+- `AOA-T-0002` sets the document-role map so recurring information has one
+  canonical home.
+- `AOA-T-0009` keeps top-level status as a short route into those homes rather
+  than a duplicate log.
+- `AOA-T-0034` protects public-share artifacts when material needs to leave the
+  local context.
+- `AOA-T-0033` records one meaningful decision when the reason must survive
+  future review.
+
+Together they form a `docs-boundary` shelf because each leaf guards a document
+boundary that prevents drift, leakage, false authority, or rationale loss. They
+should remain four separate leaves because each one has a different input,
+output, misuse boundary, and validation cue.
+
+## Instruction Trunk Fit
+
+The proposed trunk is `instruction`, not because the techniques are prompt
+instructions, but because they shape instruction-facing repository surfaces:
+document roles, status snapshots, public-safe artifacts, and decision notes are
+the surfaces that tell future humans and agents where to look, what to trust,
+what may be shared, and what tradeoff was accepted.
+
+The existing `techniques/instruction/AGENTS.md` is already the right trunk
+route card. A later migration should update its current scope to include
+`docs-boundary/` without turning the trunk into AoA doctrine, approval policy,
+runtime role law, or source-of-truth governance.
+
+## Mixed Kind Stress
+
+`docs-boundary` mixes `artifact` and `guardrail`:
+
+- `AOA-T-0002`, `AOA-T-0009`, and `AOA-T-0033` are document artifacts.
+- `AOA-T-0034` is a public-share guardrail.
+- all four are `domain: docs`.
+- three are canonical, and one is promoted.
+
+The mixed kind is acceptable because the placement question is not move shape;
+it is document-boundary browsing. The guardrail leaf belongs here only because
+public-safe artifact preparation protects what may leave a document surface.
+It should not pull approval, incident response, dry-run planning, or infra
+execution into the shelf.
+
+## Why Not Keep This As Docs
+
+`docs` remains true as `domain`: all four techniques operate on documentation,
+status, artifacts, or rationale notes.
+
+The directory tree now answers a browsing and placement question. On that
+question, `instruction/docs-boundary` is tighter than the old broad folder:
+
+- `source-of-truth-layout` gives the canonical-home map
+- `lightweight-status-snapshot` keeps entrypoints short and linked
+- `public-safe-artifact-sanitization` keeps shareable artifacts bounded
+- `decision-rationale-recording` keeps one decision's reason reviewable
+- the shelf stays away from capability registry, skill discovery, proof,
+  governance, runtime, and owner-closeout authority
+
+## Pilot Scope
+
+Move exactly these four bundles in the next migration wave:
+
+| technique | current path | pilot path |
+|---|---|---|
+| `AOA-T-0002` | `techniques/docs/source-of-truth-layout/` | `techniques/instruction/docs-boundary/source-of-truth-layout/` |
+| `AOA-T-0009` | `techniques/docs/lightweight-status-snapshot/` | `techniques/instruction/docs-boundary/lightweight-status-snapshot/` |
+| `AOA-T-0034` | `techniques/docs/public-safe-artifact-sanitization/` | `techniques/instruction/docs-boundary/public-safe-artifact-sanitization/` |
+| `AOA-T-0033` | `techniques/docs/decision-rationale-recording/` | `techniques/instruction/docs-boundary/decision-rationale-recording/` |
+
+Keep bundle IDs, `domain`, `kind`, `status`, owners, evidence, relations,
+checklists, examples, notes, and public-safety posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored sibling links inside the four moved bundles
+- generated reader docs such as `TECHNIQUE_INDEX.md`, `docs/TECHNIQUE_*`,
+  `docs/EVIDENCE_NOTE_SURFACES.md`, and generated manifests
+- generated KAG export paths while keeping the export derived and source-owned
+- generated reports for family, topology, and tree projection
+- `techniques/instruction/AGENTS.md` current scope and domain rules, because
+  `instruction/` would gain a second landed shelf
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- active mechanics review rows that still point to old homes
+- release-check output touched by regenerated catalogs, capsules, sections,
+  examples, checklists, evidence notes, source-owned KAG export, and repo-doc
+  surfaces
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `family` or `tree_path` frontmatter.
+- Do not move another `candidate` or `pilot-candidate` shelf in the same wave.
+- Do not change `domain`; the pilot tests path architecture, not owner-lane
+  frontmatter.
+- Do not move `capability-registry`, `capability-boundary`,
+  `skill-discovery`, proof, governance, runtime, owner-closeout, or
+  knowledge-lift shelves in the same wave.
+- Do not turn `docs-boundary` into source-of-truth governance, AoA
+  constitutional law, approval policy, skill acceptance, proof authority,
+  runtime role law, or architecture taxonomy.
+- Do not collapse the four leaves into one documentation-governance framework
+  bundle.
+
+## Next Honest Move
+
+Run the seventh pilot migration.
+
+Move exactly `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into
+`techniques/instruction/docs-boundary/`, update the existing
+`instruction/` route card, repair authored links, preserve a root legacy
+receipt, rebuild generated surfaces, and run `python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -104,6 +104,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-instruction-surface-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1208,7 +1209,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1373,7 +1374,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1450,7 +1451,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1538,7 +1539,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
 
@@ -1620,7 +1621,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
         self.assertIn("2026-05-04-instruction-surface-tree-pilot.md", tree_contract)
@@ -1714,7 +1715,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`kag-source-lift` is now chosen", distillation_roadmap)
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
         self.assertIn("knowledge-lift", tree_contract)
         self.assertIn("kag-source-lift", tree_contract)
@@ -1796,7 +1797,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0018`, `AOA-T-0019", tree_contract)
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1831,7 +1832,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
-        self.assertIn("Run a direct-read migration review for `docs-boundary`", root_roadmap)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertTrue(
@@ -1929,11 +1930,94 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed kag-source-lift pilot review", landing_log)
         self.assertIn("selected\n  `docs-boundary`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `docs-boundary`",
+            "Run the seventh `docs-boundary` pilot migration",
             root_roadmap,
         )
         self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
         self.assertIn("docs-boundary", tree_contract)
+
+    def test_docs_boundary_direct_read_review_accepts_seventh_pilot(self) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "docs-boundary-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Docs-Boundary Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-seventh-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `docs-boundary` as the seventh migration pilot", review)
+        for technique_id in (
+            "AOA-T-0002",
+            "AOA-T-0009",
+            "AOA-T-0034",
+            "AOA-T-0033",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Boundary Chain", review)
+        self.assertIn("Instruction Trunk Fit", review)
+        self.assertIn("Mixed Kind Stress", review)
+        self.assertIn("Move exactly these four bundles", review)
+        self.assertIn("techniques/instruction/docs-boundary/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `family` or `tree_path` frontmatter", review)
+        self.assertIn("Do not turn `docs-boundary` into source-of-truth governance", review)
+        self.assertIn("Run the seventh pilot migration", review)
+
+        self.assertIn("docs-boundary-direct-read-migration-review", reviews_index)
+        self.assertIn("docs-boundary direct-read review: landed", ingress)
+        self.assertIn("accepted-for-seventh-migration-pilot", ingress)
+        self.assertIn("The next move is the seventh pilot migration", ingress)
+        self.assertIn("accepted-for-seventh-migration-pilot", distillation_roadmap)
+        self.assertIn("Docs-boundary direct-read migration review", landing_log)
+        self.assertIn("accepted the `docs-boundary` direct-read migration review", changelog)
+        self.assertIn("Run the seventh `docs-boundary` pilot migration", root_roadmap)
+        self.assertIn("Docs-Boundary Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0002`, `AOA-T-0009", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "docs"
+                / "source-of-truth-layout"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the docs-boundary direct-read migration review over AOA-T-0002, AOA-T-0009, AOA-T-0034, and AOA-T-0033
- accept docs-boundary as the seventh bounded tree pilot without moving files or changing frontmatter
- update reform ingress, tree contract, roadmaps, landing log, changelog, and tests so the next move is the seventh docs-boundary pilot migration

## Verification
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/release_check.py
- git diff --check
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python scripts/validate_semantic_agents.py
- python -m unittest discover -s tests
- public-share scan for changed authored surfaces