### PR TITLE
Accept capability-boundary migration review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ The format is intentionally simple and human-first.
 - accepted the landed `capability-registry` pilot review and selected
   `capability-boundary` for the next direct-read migration review without
   moving a ninth shelf yet
+- accepted the `capability-boundary` direct-read migration review over
+  `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` as the ninth tree pilot while
+  keeping the review itself non-mutating
 
 ### Validation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`, and the eighth landed pilot moved `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into `techniques/instruction/capability-registry/`; all eight kept frontmatter unchanged, and the landed `capability-registry` pilot review now chooses `capability-boundary` for the next direct-read review. |
-| Next honest move | Run a direct-read migration review for `capability-boundary` before moving any other shelf. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` names the future root tree as trunks, shelves, and leaf bundles; `reports/technique_tree_projection.md` gives a non-authoritative full-corpus placement projection; the first landed pilot moved `AOA-T-0051`, `AOA-T-0052`, and `AOA-T-0054` into `techniques/continuity/review-compaction/`, the second landed pilot moved `AOA-T-0056` through `AOA-T-0062` into `techniques/continuity/handoff-continuation/`, the third landed pilot, the first non-continuity migrated shelf, moved `AOA-T-0070` through `AOA-T-0074` into `techniques/ingest/media-ingest/`, the fourth landed pilot moved `AOA-T-0080` through `AOA-T-0083` into `techniques/recovery/diagnosis-repair/`, the fifth landed pilot moved `AOA-T-0012`, `AOA-T-0013`, `AOA-T-0024`, `AOA-T-0027`, `AOA-T-0029`, `AOA-T-0030`, and `AOA-T-0035` into `techniques/instruction/instruction-surface/`, the sixth landed pilot moved `AOA-T-0018`, `AOA-T-0019`, `AOA-T-0020`, `AOA-T-0021`, `AOA-T-0022`, `AOA-T-0046`, `AOA-T-0047`, and `AOA-T-0048` into `techniques/knowledge-lift/kag-source-lift/`, the seventh landed pilot moved `AOA-T-0002`, `AOA-T-0009`, `AOA-T-0034`, and `AOA-T-0033` into `techniques/instruction/docs-boundary/`, and the eighth landed pilot moved `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` into `techniques/instruction/capability-registry/`; all eight kept frontmatter unchanged, and the `capability-boundary` direct-read review now accepts `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` as the ninth migration pilot without moving files. |
+| Next honest move | Run the ninth pilot migration for `capability-boundary` before moving any other shelf. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 ## Horizon: Small-Agent Usability
@@ -187,8 +187,8 @@ trigger is real.
 - Use the landed `review-compaction`, `handoff-continuation`, `media-ingest`,
   `diagnosis-repair`, `instruction-surface`, `kag-source-lift`,
   `docs-boundary`, and `capability-registry` pilots as precedents, and run the
-  accepted `capability-boundary` direct-read review before any broader corpus
-  move.
+  `capability-boundary` pilot migration accepted by the direct-read review
+  before any broader corpus move.
 - Add generated projections for `capability_class`, `substrate`,
   `execution_profile`, and `risk_posture` from
   `config/technique_topology_axes.yaml` only after mechanics candidates prove

--- a/docs/TECHNIQUE_TREE_CONTRACT.md
+++ b/docs/TECHNIQUE_TREE_CONTRACT.md
@@ -297,8 +297,15 @@ It validates `capability-registry` as the third successful instruction trunk
 shelf and chooses `capability-boundary` for the next direct-read migration
 review.
 
-The next reform slice should run the `capability-boundary` direct-read review
-before moving another shelf.
+The ninth migration review is
+[Capability-Boundary Direct-Read Migration Review](../mechanics/distillation/parts/technique-reform-ingress/reviews/capability-boundary-direct-read-migration-review.md).
+It accepts `capability-boundary` as the ninth migration pilot after directly
+reading `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093`.
+
+The next reform slice should run the ninth pilot migration by moving exactly
+`AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` into
+`techniques/instruction/capability-boundary/` without changing `domain`,
+`kind`, or `tree_path` frontmatter.
 
 This keeps the future tree beautiful enough to grow while preserving current
 bundle truth.

--- a/mechanics/distillation/LANDING_LOG.md
+++ b/mechanics/distillation/LANDING_LOG.md
@@ -3,6 +3,39 @@
 This log records structural landings for the `aoa-techniques` Distillation
 mechanic.
 
+## 2026-05-04 - Capability-boundary direct-read migration review
+
+Changed:
+
+- added
+  [capability-boundary-direct-read-migration-review](parts/technique-reform-ingress/reviews/capability-boundary-direct-read-migration-review.md)
+  as the direct-read review over `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093`
+- accepted `capability-boundary` as the ninth bounded migration pilot because
+  direct reading confirmed the shared capability-boundary guardrail cluster
+- kept the review non-mutating: no technique bundle moved, no frontmatter
+  changed, and no generated projection became authority
+- kept `skill-discovery`, proof, governance, runtime, owner-closeout,
+  automation-governance, and other capability-adjacent shelves outside the
+  migration wave
+- kept marketplace curation, upstream health validation, routing policy,
+  recommendation ranking, KAG graph semantics, runtime execution doctrine,
+  host inventory policy, command product design, shell doctrine, registry
+  product doctrine, and agent-role authority outside `capability-boundary`
+
+Verification lane:
+
+```bash
+python -m unittest tests.test_distillation_mechanics_topology
+python scripts/validate_repo.py
+python scripts/release_check.py
+```
+
+Not moved:
+
+- no technique bundle was moved
+- no frontmatter changed
+- no ninth shelf migration happened from the review alone
+
 ## 2026-05-04 - Landed capability-registry pilot review
 
 Changed:

--- a/mechanics/distillation/ROADMAP.md
+++ b/mechanics/distillation/ROADMAP.md
@@ -110,9 +110,15 @@
    link repair, generated rebuilds, and release-check validation in the same
    wave. The landed `capability-registry` pilot review is also landed as
    `pilot-validated`, validates the third instruction trunk shelf, and chooses
-   `capability-boundary` for the next direct-read migration review. The next
-   bounded step is a direct-read migration review for `capability-boundary`
-   before any other shelf moves.
+   `capability-boundary` for the next direct-read migration review. The
+   `capability-boundary` direct-read review is now landed as
+   `accepted-for-ninth-migration-pilot`; it accepts exactly `AOA-T-0040`,
+   `AOA-T-0043`, and `AOA-T-0093` while keeping skill marketplace curation,
+   upstream health validation, routing policy, recommendation ranking, KAG
+   graph semantics, runtime execution doctrine, host inventory policy, command
+   product design, shell doctrine, registry product doctrine, and agent-role
+   authority outside the move. The next bounded step is the ninth pilot
+   migration for `capability-boundary` before any other shelf moves.
 
 ## Hold line
 

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -86,6 +86,8 @@ permission slip to remap techniques automatically.
   `techniques/instruction/capability-registry/` without frontmatter changes
 - landed capability-registry pilot review: landed as `pilot-validated`, with
   `capability-boundary` chosen for the next direct-read migration review
+- capability-boundary direct-read review: landed as
+  `accepted-for-ninth-migration-pilot`; still not path movement
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -127,6 +129,7 @@ permission slip to remap techniques automatically.
 | [Capability-Registry Direct-Read Migration Review](reviews/capability-registry-direct-read-migration-review.md) | reads `AOA-T-0025`, `AOA-T-0063`, and `AOA-T-0064` directly and accepts the shelf as the eighth migration pilot | path movement by review alone, `tree_path` frontmatter, registry product doctrine, discovery ranking, marketplace curation, trust policy, graph semantics, runtime resolution, skill acceptance, or agent-role authority |
 | [Capability-Registry Tree Pilot Receipt](../../../../legacy/receipts/2026-05-04-capability-registry-tree-pilot.md) | preserves the eighth accepted path migration from broad `docs/` into `techniques/instruction/capability-registry/` | active technique provenance, `tree_path` frontmatter, registry product doctrine, discovery ranking, trust policy, graph semantics, runtime resolution, skill acceptance, or agent-role authority |
 | [Landed Capability-Registry Pilot Review](reviews/landed-capability-registry-pilot-review.md) | confirms the eighth migrated shelf stayed clearer, validates the third instruction trunk shelf, and chooses `capability-boundary` for the next direct-read review | movement of `capability-boundary`, `tree_path` frontmatter, skill marketplace curation, upstream health validation, routing policy, KAG graph semantics, runtime execution doctrine, host inventory policy, or agent-role authority |
+| [Capability-Boundary Direct-Read Migration Review](reviews/capability-boundary-direct-read-migration-review.md) | reads `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` directly and accepts the shelf as the ninth migration pilot | path movement by review alone, `tree_path` frontmatter, skill marketplace curation, upstream health validation, routing policy, recommendation ranking, KAG graph semantics, runtime execution doctrine, host inventory policy, command product design, shell doctrine, registry product doctrine, or agent-role authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -257,5 +260,8 @@ The landed `capability-registry` pilot review is now landed as
 `pilot-validated` and chooses `capability-boundary` for the next direct-read
 migration review.
 
-The next move is a direct-read migration review for `capability-boundary`
-before any other shelf moves.
+The `capability-boundary` direct-read review is now landed and accepts exactly
+`AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` as the ninth migration pilot.
+
+The next move is the ninth pilot migration for `capability-boundary` before
+any other shelf moves.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -28,5 +28,6 @@ Current reviews:
 - [landed-docs-boundary-pilot-review](landed-docs-boundary-pilot-review.md)
 - [capability-registry-direct-read-migration-review](capability-registry-direct-read-migration-review.md)
 - [landed-capability-registry-pilot-review](landed-capability-registry-pilot-review.md)
+- [capability-boundary-direct-read-migration-review](capability-boundary-direct-read-migration-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/capability-boundary-direct-read-migration-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/capability-boundary-direct-read-migration-review.md
@@ -1,0 +1,207 @@
+# Capability-Boundary Direct-Read Migration Review
+
+Source packet:
+[Technique Reform Ingress](../README.md)
+
+Preceding landed review:
+[Landed Capability-Registry Pilot Review](landed-capability-registry-pilot-review.md)
+
+Generated lens:
+[Technique Tree Projection](../../../../../reports/technique_tree_projection.md)
+
+Tree contract:
+[Technique Tree Contract](../../../../../docs/TECHNIQUE_TREE_CONTRACT.md)
+
+Status: accepted-for-ninth-migration-pilot, not path migration, not
+`tree_path` frontmatter.
+
+## Verdict
+
+Accept `capability-boundary` as the ninth bounded tree migration pilot.
+
+Direct reading confirms that `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093`
+form one browseable instruction-side shelf: each leaf prevents a
+capability-like object from gaining false authority at a boundary. One
+separates reusable skill meaning from command invocation, one keeps primary
+source input visible before bridge use, and one separates semantic
+recommendation truth from current host actionability.
+
+The shelf is cross-domain today, but the move tests the tree contract rather
+than frontmatter ownership. `domain: docs` and `domain: agent-workflows` remain
+true for their current review lanes. The proposed path answers a browsing
+question: where should a reader find compact guardrails that keep capability
+meaning, source priority, recommendation truth, and executable action from
+collapsing into each other?
+
+This review does not move files. It only authorizes a later migration wave to
+move exactly these three bundles into
+`techniques/instruction/capability-boundary/` if that wave also updates route
+cards, root legacy receipts, authored links, generated surfaces, and
+validation.
+
+## Sources Read
+
+- [AOA-T-0040 skill-vs-command-boundary](../../../../../techniques/docs/skill-vs-command-boundary/TECHNIQUE.md)
+- [AOA-T-0040 checklist](../../../../../techniques/docs/skill-vs-command-boundary/checks/skill-vs-command-boundary-checklist.md)
+- [AOA-T-0040 minimal example](../../../../../techniques/docs/skill-vs-command-boundary/examples/minimal-skill-vs-command-boundary.md)
+- [AOA-T-0040 evidence notes](../../../../../techniques/docs/skill-vs-command-boundary/notes/canonical-readiness.md)
+- [AOA-T-0043 multi-source-primary-input-provenance](../../../../../techniques/docs/multi-source-primary-input-provenance/TECHNIQUE.md)
+- [AOA-T-0043 checklist](../../../../../techniques/docs/multi-source-primary-input-provenance/checks/multi-source-primary-input-provenance-checklist.md)
+- [AOA-T-0043 minimal example](../../../../../techniques/docs/multi-source-primary-input-provenance/examples/minimal-multi-source-primary-input-provenance.md)
+- [AOA-T-0043 evidence notes](../../../../../techniques/docs/multi-source-primary-input-provenance/notes/canonical-readiness.md)
+- [AOA-T-0093 recommendation-truth-vs-host-actionability](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/TECHNIQUE.md)
+- [AOA-T-0093 checklist](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/checks/recommendation-truth-vs-host-actionability-checklist.md)
+- [AOA-T-0093 minimal example](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/examples/minimal-recommendation-truth-vs-host-actionability.md)
+- [AOA-T-0093 evidence notes](../../../../../techniques/agent-workflows/recommendation-truth-vs-host-actionability/notes/canonical-readiness.md)
+- [Docs route card](../../../../../techniques/docs/AGENTS.md)
+- [Agent-workflows route card](../../../../../techniques/agent-workflows/AGENTS.md)
+- [Instruction route card](../../../../../techniques/instruction/AGENTS.md)
+- [AOA-T-0041 skill-marketplace-curation](../../../../../techniques/docs/skill-marketplace-curation/TECHNIQUE.md)
+- [AOA-T-0042 upstream-skill-health-checking](../../../../../techniques/evaluation/upstream-skill-health-checking/TECHNIQUE.md)
+- [Technique family scout rows for `capability-boundary` and
+  `skill-discovery`](../../../../../reports/technique_family_scout.md)
+- [Technique topology scout rows for `capability-boundary`](../../../../../reports/technique_topology_scout.md)
+- [Technique tree projection rows for `capability-boundary` and
+  `skill-discovery`](../../../../../reports/technique_tree_projection.md)
+- [Landed capability-registry pilot review](landed-capability-registry-pilot-review.md)
+
+## Direct Bundle Read
+
+| technique | current path | domain | kind | direct-read result |
+|---|---|---|---|---|
+| `AOA-T-0040` | `techniques/docs/skill-vs-command-boundary/` | `docs` | `guardrail` | keeps reusable skill capability separate from command invocation, arguments, output shape, routing, marketplace, and shell doctrine |
+| `AOA-T-0043` | `techniques/docs/multi-source-primary-input-provenance/` | `docs` | `guardrail` | keeps one primary source input visible against supporting inputs without becoming graph traversal, ranking, relation semantics, or bridge architecture |
+| `AOA-T-0093` | `techniques/agent-workflows/recommendation-truth-vs-host-actionability/` | `agent-workflows` | `guardrail` | keeps router recommendation truth visible while host-executable action stays separately annotated and bounded |
+
+All three are promoted guardrails with source-backed evidence. That matters:
+this shelf is not mixing move kinds. It is mixing owner lanes around one
+capability-boundary question.
+
+## Why The Shelf Holds
+
+- `AOA-T-0040` protects the boundary between reusable capability meaning and
+  user-facing invocation.
+- `AOA-T-0043` protects the boundary between primary source authority and
+  supporting context before a downstream bridge, summary, or selector depends
+  on the combined surface.
+- `AOA-T-0093` protects the boundary between semantic recommendation and what
+  the current host can actually execute.
+- The examples all keep the boundary visible in compact artifacts rather than
+  hiding it in generated metadata or local runtime assumptions.
+- The checklists all reject neighboring authority: routing policy,
+  marketplace curation, graph semantics, registry doctrine, upstream-health
+  validation, and runtime execution law.
+- The canonical-readiness notes keep all three bundles promoted, not
+  canonical, which fits a migration pilot: path clarity can improve without
+  claiming default-use status.
+
+## Instruction Trunk Fit
+
+`instruction/` is the better trunk because the shelf shapes the instruction
+surfaces that tell an agent or human what a capability-like object means and
+what it does not authorize.
+
+This does not turn the three leaves into prompt doctrine. The path is useful
+because it gathers boundary guardrails around capability meaning:
+
+- skill artifacts can be reused without becoming command wrappers
+- primary source inputs can stay visible before synthesis or selection
+- recommendation reports can preserve relevance without pretending unavailable
+  actions are runnable
+
+Keeping `AOA-T-0093` in `agent-workflows` was reasonable before the tree
+started landing, because its procedure is a control-plane workflow guardrail.
+Moving it under `instruction/capability-boundary/` would be a path-architecture
+choice only: it should keep `domain: agent-workflows`, `kind: guardrail`,
+status, ID, relations, and evidence unchanged.
+
+## Boundary Watch Accepted
+
+The generated projection was right to mark this shelf `boundary-watch`.
+Capability boundary language is easy to overgrow. Direct reading accepts the
+shelf only because all three leaves repeatedly refuse adjacent authority:
+
+- no skill marketplace curation
+- no upstream health validation
+- no routing policy or recommendation ranking
+- no KAG graph semantics or bridge architecture doctrine
+- no runtime execution doctrine or host inventory policy
+- no registry product doctrine or capability-spec ownership
+- no command product design, shell-command doctrine, or agent-role authority
+
+That makes the shelf viable, but it also makes the later migration stop-lines
+important.
+
+## Proposed Move
+
+Move exactly these three bundles in the migration wave:
+
+| technique | current path | proposed path |
+|---|---|---|
+| `AOA-T-0040` | `techniques/docs/skill-vs-command-boundary/` | `techniques/instruction/capability-boundary/skill-vs-command-boundary/` |
+| `AOA-T-0043` | `techniques/docs/multi-source-primary-input-provenance/` | `techniques/instruction/capability-boundary/multi-source-primary-input-provenance/` |
+| `AOA-T-0093` | `techniques/agent-workflows/recommendation-truth-vs-host-actionability/` | `techniques/instruction/capability-boundary/recommendation-truth-vs-host-actionability/` |
+
+Keep `domain`, `kind`, status, IDs, evidence, relations, and public-safety
+posture unchanged.
+
+## Migration Blast Radius
+
+A later migration wave should expect to update:
+
+- authored links from `AOA-T-0093` to its evaluation, capability-discovery,
+  and agent-workflow siblings
+- authored links into `AOA-T-0040` and `AOA-T-0043` from selection, handoff,
+  proof, and KAG-derived reader surfaces
+- `techniques/instruction/AGENTS.md` current scope and domain rules, because
+  `instruction/` would gain a fourth landed shelf
+- root `legacy/receipts/` and `legacy/INDEX.md` accounting for the authored
+  path migration
+- generated catalogs, capsules, manifests, reports, KAG exports, docs readers,
+  and source-lift surfaces after the path move
+- active mechanics review rows that still point to old homes
+- release-check output touched by regenerated indexes and reports
+
+Do not create mechanic-style `parts/` packages or shelf READMEs for these
+technique leaves.
+
+## Why Not Neighbor Shelves In This Wave
+
+`skill-discovery` should wait. Direct reading confirms that
+`AOA-T-0041` is editorial marketplace curation and `AOA-T-0042` is upstream
+source-readiness validation. They are near this shelf, but they answer what can
+be discovered or surfaced, not where capability meaning and actionability stop.
+
+Proof, governance, runtime, owner-closeout, and automation-governance shelves
+should also wait. They carry stronger verdict, approval, execution, or owner
+truth pressure than this instruction-side boundary pilot needs.
+
+## Stop Lines
+
+- Do not move files from this review pack alone.
+- Do not add `tree_path`, `family`, capability, substrate, execution-profile,
+  or risk frontmatter.
+- Do not move `skill-discovery`, proof, governance, runtime, owner-closeout,
+  automation-governance, or other capability-adjacent shelves in the same wave.
+- Do not turn `capability-boundary` into skill marketplace curation, upstream
+  health validation, routing policy, recommendation ranking, KAG graph
+  semantics, bridge architecture doctrine, runtime execution doctrine, host
+  inventory policy, command product design, shell doctrine, registry product
+  doctrine, or agent-role authority.
+- Do not collapse the three leaves into one mega-technique; the shelf holds
+  because skill-command ownership, source-input priority, and
+  recommendation-actionability stay distinct.
+- Do not change canonical/promoted status, maturity, evidence, or
+  public-safety posture during the path migration.
+- Keep generated projection weaker than authored bundle meaning.
+
+## Next Honest Move
+
+Run the ninth pilot migration.
+
+Move exactly `AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093` into
+`techniques/instruction/capability-boundary/`; add the compact
+`capability-boundary/` shelf scope to `techniques/instruction/AGENTS.md`;
+preserve a root `legacy/receipts/` migration receipt; repair authored links;
+rebuild generated surfaces; and validate with the narrow tree-pilot tests plus
+`python scripts/release_check.py`.

--- a/tests/test_distillation_mechanics_topology.py
+++ b/tests/test_distillation_mechanics_topology.py
@@ -108,6 +108,7 @@ PART_LOCAL_TECHNIQUE_REFORM_INGRESS_ARTIFACTS = (
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-docs-boundary-pilot-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/capability-registry-direct-read-migration-review.md",
     "mechanics/distillation/parts/technique-reform-ingress/reviews/landed-capability-registry-pilot-review.md",
+    "mechanics/distillation/parts/technique-reform-ingress/reviews/capability-boundary-direct-read-migration-review.md",
 )
 
 OLD_FLAT_DISTILLATION_FILES = (
@@ -1213,7 +1214,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed handoff-continuation pilot review", landing_log)
         self.assertIn("selected\n  `media-ingest`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Handoff-Continuation Pilot Review", tree_contract)
@@ -1381,7 +1382,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed media-ingest pilot review", landing_log)
         self.assertIn("selected\n  `diagnosis-repair`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Media-Ingest Pilot Review", tree_contract)
@@ -1461,7 +1462,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("moved `AOA-T-0080` through `AOA-T-0083`", changelog)
         self.assertIn("fourth landed pilot", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Diagnosis-Repair Direct-Read Migration Review", tree_contract)
@@ -1552,7 +1553,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed diagnosis-repair pilot review", landing_log)
         self.assertIn("selected\n  `instruction-surface`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Diagnosis-Repair Pilot Review", tree_contract)
@@ -1637,7 +1638,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         )
         self.assertIn("moved `AOA-T-0012`, `AOA-T-0013", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Instruction-Surface Direct-Read Migration Review", tree_contract)
@@ -1734,7 +1735,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed instruction-surface pilot review", landing_log)
         self.assertIn("selected\n  `kag-source-lift`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Instruction-Surface Pilot Review", tree_contract)
@@ -1819,7 +1820,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `kag-source-lift` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0018`, `AOA-T-0019", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Kag-Source-Lift Direct-Read Migration Review", tree_contract)
@@ -1857,7 +1858,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-kag-source-lift-tree-pilot.md", landing_log)
         self.assertIn("sixth landed pilot moved `AOA-T-0018`", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("2026-05-04-kag-source-lift-tree-pilot.md", tree_contract)
@@ -1957,7 +1958,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("Landed kag-source-lift pilot review", landing_log)
         self.assertIn("selected\n  `docs-boundary`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Kag-Source-Lift Pilot Review", tree_contract)
@@ -2036,7 +2037,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("accepted the `docs-boundary` direct-read migration review", changelog)
         self.assertIn("moved `AOA-T-0002`, `AOA-T-0009", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Docs-Boundary Direct-Read Migration Review", tree_contract)
@@ -2092,7 +2093,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("legacy/receipts/2026-05-04-docs-boundary-tree-pilot.md", landing_log)
         self.assertIn("seventh landed pilot moved `AOA-T-0002`", root_roadmap)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("2026-05-04-docs-boundary-tree-pilot.md", tree_contract)
@@ -2202,7 +2203,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("second successful instruction trunk shelf", landing_log)
         self.assertIn("selected\n  `capability-registry`", changelog)
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Docs-Boundary Pilot Review", tree_contract)
@@ -2286,7 +2287,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Capability-Registry Direct-Read Migration Review", tree_contract)
@@ -2378,7 +2379,7 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn("capability-boundary", ingress)
         self.assertIn("direct-read migration review", ingress)
         self.assertIn("capability-boundary` for the next direct-read", distillation_roadmap)
-        self.assertIn("bounded step is a direct-read migration review", distillation_roadmap)
+        self.assertIn("ninth pilot\n   migration for `capability-boundary`", distillation_roadmap)
         self.assertIn("Landed capability-registry pilot review", landing_log)
         self.assertIn("third successful instruction trunk shelf", landing_log)
         self.assertIn(
@@ -2386,11 +2387,117 @@ class DistillationMechanicsTopologyTestCase(unittest.TestCase):
             changelog,
         )
         self.assertIn(
-            "Run a direct-read migration review for `capability-boundary` before moving any other shelf",
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
             root_roadmap,
         )
         self.assertIn("Landed Capability-Registry Pilot Review", tree_contract)
         self.assertIn("capability-boundary", tree_contract)
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "docs"
+                / "skill-vs-command-boundary"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "agent-workflows"
+                / "recommendation-truth-vs-host-actionability"
+                / "TECHNIQUE.md"
+            ).is_file()
+        )
+        self.assertFalse(
+            (
+                REPO_ROOT
+                / "techniques"
+                / "instruction"
+                / "capability-boundary"
+            ).exists()
+        )
+
+    def test_capability_boundary_direct_read_review_accepts_ninth_pilot(
+        self,
+    ) -> None:
+        ingress = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        reviews_index = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "capability-boundary-direct-read-migration-review.md"
+        ).read_text(encoding="utf-8")
+        distillation_roadmap = (
+            REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md"
+        ).read_text(encoding="utf-8")
+        landing_log = (
+            REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md"
+        ).read_text(encoding="utf-8")
+        root_roadmap = (REPO_ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+        tree_contract = (
+            REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md"
+        ).read_text(encoding="utf-8")
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+        self.assertIn("Capability-Boundary Direct-Read Migration Review", review)
+        self.assertIn("accepted-for-ninth-migration-pilot", review)
+        self.assertIn("not path migration", review)
+        self.assertIn("not\n`tree_path` frontmatter", review)
+        self.assertIn("Accept `capability-boundary` as the ninth", review)
+        self.assertIn("Direct Bundle Read", review)
+        for technique_id in ("AOA-T-0040", "AOA-T-0043", "AOA-T-0093"):
+            with self.subTest(technique_id=technique_id):
+                self.assertIn(technique_id, review)
+
+        self.assertIn("all three are promoted guardrails", review.lower())
+        self.assertIn("Instruction Trunk Fit", review)
+        self.assertIn("Boundary Watch Accepted", review)
+        self.assertIn("Move exactly these three bundles", review)
+        self.assertIn("techniques/instruction/capability-boundary/", review)
+        self.assertIn("skill-discovery` should wait", review)
+        self.assertIn("Do not move files from this review pack alone", review)
+        self.assertIn("Do not add `tree_path`", review)
+        self.assertIn("Do not collapse the three leaves", review)
+        self.assertIn("Run the ninth pilot migration", review)
+
+        self.assertIn("capability-boundary-direct-read-migration-review", reviews_index)
+        self.assertIn("capability-boundary direct-read review: landed", ingress)
+        self.assertIn("accepted-for-ninth-migration-pilot", ingress)
+        self.assertIn("Capability-boundary direct-read migration review", landing_log)
+        self.assertIn("shared capability-boundary guardrail cluster", landing_log)
+        self.assertIn("accepted-for-ninth-migration-pilot", distillation_roadmap)
+        self.assertIn("ninth pilot\n   migration for `capability-boundary`", distillation_roadmap)
+        self.assertIn(
+            "accepted the `capability-boundary` direct-read migration review",
+            changelog,
+        )
+        self.assertIn(
+            "Run the ninth pilot migration for `capability-boundary` before moving any other shelf",
+            root_roadmap,
+        )
+        self.assertIn("Capability-Boundary Direct-Read Migration Review", tree_contract)
+        self.assertIn("AOA-T-0040`, `AOA-T-0043`, and `AOA-T-0093", tree_contract)
         self.assertTrue(
             (
                 REPO_ROOT


### PR DESCRIPTION
## Summary

- add the capability-boundary direct-read migration review
- accept AOA-T-0040, AOA-T-0043, and AOA-T-0093 as the ninth tree pilot scope
- update reform ingress, roadmap, tree contract, landing log, changelog, and topology tests without moving technique bundles

## Validation

- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- git diff --check
- python scripts/validate_semantic_agents.py
- public-share diff scan: no findings