### PR TITLE
Accept capability-registry migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `docs-boundary` pilot review and selected
   `capability-registry` for the next direct-read migration review without
   moving an eighth shelf yet
+- accepted the `capability-registry` direct-read migration review over
+  `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` as the eighth tree pilot while
+  keeping the review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, and the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`; all seven kept frontmatter unchanged, and the landed `docs-boundary` pilot review now chooses `capability-registry` for the next direct-read review. |
-| Next honest move | Run a direct-read migration review for `capability-registry` before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, and the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`; all seven kept frontmatter unchanged, and the `capability-registry` direct-read review now accepts `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` as the eighth migration pilot without moving them yet. |
+| Next honest move | Run the eighth pilot migration for `capability-registry` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,7 +186,7 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, `kag-source-lift`, and
-  `docs-boundary` pilots as precedents while direct-reading the
+  `docs-boundary` pilots as precedents while migrating the accepted
   `capability-registry` boundary-watch shelf before any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -281,7 +281,12 @@ It validates the `docs-boundary` migration as the second successful
 instruction trunk shelf and chooses `capability-registry` for the next
 direct-read migration review.
 
-The next reform slice should run a direct-read review for
+The eighth migration review is
+[Capability-Registry Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md).
+It accepts `capability-registry` as the eighth migration pilot after directly
+reading `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064`.
+
+The next reform slice should run the eighth pilot migration for
 `capability-registry` before moving another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,37 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Capability-registry direct-read migration review
+
+Changed:
+
+- added
+  [capability-registry-direct-read-migration-review](parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064`
+- accepted `capability-registry` as the eighth bounded migration pilot because
+  direct reading confirmed the spec-entry-query chain
+- kept the review non-mutating: no technique bundle moved, no frontmatter
+  changed, and no generated projection became authority
+- kept `capability-boundary`, `skill-discovery`, proof, governance, runtime,
+  and owner-closeout shelves outside the migration wave
+- kept registry product doctrine, discovery ranking, marketplace curation,
+  trust policy, graph semantics, runtime resolution, skill acceptance, and
+  agent-role authority outside `capability-registry`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no eighth shelf migration happened from the review alone
+
 ## 2026-05-04 - Landed docs-boundary pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -98,8 +98,14 @@
    repair, generated rebuilds, and release-check validation in the same wave.
    The landed `docs-boundary` pilot review is also landed as
    `pilot-validated`, validates the second instruction trunk shelf, and chooses
-   `capability-registry` for the next direct-read migration review before any
-   eighth shelf moves.
+   `capability-registry` for the next direct-read migration review. The
+   `capability-registry` direct-read review is now landed as
+   `accepted-for-eighth-migration-pilot`; it accepts exactly `AOA-T-0025`,
+   `AOA-T-0063`, and `AOA-T-0064` while keeping registry product doctrine,
+   discovery ranking, marketplace curation, trust policy, graph semantics,
+   runtime resolution, skill acceptance, and agent-role authority outside the
+   move. The next bounded step is the eighth pilot migration before any other
+   shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -79,6 +79,8 @@ permission slip to remap techniques automatically.
   `techniques/instruction/docs-boundary/` without frontmatter changes
 - landed docs-boundary pilot review: landed as `pilot-validated`, with
   `capability-registry` chosen for the next direct-read migration review
+- capability-registry direct-read review: landed as
+  `accepted-for-eighth-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -117,6 +119,7 @@ permission slip to remap techniques automatically.
 | [Landed Kag-Source-Lift Pilot Review](reviews/landed-kag-source-lift-pilot-review.md) | confirms the sixth migrated shelf stayed clearer, validates the first knowledge-lift trunk machinery, and chooses `docs-boundary` for the next direct-read review | movement of `docs-boundary`, `tree_path` frontmatter, KAG owner authority, or proof that every instruction boundary shelf is safe |
 | [Docs-Boundary Direct-Read Migration Review](reviews/docs-boundary-direct-read-migration-review.md) | reads `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` directly and accepts the shelf as the seventh migration pilot | path movement by review alone, `tree_path` frontmatter, source-of-truth governance, approval policy, skill acceptance, proof authority, runtime role law, or architecture taxonomy |
 | [Landed Docs-Boundary Pilot Review](reviews/landed-docs-boundary-pilot-review.md) | confirms the seventh migrated shelf stayed clearer, validates the second instruction trunk shelf, and chooses `capability-registry` for the next direct-read review | movement of `capability-registry`, `tree_path` frontmatter, registry product doctrine, discovery ranking, trust policy, marketplace curation, graph semantics, runtime resolution, or agent-role authority |
+| [Capability-Registry Direct-Read Migration Review](reviews/capability-registry-direct-read-migration-review.md) | reads `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` directly and accepts the shelf as the eighth migration pilot | path movement by review alone, `tree_path` frontmatter, registry product doctrine, discovery ranking, marketplace curation, trust policy, graph semantics, runtime resolution, skill acceptance, or agent-role authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -235,5 +238,8 @@ surfaces were rebuilt, and frontmatter stayed unchanged.
 The landed `docs-boundary` pilot review is now landed as `pilot-validated` and
 chooses `capability-registry` for the next direct-read migration review.
 
-The next move is a direct-read migration review for `capability-registry`
-before any eighth shelf moves.
+The `capability-registry` direct-read review is now landed and accepts exactly
+`AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` as the eighth migration pilot.
+
+The next move is the eighth pilot migration for `capability-registry` before
+any other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -26,5 +26,6 @@ Current reviews:
 - [landed-kag-source-lift-pilot-review](landed-kag-source-lift-pilot-review.md)
 - [docs-boundary-direct-read-migration-review](docs-boundary-direct-read-migration-review.md)
 - [landed-docs-boundary-pilot-review](landed-docs-boundary-pilot-review.md)
+- [capability-registry-direct-read-migration-review](capability-registry-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md
@@ -1,0 +1,165 @@
+# Capability-Registry Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Preceding landed review:
+[Landed Docs-Boundary Pilot Review](landed-docs-boundary-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-eighth-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `capability-registry` as the eighth bounded tree migration pilot.
+
+Direct reading confirms that `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064`
+form one browseable instruction-side shelf: a capability contract is versioned,
+a registry-facing entry publishes a named versioned record, and a lookup
+contract discovers already-published records. The three leaves stay separate,
+but the reader benefits from finding them in one capability-registry
+neighborhood instead of hunting across broad `docs/`.
+
+This review does not move files. It only authorizes a later migration wave to
+move exactly these three bundles into
+`techniques/instruction/capability-registry/` if that wave also updates route
+cards, root legacy receipts, links, generated surfaces, and validation.
+
+## Sources Read
+
+- [AOA-T-0025 capability-spec-versioning](../../../../../techniques/docs/capability-spec-versioning/TECHNIQUE.md)
+- [AOA-T-0025 checklist](../../../../../techniques/docs/capability-spec-versioning/checks/capability-spec-versioning-checklist.md)
+- [AOA-T-0025 minimal example](../../../../../techniques/docs/capability-spec-versioning/examples/minimal-capability-spec-versioning.md)
+- [AOA-T-0025 compatibility example](../../../../../techniques/docs/capability-spec-versioning/examples/concrete-capability-upgrade-with-compat-window.md)
+- [AOA-T-0025 evidence notes](../../../../../techniques/docs/capability-spec-versioning/notes/canonical-readiness.md)
+- [AOA-T-0063 versioned-agent-registry-contract](../../../../../techniques/docs/versioned-agent-registry-contract/TECHNIQUE.md)
+- [AOA-T-0063 checklist](../../../../../techniques/docs/versioned-agent-registry-contract/checks/versioned-agent-registry-contract-checklist.md)
+- [AOA-T-0063 minimal example](../../../../../techniques/docs/versioned-agent-registry-contract/examples/minimal-versioned-agent-registry-contract.md)
+- [AOA-T-0063 evidence notes](../../../../../techniques/docs/versioned-agent-registry-contract/notes/canonical-readiness.md)
+- [AOA-T-0064 capability-discovery](../../../../../techniques/docs/capability-discovery/TECHNIQUE.md)
+- [AOA-T-0064 checklist](../../../../../techniques/docs/capability-discovery/checks/capability-discovery-checklist.md)
+- [AOA-T-0064 minimal example](../../../../../techniques/docs/capability-discovery/examples/minimal-capability-discovery.md)
+- [AOA-T-0064 evidence notes](../../../../../techniques/docs/capability-discovery/notes/canonical-readiness.md)
+- [Docs route card](../../../../../techniques/docs/AGENTS.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- [Landed docs-boundary pilot review](landed-docs-boundary-pilot-review.md)
+- [Technique tree projection rows for `capability-registry`,
+  `capability-boundary`, and `skill-discovery`](../../../../../reports/technique_tree_projection.md)
+
+## Direct Bundle Read
+
+| technique | current path | kind | direct-read result |
+|---|---|---|---|
+| `AOA-T-0025` | `techniques/docs/capability-spec-versioning/` | `artifact` | one named capability stays explicit through a versioned spec with inputs, outputs, invariants, and compatibility notes |
+| `AOA-T-0063` | `techniques/docs/versioned-agent-registry-contract/` | `artifact` | one registry-facing entry publishes a named versioned record with stable reference and bounded metadata |
+| `AOA-T-0064` | `techniques/docs/capability-discovery/` | `discovery` | one bounded query surface locates already-published capability records with explicit fields, match rules, and result shape |
+
+The kinds are mixed, but the shelf is not pretending to be one move kind. It is
+a path neighborhood for one capability-registry chain.
+
+## Why The Shelf Holds
+
+- `AOA-T-0025` owns the capability contract itself and explicitly refuses
+  registry, orchestration, persistence, and routing breadth.
+- `AOA-T-0063` complements `AOA-T-0025` by owning the publication entry, not
+  the full capability spec and not the discovery layer.
+- `AOA-T-0064` complements `AOA-T-0063` by owning lookup over already-published
+  entries, not publication, ranking, curation, or trust verdicts.
+- The examples preserve the same layering: spec example, registry-entry
+  example, then query/response example.
+- The checklists independently guard the same boundary by keeping runtime,
+  marketplace, trust, graph, and product semantics out of the leaf contracts.
+- The canonical-readiness notes all keep the bundles promoted rather than
+  canonical, which fits a migration pilot: path clarity can improve before any
+  stronger quality or default-use status changes.
+
+## Instruction Trunk Fit
+
+`instruction/` is the better trunk because these bundles shape agent-facing
+capability surfaces: what a capability contract says, how a versioned record is
+published, and how lookup asks for records. They are documentation-domain
+techniques today, but their browsing question is capability instruction and
+registry surface legibility rather than generic documentation craft.
+
+The `docs/` route card remains correct for their current home until migration.
+It already warns against smuggling graph semantics, runtime orchestration, and
+repo-specific workflow into docs techniques. The `instruction/` route card is
+also ready to host a new shelf if the migration wave adds a compact local scope
+bullet and keeps this trunk from becoming skill marketplace policy or runtime
+role law.
+
+## Boundary Watch Accepted
+
+The generated projection was right to label this shelf `boundary-watch`.
+Capability registry language easily grows too wide. Direct reading accepts the
+shelf only because the three bundles repeatedly keep neighboring authority out:
+
+- no registry product doctrine
+- no discovery ranking
+- no marketplace curation
+- no trust or signature policy
+- no graph semantics
+- no runtime capability resolution
+- no role, skill-acceptance, or governance authority
+
+That makes the shelf viable, but also makes the migration stop-lines important.
+
+## Proposed Move
+
+Move exactly these three bundles in the migration wave:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0025` | `techniques/docs/capability-spec-versioning/` | `techniques/instruction/capability-registry/capability-spec-versioning/` |
+| `AOA-T-0063` | `techniques/docs/versioned-agent-registry-contract/` | `techniques/instruction/capability-registry/versioned-agent-registry-contract/` |
+| `AOA-T-0064` | `techniques/docs/capability-discovery/` | `techniques/instruction/capability-registry/capability-discovery/` |
+
+Keep `domain`, `kind`, status, IDs, evidence, relations, and public-safety
+posture unchanged.
+
+## Why Not Neighbor Shelves In This Wave
+
+`capability-boundary` should wait because its projected rows mix
+host-actionability, skill-command ownership, and multi-source provenance. That
+is a real neighboring pressure, but it is more cross-owner than this
+spec-entry-query chain.
+
+`skill-discovery` should wait because it mixes marketplace curation and
+upstream-health validation. That may become an instruction shelf, but it needs
+its own direct-read review before any path move.
+
+Proof, governance, runtime, and owner-closeout shelves should wait because they
+test stronger authority surfaces than this migration needs.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `tree_path`, `family`, capability, substrate, execution-profile,
+  or risk frontmatter.
+- Do not move `capability-boundary`, `skill-discovery`, proof, governance,
+  runtime, or owner-closeout shelves in the same wave.
+- Do not turn `capability-registry` into registry product doctrine, discovery
+  ranking, marketplace curation, trust policy, graph semantics, runtime
+  resolution, skill acceptance, or agent-role authority.
+- Do not collapse the three leaves into one technique; the shelf holds because
+  spec, entry publication, and lookup remain distinct.
+- Do not change canonical/promoted status, maturity, evidence, or
+  public-safety posture during the path migration.
+- Keep generated projection weaker than authored bundle meaning.
+
+## Next Honest Move
+
+Run the eighth pilot migration.
+
+Move exactly `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into
+`techniques/instruction/capability-registry/`; add the compact
+`capability-registry/` shelf scope to `techniques/instruction/AGENTS.md`;
+preserve a root `legacy/receipts/` migration receipt; repair authored links;
+rebuild generated surfaces; and validate with the narrow tree-pilot tests plus
+`python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -106,6 +106,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-kag-source-lift-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1211,7 +1212,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
@@ -1379,7 +1380,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
@@ -1459,7 +1460,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
@@ -1550,7 +1551,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
@@ -1635,7 +1636,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
@@ -1732,7 +1733,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
@@ -1817,7 +1818,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
@@ -1855,7 +1856,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1955,7 +1956,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed kag-source-lift pilot review", landing_log)
         self.assertIn("selected\n  `docs-boundary`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
@@ -2034,7 +2035,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `docs-boundary` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0002`, `AOA-T-0009", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Docs-Boundary Direct-Read Migration Review", tree_contract)
@@ -2090,7 +2091,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md", landing_log)
         self.assertIn("seventh landed pilot moved `AOA-T-0002`", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("2026-05-04-docs-boundary-tree-pilot.md", tree_contract)
@@ -2192,16 +2193,115 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("capability-registry", ingress)
         self.assertIn("direct-read migration review", ingress)
         self.assertIn("`capability-registry` for the next", distillation_roadmap)
-        self.assertIn("before any\n   eighth shelf moves", distillation_roadmap)
+        self.assertIn(
+            "The next bounded step is the eighth pilot migration",
+            distillation_roadmap,
+        )
         self.assertIn("Landed docs-boundary pilot review", landing_log)
         self.assertIn("second successful instruction trunk shelf", landing_log)
         self.assertIn("selected\n  `capability-registry`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-registry`",
+            "Run the eighth pilot migration for `capability-registry`",
             root_roadmap,
         )
         self.assertIn("Landed Docs-Boundary Pilot Review", tree_contract)
         self.assertIn("capability-registry", tree_contract)
+
+    def test_capability_registry_direct_read_review_accepts_eighth_pilot(
+        self,
+    ) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "capability-registry-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Capability-Registry Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-eighth-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `capability-registry` as the eighth", review)
+        self.assertIn("spec-entry-query chain", review)
+        self.assertIn("Direct Bundle Read", review)
+        for technique_id in ("AOA-T-0025", "AOA-T-0063", "AOA-T-0064"):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Move exactly these three bundles", review)
+        self.assertIn("techniques/instruction/capability-registry/", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `tree_path`", review)
+        self.assertIn("registry product doctrine", review)
+        self.assertIn("Do not collapse the three leaves into one technique", review)
+        self.assertIn("Run the eighth pilot migration", review)
+
+        self.assertIn("capability-registry-direct-read-migration-review", reviews_index)
+        self.assertIn("capability-registry direct-read review: landed", ingress)
+        self.assertIn("accepted-for-eighth-migration-pilot", ingress)
+        self.assertIn("accepted-for-eighth-migration-pilot", distillation_roadmap)
+        self.assertIn("eighth pilot migration", distillation_roadmap)
+        self.assertIn("Capability-registry direct-read migration review", landing_log)
+        self.assertIn("spec-entry-query chain", landing_log)
+        self.assertIn(
+            "accepted the `capability-registry` direct-read migration review",
+            changelog,
+        )
+        self.assertIn(
+            "Run the eighth pilot migration for `capability-registry`",
+            root_roadmap,
+        )
+        self.assertIn("Capability-Registry Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0025`, `AOA-T-0063", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "docs"
+                / "capability-spec-versioning"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "instruction"
+                / "capability-registry"
+                / "capability-spec-versioning"
+            ).exists()
+        )
 
     def test_cross_layer_candidate_ledger_has_preserved_pre_prune_receipt(self) -> None:
         active = (


### PR DESCRIPTION
## Summary
- add a direct-read migration review for the capability-registry shelf
- accept AOA-T-0025, AOA-T-0063, and AOA-T-0064 as the eighth migration pilot without moving files yet
- update reform ingress, roadmap, tree contract, changelog, landing log, and topology tests

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- git diff --check
- python scripts/validate_semantic_agents.py
- public-share diff scan for secret/private tokens: no findings