### PR TITLE
Review landed docs-boundary tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ The format is intentionally simple and human-first.
 - moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into
   `techniques/instruction/docs-boundary/` while keeping `domain`, `kind`, IDs,
   status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `docs-boundary` pilot review and selected
+  `capability-registry` for the next direct-read migration review without
+  moving an eighth shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, and the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`; all seven kept frontmatter unchanged. |
-| Next honest move | Review the landed `docs-boundary` pilot before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, and the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`; all seven kept frontmatter unchanged, and the landed `docs-boundary` pilot review now chooses `capability-registry` for the next direct-read review. |
+| Next honest move | Run a direct-read migration review for `capability-registry` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,8 +186,8 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, `kag-source-lift`, and
-  `docs-boundary` pilots as precedents while reviewing the seventh landed shelf
-  before any broader corpus move.
+  `docs-boundary` pilots as precedents while direct-reading the
+  `capability-registry` boundary-watch shelf before any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -275,8 +275,14 @@ and `AOA-T-0033` into `techniques/instruction/docs-boundary/` without changing
 `domain`, `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md`](../legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md).
 
-The next reform slice should review the landed `docs-boundary` pilot before
-moving another shelf.
+The landed seventh pilot review is
+[Landed Docs-Boundary Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md).
+It validates the `docs-boundary` migration as the second successful
+instruction trunk shelf and chooses `capability-registry` for the next
+direct-read migration review.
+
+The next reform slice should run a direct-read review for
+`capability-registry` before moving another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,38 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed docs-boundary pilot review
+
+Changed:
+
+- added
+  [landed-docs-boundary-pilot-review](parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md)
+  as the post-migration review over the seventh tree pilot
+- accepted the landed `docs-boundary` shelf as clearer after validation and as
+  the second successful instruction trunk shelf
+- chose `capability-registry` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `capability-boundary`, `skill-discovery`, proof, governance, runtime,
+  and owner-closeout shelves outside the next move
+- kept registry product doctrine, discovery ranking, trust policy, marketplace
+  curation, graph semantics, runtime resolution, and agent-role authority
+  outside `capability-registry`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no eighth shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Docs-boundary tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -96,7 +96,9 @@
    under `techniques/instruction/docs-boundary/`, with the instruction route
    card extended for the second shelf, root legacy receipt accounting, link
    repair, generated rebuilds, and release-check validation in the same wave.
-   The next bounded step is the landed `docs-boundary` pilot review before any
+   The landed `docs-boundary` pilot review is also landed as
+   `pilot-validated`, validates the second instruction trunk shelf, and chooses
+   `capability-registry` for the next direct-read migration review before any
    eighth shelf moves.
 
 ## Hold line

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -77,6 +77,8 @@ permission slip to remap techniques automatically.
 - docs-boundary migration: landed exactly `AOA-T-0002`, `AOA-T-0009`,
   `AOA-T-0034`, and `AOA-T-0033` under
   `techniques/instruction/docs-boundary/` without frontmatter changes
+- landed docs-boundary pilot review: landed as `pilot-validated`, with
+  `capability-registry` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -114,6 +116,7 @@ permission slip to remap techniques automatically.
 | [Kag-Source-Lift Direct-Read Migration Review](reviews/kag-source-lift-direct-read-migration-review.md) | reads `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` directly and accepts the shelf as the sixth migration pilot | path movement by review alone, `tree_path` frontmatter, KAG owner doctrine, graph authority, scoring, policy, or generated verdicts |
 | [Landed Kag-Source-Lift Pilot Review](reviews/landed-kag-source-lift-pilot-review.md) | confirms the sixth migrated shelf stayed clearer, validates the first knowledge-lift trunk machinery, and chooses `docs-boundary` for the next direct-read review | movement of `docs-boundary`, `tree_path` frontmatter, KAG owner authority, or proof that every instruction boundary shelf is safe |
 | [Docs-Boundary Direct-Read Migration Review](reviews/docs-boundary-direct-read-migration-review.md) | reads `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` directly and accepts the shelf as the seventh migration pilot | path movement by review alone, `tree_path` frontmatter, source-of-truth governance, approval policy, skill acceptance, proof authority, runtime role law, or architecture taxonomy |
+| [Landed Docs-Boundary Pilot Review](reviews/landed-docs-boundary-pilot-review.md) | confirms the seventh migrated shelf stayed clearer, validates the second instruction trunk shelf, and chooses `capability-registry` for the next direct-read review | movement of `capability-registry`, `tree_path` frontmatter, registry product doctrine, discovery ranking, trust policy, marketplace curation, graph semantics, runtime resolution, or agent-role authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -229,5 +232,8 @@ The seventh pilot migration is now landed: those four bundles live under
 root legacy receipt are in place, authored links were repaired, generated
 surfaces were rebuilt, and frontmatter stayed unchanged.
 
-The next move is the landed `docs-boundary` pilot review before any other shelf
-moves.
+The landed `docs-boundary` pilot review is now landed as `pilot-validated` and
+chooses `capability-registry` for the next direct-read migration review.
+
+The next move is a direct-read migration review for `capability-registry`
+before any eighth shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -25,5 +25,6 @@ Current reviews:
 - [kag-source-lift-direct-read-migration-review](kag-source-lift-direct-read-migration-review.md)
 - [landed-kag-source-lift-pilot-review](landed-kag-source-lift-pilot-review.md)
 - [docs-boundary-direct-read-migration-review](docs-boundary-direct-read-migration-review.md)
+- [landed-docs-boundary-pilot-review](landed-docs-boundary-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md
@@ -1,0 +1,168 @@
+# Landed Docs-Boundary Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Docs-Boundary Direct-Read Migration Review](docs-boundary-direct-read-migration-review.md)
+
+Migration receipt:
+[Docs-Boundary Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `capability-registry` for direct-read
+migration review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `docs-boundary` pilot as a successful seventh tree migration
+and the second successful shelf under the `instruction` trunk.
+
+The shelf stayed legible after landing. Four docs-domain techniques now sit
+under one document-boundary neighborhood, while IDs, `domain`, `kind`, status,
+evidence, notes, examples, checks, relations, and public-safety posture stayed
+unchanged. The move improved browsing without turning source-of-truth layout,
+status snapshots, public-safe share preparation, and decision rationale into
+one governance doctrine or architecture taxonomy.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should run a direct-read review for `capability-registry`, because the
+instruction trunk has now held both instruction-surface and document-boundary
+practice. The next pressure should test whether capability specs, registry
+entries, and discovery queries form one bounded capability-registry shelf
+without importing registry product doctrine, ranking, trust policy, runtime
+resolution, or marketplace curation.
+
+## Sources Read
+
+- [AOA-T-0002 source-of-truth-layout](../../../../../techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md)
+- [AOA-T-0009 lightweight-status-snapshot](../../../../../techniques/instruction/docs-boundary/lightweight-status-snapshot/TECHNIQUE.md)
+- [AOA-T-0034 public-safe-artifact-sanitization](../../../../../techniques/instruction/docs-boundary/public-safe-artifact-sanitization/TECHNIQUE.md)
+- [AOA-T-0033 decision-rationale-recording](../../../../../techniques/instruction/docs-boundary/decision-rationale-recording/TECHNIQUE.md)
+- [AOA-T-0025 capability-spec-versioning](../../../../../techniques/docs/capability-spec-versioning/TECHNIQUE.md)
+- [AOA-T-0063 versioned-agent-registry-contract](../../../../../techniques/docs/versioned-agent-registry-contract/TECHNIQUE.md)
+- [AOA-T-0064 capability-discovery](../../../../../techniques/docs/capability-discovery/TECHNIQUE.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- [Docs route card](../../../../../techniques/docs/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Docs-boundary tree pilot receipt](../../../../../legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md)
+- [Technique tree projection rows for `docs-boundary`,
+  `capability-registry`, `capability-boundary`, and `skill-discovery`](../../../../../reports/technique_tree_projection.md)
+- [First family shelf review pack](first-family-shelf-review-pack.md)
+- [First tree projection review pack](first-tree-projection-review-pack.md)
+- [Landed kag-source-lift pilot review](landed-kag-source-lift-pilot-review.md)
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/instruction/docs-boundary/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | all four leaves keep `domain: docs`; `kind` remains `artifact` or `guardrail` as authored |
+| route card | present | `techniques/instruction/AGENTS.md` now names `instruction-surface/` and `docs-boundary/` without becoming a governance surface |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, manifests, reports, source-owned KAG exports, and reader surfaces point at current paths |
+| mechanics links | repaired | Distillation, Audit, Experience, and Agon active references route to current authored paths; legacy raw links remain historical receipts |
+| validation | green | release check covered unit tests, nested AGENTS coverage, repository parity, and regenerated surfaces |
+
+## What The Seventh Pilot Proved
+
+- `instruction/` can hold more than one shelf without becoming a frontmatter
+  domain or an AoA constitutional surface.
+- A document-boundary shelf can mix `artifact` and `guardrail` when the shared
+  browsing question is boundary maintenance rather than move shape.
+- Broad `docs/` can shrink honestly: moved leaves keep `domain: docs`, while
+  the remaining docs folder stays useful for still-unmigrated docs-domain
+  bundles.
+- Root `legacy/receipts/` remains enough for path-migration accounting; active
+  bundles did not need to pass through legacy.
+- Route-card economy matters. The useful bridge is the local shelf statement,
+  not a repeated law block inserted into every technique.
+- Standalone portability is stronger after the move: external builders can
+  reuse one document-boundary technique without deploying OS Abyss or accepting
+  AoA governance doctrine.
+
+## Remaining Weaknesses
+
+- The generated projection still labels landed shelves with candidate-style
+  review statuses. That remains tolerable while projection status is
+  non-authoritative, but later generated status language needs a separate
+  review if it starts confusing readers.
+- `instruction/` now has two landed shelves, but it is not a complete
+  instruction taxonomy.
+- `capability-registry`, `capability-boundary`, and `skill-discovery` still
+  carry stronger capability, skill, registry, marketplace, and upstream-health
+  authority pressure than `docs-boundary` did.
+- `docs/` still contains several boundary-watch shelves. That is acceptable
+  until each one gets direct reading and a migration receipt.
+
+## Eighth Shelf Choice
+
+Choose `capability-registry` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0025` | `techniques/docs/capability-spec-versioning/` | `techniques/instruction/capability-registry/capability-spec-versioning/` |
+| `AOA-T-0063` | `techniques/docs/versioned-agent-registry-contract/` | `techniques/instruction/capability-registry/versioned-agent-registry-contract/` |
+| `AOA-T-0064` | `techniques/docs/capability-discovery/` | `techniques/instruction/capability-registry/capability-discovery/` |
+
+Reason:
+
+`capability-registry` is the cleanest next review target because the three
+leaves form a bounded sequence: a capability contract is versioned, a
+registry-facing entry publishes a named versioned record, and discovery queries
+already-published entries. All three are docs-domain techniques that shape
+agent-facing capability surfaces, which fits the instruction trunk better than
+the broad `docs/` folder if direct reading confirms the boundaries.
+
+Why direct-read first:
+
+The generated projection marks these rows as `boundary-watch`, and that is
+right. The shelf touches registry, discovery, and capability language, so the
+next step must read the bundles directly and keep registry product semantics,
+ranking, trust policy, marketplace curation, graph semantics, and runtime
+resolution outside the move before any path migration is allowed.
+
+Why not `capability-boundary` or `skill-discovery` first:
+
+`capability-boundary` mixes host-actionability, skill-command ownership, and
+multi-source provenance. `skill-discovery` mixes marketplace curation with
+upstream-health validation. Both may be real shelves, but their owner pressure
+is more cross-cutting than the capability-registry chain.
+
+Why not proof, governance, runtime, or owner-closeout shelves first:
+
+Those shelves test stronger authority surfaces. The tree should finish this
+instruction-side capability-registry review before taking on proof,
+governance, runtime, or closeout semantics.
+
+## Stop Lines
+
+- Do not move `capability-registry` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `capability-boundary`, `skill-discovery`, proof, governance,
+  runtime, or owner-closeout shelves in the same wave.
+- Do not treat `capability-registry` as registry product doctrine, discovery
+  ranking, trust policy, marketplace curation, graph semantics, runtime
+  resolution, or agent-role authority.
+- Keep capability specs, registry entries, and discovery queries as separate
+  leaves unless direct reading proves a different boundary.
+- Keep authored bundle markdown and frontmatter stronger than generated
+  projection rows.
+
+## Next Honest Move
+
+Run a direct-read migration review for `capability-registry`.
+
+Read `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064`; inspect their capability
+contract, registry-entry, and discovery-query boundaries, route-card needs,
+owner-authority stop-lines, and whether
+`techniques/instruction/capability-registry/` is clearer than the current broad
+`docs/` folder.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -105,6 +105,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/kag-source-lift-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1209,7 +1210,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`media-ingest` direct-read review is now", distillation_roadmap)
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
         self.assertIn("techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md", incoming_wave2)
         self.assertIn("techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md", incoming_wave3)
@@ -1374,7 +1378,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("diagnosis-repair` is now", distillation_roadmap)
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
         self.assertIn("techniques/recovery/diagnosis-repair/", tree_contract)
 
@@ -1451,7 +1458,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `diagnosis-repair` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0080` through `AOA-T-0083", tree_contract)
         self.assertIn("2026-05-04-diagnosis-repair-tree-pilot.md", tree_contract)
@@ -1539,7 +1549,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted-for-fifth-migration-pilot", distillation_roadmap)
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
         self.assertIn("instruction-surface", tree_contract)
 
@@ -1621,7 +1634,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0012`, `AOA-T-0013", tree_contract)
         self.assertIn("2026-05-04-instruction-surface-tree-pilot.md", tree_contract)
@@ -1715,7 +1731,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("`kag-source-lift` is now chosen", distillation_roadmap)
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
         self.assertIn("knowledge-lift", tree_contract)
         self.assertIn("kag-source-lift", tree_contract)
@@ -1797,7 +1816,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0018`, `AOA-T-0019", tree_contract)
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1832,7 +1854,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Kag-source-lift tree pilot migration", landing_log)
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertTrue(
@@ -1930,7 +1955,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed kag-source-lift pilot review", landing_log)
         self.assertIn("selected\n  `docs-boundary`", changelog)
         self.assertIn(
-            "Review the landed `docs-boundary` pilot",
+            "Run a direct-read migration review for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
@@ -2008,7 +2033,10 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Docs-boundary direct-read migration review", landing_log)
         self.assertIn("accepted the `docs-boundary` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0002`, `AOA-T-0009", changelog)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("Docs-Boundary Direct-Read Migration Review", tree_contract)
         self.assertIn("AOA-T-0002`, `AOA-T-0009", tree_contract)
         self.assertIn("2026-05-04-docs-boundary-tree-pilot.md", tree_contract)
@@ -2055,13 +2083,16 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("docs-boundary migration: landed", ingress)
         self.assertIn("techniques/instruction/docs-boundary/", ingress)
         self.assertIn("without frontmatter changes", ingress)
-        self.assertIn("landed `docs-boundary` pilot review", ingress)
+        self.assertIn("landed docs-boundary pilot review", ingress)
         self.assertIn("seventh pilot migration is now landed", distillation_roadmap)
         self.assertIn("techniques/instruction/docs-boundary/", distillation_roadmap)
         self.assertIn("Docs-boundary tree pilot migration", landing_log)
         self.assertIn("legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md", landing_log)
         self.assertIn("seventh landed pilot moved `AOA-T-0002`", root_roadmap)
-        self.assertIn("Review the landed `docs-boundary` pilot", root_roadmap)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
         self.assertIn("2026-05-04-docs-boundary-tree-pilot.md", tree_contract)
         self.assertIn("moved `AOA-T-0002`, `AOA-T-0009", changelog)
         self.assertTrue(
@@ -2082,6 +2113,95 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "decision-rationale-recording"
             ).exists()
         )
+
+    def test_landed_docs_boundary_pilot_review_selects_capability_registry(
+        self,
+    ) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-docs-boundary-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Docs-Boundary Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not `tree_path` frontmatter", review)
+        self.assertIn("Accept the landed `docs-boundary` pilot", review)
+        self.assertIn(
+            "second successful shelf under the `instruction` trunk",
+            review,
+        )
+        self.assertIn("Choose `capability-registry`", review)
+        for technique_id in (
+            "AOA-T-0002",
+            "AOA-T-0009",
+            "AOA-T-0034",
+            "AOA-T-0033",
+            "AOA-T-0025",
+            "AOA-T-0063",
+            "AOA-T-0064",
+        ):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn(
+            "Do not move `capability-registry` from this review alone",
+            review,
+        )
+        self.assertIn("registry product doctrine", review)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            review,
+        )
+
+        self.assertIn("landed-docs-boundary-pilot-review", reviews_index)
+        self.assertIn("landed docs-boundary pilot review: landed", ingress)
+        self.assertIn("capability-registry", ingress)
+        self.assertIn("direct-read migration review", ingress)
+        self.assertIn("`capability-registry` for the next", distillation_roadmap)
+        self.assertIn("before any\n   eighth shelf moves", distillation_roadmap)
+        self.assertIn("Landed docs-boundary pilot review", landing_log)
+        self.assertIn("second successful instruction trunk shelf", landing_log)
+        self.assertIn("selected\n  `capability-registry`", changelog)
+        self.assertIn(
+            "Run a direct-read migration review for `capability-registry`",
+            root_roadmap,
+        )
+        self.assertIn("Landed Docs-Boundary Pilot Review", tree_contract)
+        self.assertIn("capability-registry", tree_contract)
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add the landed docs-boundary pilot review and accept the seventh shelf as validated
- select capability-registry for the next direct-read migration review without moving another shelf
- update roadmap, tree contract, changelog, landing log, and topology tests

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- git diff --check
- python scripts/validate_semantic_agents.py
- public-share diff scan for secret/private tokens: no findings