### PR TITLE
Review landed capability-registry tree pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ The format is intentionally simple and human-first.
 - moved `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into
   `techniques/instruction/capability-registry/` while keeping `domain`,
   `kind`, IDs, status, evidence, and `tree_path` frontmatter unchanged
+- accepted the landed `capability-registry` pilot review and selected
+  `capability-boundary` for the next direct-read migration review without
+  moving a ninth shelf yet
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`, and the eighth landed pilot moved `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into `techniques/instruction/capability-registry/`; all eight kept frontmatter unchanged. |
-| Next honest move | Review the landed `capability-registry` pilot before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`, and the eighth landed pilot moved `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into `techniques/instruction/capability-registry/`; all eight kept frontmatter unchanged, and the landed `capability-registry` pilot review now chooses `capability-boundary` for the next direct-read review. |
+| Next honest move | Run a direct-read migration review for `capability-boundary` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -186,8 +186,9 @@ trigger is real.
   examples and tie-break rules stay stable across multiple technique waves.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, `kag-source-lift`,
-  `docs-boundary`, and `capability-registry` pilots as precedents, and review
-  the landed `capability-registry` shelf before any broader corpus move.
+  `docs-boundary`, and `capability-registry` pilots as precedents, and run the
+  accepted `capability-boundary` direct-read review before any broader corpus
+  move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -291,7 +291,13 @@ into `techniques/instruction/capability-registry/` without changing `domain`,
 `kind`, or `tree_path` frontmatter. The root receipt is
 [`legacy/receipts/2026-05-04-capability-registry-tree-pilot.md`](../legacy/receipts/2026-05-04-capability-registry-tree-pilot.md).
 
-The next reform slice should review the landed `capability-registry` pilot
+The landed eighth pilot review is
+[Landed Capability-Registry Pilot Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md).
+It validates `capability-registry` as the third successful instruction trunk
+shelf and chooses `capability-boundary` for the next direct-read migration
+review.
+
+The next reform slice should run the `capability-boundary` direct-read review
 before moving another shelf.
 
 This keeps the future tree beautiful enough to grow while preserving current

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,38 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Landed capability-registry pilot review
+
+Changed:
+
+- added
+  [landed-capability-registry-pilot-review](parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md)
+  as the post-migration review over the eighth tree pilot
+- accepted the landed `capability-registry` shelf as clearer after validation
+  and as the third successful instruction trunk shelf
+- chose `capability-boundary` for the next direct-read migration review without
+  moving another shelf
+- kept `family`, `tree_path`, and scout topology axes out of frontmatter
+- kept `skill-discovery`, proof, governance, runtime, owner-closeout, and
+  other capability-adjacent shelves outside the next move
+- kept skill marketplace curation, upstream health validation, routing policy,
+  KAG graph semantics, runtime execution doctrine, host inventory policy, and
+  agent-role authority outside `capability-boundary`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no ninth shelf migration was authorized without direct-read review
+
 ## 2026-05-04 - Capability-registry tree pilot migration
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -108,7 +108,10 @@
    under `techniques/instruction/capability-registry/`, with the instruction
    route card extended for the third shelf, root legacy receipt accounting,
    link repair, generated rebuilds, and release-check validation in the same
-   wave. The next bounded step is a landed `capability-registry` pilot review
+   wave. The landed `capability-registry` pilot review is also landed as
+   `pilot-validated`, validates the third instruction trunk shelf, and chooses
+   `capability-boundary` for the next direct-read migration review. The next
+   bounded step is a direct-read migration review for `capability-boundary`
    before any other shelf moves.
 
 ## Hold line

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -84,6 +84,8 @@ permission slip to remap techniques automatically.
 - capability-registry migration: landed exactly `AOA-T-0025`, `AOA-T-0063`,
   and `AOA-T-0064` under
   `techniques/instruction/capability-registry/` without frontmatter changes
+- landed capability-registry pilot review: landed as `pilot-validated`, with
+  `capability-boundary` chosen for the next direct-read migration review
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -124,6 +126,7 @@ permission slip to remap techniques automatically.
 | [Landed Docs-Boundary Pilot Review](reviews/landed-docs-boundary-pilot-review.md) | confirms the seventh migrated shelf stayed clearer, validates the second instruction trunk shelf, and chooses `capability-registry` for the next direct-read review | movement of `capability-registry`, `tree_path` frontmatter, registry product doctrine, discovery ranking, trust policy, marketplace curation, graph semantics, runtime resolution, or agent-role authority |
 | [Capability-Registry Direct-Read Migration Review](reviews/capability-registry-direct-read-migration-review.md) | reads `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` directly and accepts the shelf as the eighth migration pilot | path movement by review alone, `tree_path` frontmatter, registry product doctrine, discovery ranking, marketplace curation, trust policy, graph semantics, runtime resolution, skill acceptance, or agent-role authority |
 | [Capability-Registry Tree Pilot Receipt](../../../../legacy/receipts/2026-05-04-capability-registry-tree-pilot.md) | preserves the eighth accepted path migration from broad `docs/` into `techniques/instruction/capability-registry/` | active technique provenance, `tree_path` frontmatter, registry product doctrine, discovery ranking, trust policy, graph semantics, runtime resolution, skill acceptance, or agent-role authority |
+| [Landed Capability-Registry Pilot Review](reviews/landed-capability-registry-pilot-review.md) | confirms the eighth migrated shelf stayed clearer, validates the third instruction trunk shelf, and chooses `capability-boundary` for the next direct-read review | movement of `capability-boundary`, `tree_path` frontmatter, skill marketplace curation, upstream health validation, routing policy, KAG graph semantics, runtime execution doctrine, host inventory policy, or agent-role authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -250,5 +253,9 @@ The eighth pilot migration is now landed: those three bundles live under
 and root legacy receipt are in place, authored links were repaired, generated
 surfaces were rebuilt, and frontmatter stayed unchanged.
 
-The next move is a landed `capability-registry` pilot review before any other
-shelf moves.
+The landed `capability-registry` pilot review is now landed as
+`pilot-validated` and chooses `capability-boundary` for the next direct-read
+migration review.
+
+The next move is a direct-read migration review for `capability-boundary`
+before any other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -27,5 +27,6 @@ Current reviews:
 - [docs-boundary-direct-read-migration-review](docs-boundary-direct-read-migration-review.md)
 - [landed-docs-boundary-pilot-review](landed-docs-boundary-pilot-review.md)
 - [capability-registry-direct-read-migration-review](capability-registry-direct-read-migration-review.md)
+- [landed-capability-registry-pilot-review](landed-capability-registry-pilot-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md
@@ -1,0 +1,175 @@
+# Landed Capability-Registry Pilot Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Migration review:
+[Capability-Registry Direct-Read Migration Review](capability-registry-direct-read-migration-review.md)
+
+Migration receipt:
+[Capability-Registry Tree Pilot Receipt](../../../../../legacy/receipts/2026-05-04-capability-registry-tree-pilot.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: pilot-validated, choose `capability-boundary` for direct-read migration
+review, not path migration, not `tree_path` frontmatter.
+
+## Verdict
+
+Accept the landed `capability-registry` pilot as a successful eighth tree
+migration and the third successful shelf under the `instruction` trunk.
+
+The shelf stayed legible after landing. Three docs-domain techniques now sit
+under one capability-registry neighborhood, while IDs, `domain`, `kind`,
+status, evidence, notes, examples, checks, relations, and public-safety posture
+stayed unchanged. The move improved browsing without turning capability specs,
+registry-facing entries, and bounded lookup into registry product doctrine,
+discovery ranking, trust policy, marketplace curation, graph semantics,
+runtime resolution, skill acceptance, or agent-role authority.
+
+This review does not move another shelf. It confirms that the next honest tree
+slice should run a direct-read review for `capability-boundary`, because the
+instruction trunk has now held instruction surfaces, document boundaries, and a
+capability registry chain. The next pressure should test whether skill-command
+ownership, primary input provenance, and recommendation-vs-host-actionability
+form one bounded capability-boundary shelf without importing marketplace
+curation, upstream-health validation, routing policy, KAG graph semantics, or
+runtime execution doctrine.
+
+## Sources Read
+
+- [AOA-T-0025 capability-spec-versioning](../../../../../techniques/instruction/capability-registry/capability-spec-versioning/TECHNIQUE.md)
+- [AOA-T-0063 versioned-agent-registry-contract](../../../../../techniques/instruction/capability-registry/versioned-agent-registry-contract/TECHNIQUE.md)
+- [AOA-T-0064 capability-discovery](../../../../../techniques/instruction/capability-registry/capability-discovery/TECHNIQUE.md)
+- [AOA-T-0040 skill-vs-command-boundary](../../../../../techniques/docs/skill-vs-command-boundary/TECHNIQUE.md)
+- [AOA-T-0043 multi-source-primary-input-provenance](../../../../../techniques/docs/multi-source-primary-input-provenance/TECHNIQUE.md)
+- [AOA-T-0093 recommendation-truth-vs-host-actionability](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md)
+- [AOA-T-0041 skill-marketplace-curation](../../../../../techniques/docs/skill-marketplace-curation/TECHNIQUE.md)
+- [AOA-T-0042 upstream-skill-health-checking](../../../../../techniques/evaluation/upstream-skill-health-checking/TECHNIQUE.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- [Docs route card](../../../../../techniques/docs/AGENTS.md)
+- [Root legacy index](../../../../../legacy/INDEX.md)
+- [Capability-registry tree pilot receipt](../../../../../legacy/receipts/2026-05-04-capability-registry-tree-pilot.md)
+- [Technique tree projection rows for `capability-registry`,
+  `capability-boundary`, and `skill-discovery`](../../../../../reports/technique_tree_projection.md)
+- [Landed docs-boundary pilot review](landed-docs-boundary-pilot-review.md)
+- `python scripts/release_check.py` result recorded in the migration receipt
+
+## Landed Shape Read
+
+| check | result | reading |
+|---|---|---|
+| current path | `techniques/instruction/capability-registry/` | the active path now matches the projected trunk and shelf |
+| frontmatter truth | unchanged | all three leaves keep `domain: docs`; `kind` remains `artifact` or `discovery` as authored |
+| route card | present | `techniques/instruction/AGENTS.md` now names `instruction-surface/`, `docs-boundary/`, and `capability-registry/` without becoming registry doctrine |
+| root legacy | receipt only | active bundles moved directly between authored homes; `legacy/` preserves accounting |
+| generated surfaces | rebuilt | catalogs, capsules, manifests, reports, source-owned KAG exports, and reader surfaces point at current paths |
+| mechanics links | repaired | Distillation, Audit, and incoming active references route to current authored paths; legacy raw links remain historical receipts |
+| validation | green | release check covered unit tests, nested AGENTS coverage, repository parity, and regenerated surfaces |
+
+## What The Eighth Pilot Proved
+
+- `instruction/` can hold a capability-facing shelf without becoming a
+  capability registry, skill marketplace, or agent-role policy surface.
+- A shelf can mix `artifact` and `discovery` when the shared browsing question
+  is a capability surface chain rather than one move kind.
+- Broad `docs/` can shrink again while moved leaves still keep `domain: docs`
+  as their frontmatter truth.
+- The three leaves stay distinct after moving: capability contract,
+  registry-facing entry, and lookup contract did not collapse into one
+  framework bundle.
+- Route-card economy still works. The useful bridge is a compact local shelf
+  statement, not a heavy law block repeated through every moved bundle.
+- Standalone portability is stronger after the move: external builders can
+  reuse one capability-registry technique without deploying OS Abyss or
+  accepting AoA registry, routing, or runtime doctrine.
+
+## Remaining Weaknesses
+
+- The generated projection still labels landed shelves with candidate-style
+  statuses. That remains tolerable while projection status is non-authoritative,
+  but later generated status language may need a separate review if it starts
+  confusing readers.
+- `instruction/` now has three landed shelves, but it is not a complete
+  instruction taxonomy.
+- `capability-boundary` is cross-domain: it mixes docs-domain boundary
+  guardrails with one agent-workflow guardrail about local host actionability.
+  That makes it interesting, but it requires direct reading before any path
+  move.
+- `skill-discovery` still carries marketplace curation and upstream-health
+  pressure. It may become a clean shelf, but it should wait behind the
+  capability-boundary read.
+- Proof, governance, runtime, and owner-closeout shelves still test stronger
+  authority surfaces than this instruction-side progression should take next.
+
+## Ninth Shelf Choice
+
+Choose `capability-boundary` for the next direct-read migration review.
+
+Projected shelf:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0040` | `techniques/docs/skill-vs-command-boundary/` | `techniques/instruction/capability-boundary/skill-vs-command-boundary/` |
+| `AOA-T-0043` | `techniques/docs/multi-source-primary-input-provenance/` | `techniques/instruction/capability-boundary/multi-source-primary-input-provenance/` |
+| `AOA-T-0093` | `techniques/agent-workflows/recommendation-truth-vs-host-actionability/` | `techniques/instruction/capability-boundary/recommendation-truth-vs-host-actionability/` |
+
+Reason:
+
+`capability-boundary` is the cleanest next review target because it checks the
+boundary around capability meaning after the capability-registry chain has
+landed. `AOA-T-0040` separates reusable skill capability from command
+invocation. `AOA-T-0043` keeps primary and supporting source inputs visible
+before downstream synthesis or selection depends on them. `AOA-T-0093` keeps
+semantic recommendation truth separate from what the current host can actually
+execute. Together they ask one useful question: when a capability-like object
+is named, sourced, recommended, or invoked, what boundary keeps it honest?
+
+Why direct-read first:
+
+The generated projection marks all three rows as `boundary-watch`, and that is
+right. The shelf crosses `docs` and `agent-workflows`, touches host
+actionability, and sits next to skill discovery, upstream health, routing,
+runtime execution, and KAG/source provenance. A direct-read review must decide
+whether the shared boundary is real enough before any path migration.
+
+Why not `skill-discovery` first:
+
+`skill-discovery` is smaller, but it mixes editorial marketplace curation with
+upstream source-readiness validation. That is a good later read after the
+capability-boundary review clarifies what belongs to capability meaning,
+recommendation truth, and host actionability.
+
+Why not proof, governance, runtime, or owner-closeout shelves first:
+
+Those shelves test stronger authority surfaces. The tree should finish this
+instruction-side capability-boundary review before taking on proof,
+governance, runtime, or closeout semantics.
+
+## Stop Lines
+
+- Do not move `capability-boundary` from this review alone.
+- Do not add `tree_path`, `family`, or scout topology axes to frontmatter.
+- Do not move `skill-discovery`, proof, governance, runtime, owner-closeout, or
+  other capability-adjacent shelves in the same wave.
+- Do not treat `capability-boundary` as skill marketplace curation, upstream
+  health validation, routing policy, KAG graph semantics, runtime execution
+  doctrine, host inventory policy, or agent-role authority.
+- Do not collapse skill-command ownership, primary input provenance, and
+  recommendation-vs-host-actionability into one mega-technique.
+- Keep authored bundle markdown and frontmatter stronger than generated
+  projection rows.
+
+## Next Honest Move
+
+Run a direct-read migration review for `capability-boundary`.
+
+Read `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093`; inspect their skill-command
+ownership, primary-input provenance, recommendation/actionability boundary,
+route-card needs, owner-authority stop-lines, and whether
+`techniques/instruction/capability-boundary/` is clearer than their current
+paths before any move.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -107,6 +107,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/docs-boundary-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1212,7 +1213,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
@@ -1380,7 +1381,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
@@ -1460,7 +1461,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
@@ -1551,7 +1552,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
@@ -1636,7 +1637,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
@@ -1733,7 +1734,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
@@ -1818,7 +1819,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
@@ -1856,7 +1857,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1956,7 +1957,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed kag-source-lift pilot review", landing_log)
         self.assertIn("selected\n  `docs-boundary`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
@@ -2035,7 +2036,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `docs-boundary` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0002`, `AOA-T-0009", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Docs-Boundary Direct-Read Migration Review", tree_contract)
@@ -2091,7 +2092,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md", landing_log)
         self.assertIn("seventh landed pilot moved `AOA-T-0002`", root_roadmap)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("2026-05-04-docs-boundary-tree-pilot.md", tree_contract)
@@ -2201,7 +2202,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("second successful instruction trunk shelf", landing_log)
         self.assertIn("selected\n  `capability-registry`", changelog)
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Docs-Boundary Pilot Review", tree_contract)
@@ -2285,7 +2286,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn(
-            "Review the landed `capability-registry` pilot before moving any other shelf",
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Capability-Registry Direct-Read Migration Review", tree_contract)
@@ -2307,6 +2308,113 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
                 / "techniques"
                 / "docs"
                 / "capability-spec-versioning"
+            ).exists()
+        )
+
+    def test_landed_capability_registry_pilot_review_selects_capability_boundary(
+        self,
+    ) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "landed-capability-registry-pilot-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Landed Capability-Registry Pilot Review", review)
+        self.assertIn("pilot-validated", review)
+        self.assertIn("choose `capability-boundary`", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("third successful shelf under the `instruction` trunk", review)
+        self.assertIn("What The Eighth Pilot Proved", review)
+        self.assertIn("Ninth Shelf Choice", review)
+        for technique_id in ("AOA-T-0040", "AOA-T-0043", "AOA-T-0093"):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("Projected shelf", review)
+        self.assertIn("techniques/instruction/capability-boundary/", review)
+        self.assertIn("Why direct-read first", review)
+        self.assertIn(
+            "Do not move `capability-boundary` from this review alone",
+            review,
+        )
+        self.assertIn("Do not add `tree_path`", review)
+        self.assertIn("Run a direct-read migration review for `capability-boundary`", review)
+
+        self.assertIn("landed-capability-registry-pilot-review", reviews_index)
+        self.assertIn("landed capability-registry pilot review: landed", ingress)
+        self.assertIn("capability-boundary", ingress)
+        self.assertIn("direct-read migration review", ingress)
+        self.assertIn("capability-boundary` for the next direct-read", distillation_roadmap)
+        self.assertIn("bounded step is a direct-read migration review", distillation_roadmap)
+        self.assertIn("Landed capability-registry pilot review", landing_log)
+        self.assertIn("third successful instruction trunk shelf", landing_log)
+        self.assertIn(
+            "accepted the landed `capability-registry` pilot review",
+            changelog,
+        )
+        self.assertIn(
+            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            root_roadmap,
+        )
+        self.assertIn("Landed Capability-Registry Pilot Review", tree_contract)
+        self.assertIn("capability-boundary", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "docs"
+                / "skill-vs-command-boundary"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "agent-workflows"
+                / "recommendation-truth-vs-host-actionability"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "instruction"
+                / "capability-boundary"
             ).exists()
         )
 


### PR DESCRIPTION
## Summary

- add the landed capability-registry pilot review
- accept capability-registry as the third successful instruction shelf after the migration
- choose capability-boundary for the next direct-read migration review without moving another shelf

## Validation

- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/release_check.py
- git diff --check
- python scripts/validate_semantic_agents.py
- public-share diff scan: no findings