### PR TITLE
Add bundle reform baseline inventory

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -72,5 +72,6 @@ Current reviews:
 - [landed-tool-gateway-pilot-review](landed-tool-gateway-pilot-review.md)
 - [whole-tree-closeout-review](whole-tree-closeout-review.md)
 - [final-tree-migration-ledger](final-tree-migration-ledger.md)
+- [bundle-anatomy-baseline-inventory](bundle-anatomy-baseline-inventory.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-baseline-inventory.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-baseline-inventory.md
@@ -1,0 +1,241 @@
+# Bundle Anatomy Baseline Inventory
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Temporary plan: [Temporary Bundle Reform Rhythm Plan](../TEMP_BUNDLE_REFORM_RHYTHM_PLAN.md)
+
+Final tree ledger: [Final Tree Migration Ledger](final-tree-migration-ledger.md)
+
+Status: baseline-inventory, not repair verdict, not path movement, not frontmatter migration.
+
+## Verdict
+
+Open the post-tree bundle reform pass with a whole-corpus inventory. This packet records the current authored bundle count, generated-reader parity, tree path parity, and first mechanical presence checks for examples, checks, notes, capsules, and projection rows.
+
+This is not yet a human anatomy verdict. Labels ending in `-candidate` are inventory pressure only; each one still needs direct bundle reading before any repair, split, route-away, generated change, or status move.
+
+## Baseline Counts
+
+| check | result |
+|---|---:|
+| authored technique bundles | `107` |
+| generated catalog rows | `107` |
+| generated capsule rows | `107` |
+| generated tree projection rows | `107` |
+| current path equals projected path | `107/107` |
+| bundles with checks files | `107/107` |
+| bundles with examples files | `107/107` |
+| bundles with notes files | `107/107` |
+
+## Status Counts
+
+| status | bundles |
+|---|---:|
+| `canonical` | 25 |
+| `promoted` | 82 |
+
+## Domain Counts
+
+| domain | bundles |
+|---|---:|
+| `agent-workflows` | 57 |
+| `docs` | 28 |
+| `evaluation` | 12 |
+| `history` | 6 |
+| `system-recovery` | 3 |
+| `validation-patterns` | 1 |
+
+## Kind Counts
+
+| kind | bundles |
+|---|---:|
+| `artifact` | 14 |
+| `assessment` | 10 |
+| `composition` | 7 |
+| `discovery` | 2 |
+| `distribution` | 4 |
+| `guardrail` | 13 |
+| `handoff` | 11 |
+| `ingest` | 5 |
+| `lift` | 12 |
+| `recovery` | 6 |
+| `validation` | 10 |
+| `workflow` | 13 |
+
+## Trunk Counts
+
+| trunk | bundles |
+|---|---:|
+| `continuity` | 14 |
+| `execution` | 14 |
+| `governance` | 14 |
+| `history` | 6 |
+| `ingest` | 5 |
+| `instruction` | 19 |
+| `knowledge-lift` | 8 |
+| `proof` | 18 |
+| `recovery` | 8 |
+| `tool-use` | 1 |
+
+## Shelf Counts
+
+| shelf | bundles |
+|---|---:|
+| `continuity/donor-harvest` | 4 |
+| `continuity/handoff-continuation` | 7 |
+| `continuity/review-compaction` | 3 |
+| `execution/agent-workflows-core` | 5 |
+| `execution/intent-chain` | 2 |
+| `execution/ready-work-graphs` | 3 |
+| `execution/runtime-truth-lifecycle` | 4 |
+| `governance/approval-evidence` | 2 |
+| `governance/automation-readiness` | 3 |
+| `governance/decision-routing` | 3 |
+| `governance/practice-adoption-lifecycle` | 3 |
+| `governance/promotion-boundary` | 3 |
+| `history/history-artifacts` | 6 |
+| `ingest/media-ingest` | 5 |
+| `instruction/capability-boundary` | 3 |
+| `instruction/capability-registry` | 3 |
+| `instruction/docs-boundary` | 4 |
+| `instruction/instruction-surface` | 7 |
+| `instruction/skill-discovery` | 2 |
+| `knowledge-lift/kag-source-lift` | 8 |
+| `proof/evaluation-chain` | 3 |
+| `proof/owner-truth-closeout` | 5 |
+| `proof/published-summary` | 4 |
+| `proof/review-evidence` | 3 |
+| `proof/skill-support` | 3 |
+| `recovery/antifragility-recovery` | 4 |
+| `recovery/diagnosis-repair` | 4 |
+| `tool-use/tool-gateway` | 1 |
+
+## Inventory Label Counts
+
+| label | bundles |
+|---|---:|
+| `inventory-pass` | 107 |
+
+## Bundle Rows
+
+| id | path | status | domain | kind | checks | examples | notes | capsule | projection | inventory labels |
+|---|---|---|---|---|---:|---:|---:|---|---|---|
+| `AOA-T-0001` | `techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md` | `canonical` | `agent-workflows` | `workflow` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0002` | `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` | `canonical` | `docs` | `artifact` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0003` | `techniques/proof/evaluation-chain/contract-first-smoke-summary/TECHNIQUE.md` | `canonical` | `evaluation` | `validation` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0004` | `techniques/execution/intent-chain/intent-plan-dry-run-contract-chain/TECHNIQUE.md` | `canonical` | `agent-workflows` | `workflow` | 1 | 2 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0005` | `techniques/execution/intent-chain/new-intent-rollout-checklist/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0006` | `techniques/proof/published-summary/latest-alias-plus-history-copy/TECHNIQUE.md` | `canonical` | `evaluation` | `artifact` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0007` | `techniques/proof/evaluation-chain/signal-first-gate-promotion/TECHNIQUE.md` | `canonical` | `evaluation` | `guardrail` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0008` | `techniques/proof/published-summary/published-summary-remediation-snapshot/TECHNIQUE.md` | `canonical` | `evaluation` | `lift` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0009` | `techniques/instruction/docs-boundary/lightweight-status-snapshot/TECHNIQUE.md` | `canonical` | `docs` | `artifact` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0010` | `techniques/proof/published-summary/telemetry-integrity-snapshot/TECHNIQUE.md` | `canonical` | `evaluation` | `validation` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0011` | `techniques/proof/published-summary/required-vs-optional-source-rendering/TECHNIQUE.md` | `canonical` | `evaluation` | `guardrail` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0012` | `techniques/instruction/instruction-surface/deterministic-context-composition/TECHNIQUE.md` | `canonical` | `docs` | `composition` | 1 | 2 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0013` | `techniques/instruction/instruction-surface/single-source-rule-distribution/TECHNIQUE.md` | `canonical` | `docs` | `distribution` | 1 | 2 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0014` | `techniques/execution/agent-workflows-core/tdd-slice/TECHNIQUE.md` | `canonical` | `agent-workflows` | `workflow` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0015` | `techniques/proof/skill-support/contract-test-design/TECHNIQUE.md` | `canonical` | `evaluation` | `validation` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0016` | `techniques/proof/skill-support/bounded-context-map/TECHNIQUE.md` | `canonical` | `docs` | `artifact` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0017` | `techniques/proof/skill-support/property-invariants/TECHNIQUE.md` | `canonical` | `evaluation` | `validation` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0018` | `techniques/knowledge-lift/kag-source-lift/markdown-technique-section-lift/TECHNIQUE.md` | `canonical` | `docs` | `lift` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0019` | `techniques/knowledge-lift/kag-source-lift/frontmatter-metadata-spine/TECHNIQUE.md` | `canonical` | `docs` | `lift` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0020` | `techniques/knowledge-lift/kag-source-lift/evidence-note-provenance-lift/TECHNIQUE.md` | `promoted` | `docs` | `lift` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0021` | `techniques/knowledge-lift/kag-source-lift/bounded-relation-lift-for-kag/TECHNIQUE.md` | `canonical` | `docs` | `lift` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0022` | `techniques/knowledge-lift/kag-source-lift/risk-and-negative-effect-lift/TECHNIQUE.md` | `promoted` | `docs` | `lift` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0023` | `techniques/execution/agent-workflows-core/stateless-single-shot-agent/TECHNIQUE.md` | `canonical` | `agent-workflows` | `workflow` | 1 | 2 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0024` | `techniques/instruction/instruction-surface/upstream-mirroring-with-provenance/TECHNIQUE.md` | `promoted` | `docs` | `distribution` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0025` | `techniques/instruction/capability-registry/capability-spec-versioning/TECHNIQUE.md` | `promoted` | `docs` | `artifact` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0026` | `techniques/history/history-artifacts/session-capture-as-repo-artifact/TECHNIQUE.md` | `promoted` | `history` | `artifact` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0027` | `techniques/instruction/instruction-surface/cross-agent-skill-propagation/TECHNIQUE.md` | `promoted` | `docs` | `distribution` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0028` | `techniques/execution/agent-workflows-core/confirmation-gated-mutating-action/TECHNIQUE.md` | `canonical` | `agent-workflows` | `guardrail` | 1 | 2 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0029` | `techniques/instruction/instruction-surface/nested-rule-loading/TECHNIQUE.md` | `promoted` | `docs` | `composition` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0030` | `techniques/instruction/instruction-surface/fragmented-agent-context/TECHNIQUE.md` | `promoted` | `docs` | `composition` | 1 | 3 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0031` | `techniques/execution/agent-workflows-core/shell-composable-agent-invocation/TECHNIQUE.md` | `canonical` | `agent-workflows` | `composition` | 1 | 3 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0032` | `techniques/proof/evaluation-chain/context-report-for-ci/TECHNIQUE.md` | `promoted` | `evaluation` | `validation` | 1 | 2 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0033` | `techniques/instruction/docs-boundary/decision-rationale-recording/TECHNIQUE.md` | `promoted` | `docs` | `artifact` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0034` | `techniques/instruction/docs-boundary/public-safe-artifact-sanitization/TECHNIQUE.md` | `canonical` | `docs` | `guardrail` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0035` | `techniques/instruction/instruction-surface/profile-preset-composition/TECHNIQUE.md` | `promoted` | `docs` | `composition` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0036` | `techniques/execution/runtime-truth-lifecycle/render-truth-before-startup/TECHNIQUE.md` | `promoted` | `agent-workflows` | `composition` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0037` | `techniques/execution/runtime-truth-lifecycle/contextual-host-doctor/TECHNIQUE.md` | `promoted` | `evaluation` | `validation` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0038` | `techniques/execution/runtime-truth-lifecycle/one-command-service-lifecycle/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0039` | `techniques/execution/runtime-truth-lifecycle/baseline-first-additive-profile-benchmarks/TECHNIQUE.md` | `promoted` | `evaluation` | `validation` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0040` | `techniques/instruction/capability-boundary/skill-vs-command-boundary/TECHNIQUE.md` | `promoted` | `docs` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0041` | `techniques/instruction/skill-discovery/skill-marketplace-curation/TECHNIQUE.md` | `promoted` | `docs` | `discovery` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0042` | `techniques/instruction/skill-discovery/upstream-skill-health-checking/TECHNIQUE.md` | `promoted` | `evaluation` | `validation` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0043` | `techniques/instruction/capability-boundary/multi-source-primary-input-provenance/TECHNIQUE.md` | `promoted` | `docs` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0044` | `techniques/history/history-artifacts/versionable-session-transcripts/TECHNIQUE.md` | `canonical` | `history` | `artifact` | 1 | 1 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0045` | `techniques/history/history-artifacts/witness-trace-as-reviewable-artifact/TECHNIQUE.md` | `promoted` | `history` | `artifact` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0046` | `techniques/knowledge-lift/kag-source-lift/repo-doc-surface-lift/TECHNIQUE.md` | `promoted` | `docs` | `lift` | 1 | 1 | 1 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0047` | `techniques/knowledge-lift/kag-source-lift/github-review-template-lift/TECHNIQUE.md` | `promoted` | `docs` | `lift` | 1 | 1 | 1 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0048` | `techniques/knowledge-lift/kag-source-lift/semantic-review-surface-lift/TECHNIQUE.md` | `promoted` | `docs` | `lift` | 1 | 1 | 1 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0049` | `techniques/execution/ready-work-graphs/dependency-aware-task-graph/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0050` | `techniques/execution/ready-work-graphs/ready-work-from-blocker-graph/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0051` | `techniques/continuity/review-compaction/commit-triggered-background-review/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0052` | `techniques/continuity/review-compaction/review-findings-compaction/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0053` | `techniques/history/history-artifacts/local-first-session-index/TECHNIQUE.md` | `canonical` | `history` | `artifact` | 1 | 1 | 5 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0054` | `techniques/continuity/review-compaction/compaction-resilient-skill-loading/TECHNIQUE.md` | `promoted` | `agent-workflows` | `recovery` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0055` | `techniques/execution/ready-work-graphs/requirements-design-tasks-ladder/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0056` | `techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0057` | `techniques/continuity/handoff-continuation/structured-handoff-before-compaction/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0058` | `techniques/continuity/handoff-continuation/receipt-confirmed-handoff-packet/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0059` | `techniques/continuity/handoff-continuation/git-verified-handoff-claims/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0060` | `techniques/continuity/handoff-continuation/session-opening-ritual-before-work/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0061` | `techniques/continuity/handoff-continuation/cross-repo-resource-map-bootstrap/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0062` | `techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0063` | `techniques/instruction/capability-registry/versioned-agent-registry-contract/TECHNIQUE.md` | `promoted` | `docs` | `artifact` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0064` | `techniques/instruction/capability-registry/capability-discovery/TECHNIQUE.md` | `promoted` | `docs` | `discovery` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0065` | `techniques/tool-use/tool-gateway/mcp-gateway-proxy/TECHNIQUE.md` | `promoted` | `agent-workflows` | `composition` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0066` | `techniques/history/history-artifacts/transcript-replay-artifact/TECHNIQUE.md` | `promoted` | `history` | `artifact` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0067` | `techniques/history/history-artifacts/transcript-linked-code-lineage/TECHNIQUE.md` | `promoted` | `history` | `artifact` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0068` | `techniques/governance/approval-evidence/fail-closed-evidence-gate/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0069` | `techniques/governance/approval-evidence/approval-bound-durable-jobs/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0070` | `techniques/ingest/media-ingest/two-stage-document-ocr-pipeline/TECHNIQUE.md` | `promoted` | `agent-workflows` | `ingest` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0071` | `techniques/ingest/media-ingest/template-backed-field-extraction-after-ocr/TECHNIQUE.md` | `promoted` | `agent-workflows` | `ingest` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0072` | `techniques/ingest/media-ingest/perceptual-media-dedupe-with-threshold-review/TECHNIQUE.md` | `promoted` | `agent-workflows` | `ingest` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0073` | `techniques/ingest/media-ingest/semantic-media-bucketing-with-vision-plus-ocr/TECHNIQUE.md` | `promoted` | `agent-workflows` | `ingest` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0074` | `techniques/ingest/media-ingest/telegram-export-normalization-to-local-store/TECHNIQUE.md` | `promoted` | `agent-workflows` | `ingest` | 1 | 1 | 4 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0075` | `techniques/continuity/donor-harvest/session-donor-harvest/TECHNIQUE.md` | `promoted` | `agent-workflows` | `lift` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0076` | `techniques/governance/decision-routing/owner-layer-triage/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0077` | `techniques/continuity/donor-harvest/harvest-packet-contract/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0078` | `techniques/governance/decision-routing/decision-fork-cards/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0079` | `techniques/governance/decision-routing/risk-passport-lift/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0080` | `techniques/recovery/diagnosis-repair/session-drift-taxonomy/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0081` | `techniques/recovery/diagnosis-repair/diagnosis-from-reviewed-evidence/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0082` | `techniques/recovery/diagnosis-repair/repair-shape-from-diagnosis/TECHNIQUE.md` | `promoted` | `agent-workflows` | `recovery` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0083` | `techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/TECHNIQUE.md` | `promoted` | `agent-workflows` | `recovery` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0084` | `techniques/continuity/donor-harvest/progression-evidence-lift/TECHNIQUE.md` | `promoted` | `agent-workflows` | `lift` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0085` | `techniques/continuity/donor-harvest/multi-axis-quest-overlay/TECHNIQUE.md` | `promoted` | `agent-workflows` | `lift` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0086` | `techniques/governance/automation-readiness/automation-fit-matrix/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0087` | `techniques/governance/automation-readiness/human-loop-to-seed-lift/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0088` | `techniques/governance/automation-readiness/approval-sensitivity-check/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0089` | `techniques/governance/promotion-boundary/quest-unit-promotion-review/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0090` | `techniques/governance/promotion-boundary/nearest-wrong-target-rejection/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0091` | `techniques/proof/owner-truth-closeout/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0092` | `techniques/proof/owner-truth-closeout/audit-to-closeout-proof-loop/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0093` | `techniques/instruction/capability-boundary/recommendation-truth-vs-host-actionability/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0094` | `techniques/proof/owner-truth-closeout/canonical-owner-with-validated-mirror/TECHNIQUE.md` | `promoted` | `docs` | `distribution` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0095` | `techniques/proof/owner-truth-closeout/github-only-owner-endcap-with-reality-sync/TECHNIQUE.md` | `promoted` | `agent-workflows` | `workflow` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0096` | `techniques/proof/owner-truth-closeout/pinned-validation-matrix-before-generated-publish/TECHNIQUE.md` | `promoted` | `agent-workflows` | `validation` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0097` | `techniques/recovery/antifragility-recovery/degrade-reground-recover/TECHNIQUE.md` | `promoted` | `system-recovery` | `recovery` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0098` | `techniques/recovery/antifragility-recovery/receipt-first-failure-analysis/TECHNIQUE.md` | `promoted` | `validation-patterns` | `validation` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0099` | `techniques/recovery/antifragility-recovery/isolated-service-stop-on-shared-substrate/TECHNIQUE.md` | `promoted` | `system-recovery` | `recovery` | 1 | 1 | 1 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0100` | `techniques/recovery/antifragility-recovery/stress-receipt-reground-closeout/TECHNIQUE.md` | `promoted` | `system-recovery` | `recovery` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0101` | `techniques/governance/practice-adoption-lifecycle/local-pattern-adoption-gate/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0102` | `techniques/governance/promotion-boundary/skill-proposal-handoff-packet/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0103` | `techniques/governance/practice-adoption-lifecycle/adopted-practice-retention-review/TECHNIQUE.md` | `promoted` | `agent-workflows` | `assessment` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0104` | `techniques/governance/practice-adoption-lifecycle/superseded-practice-obsolescence-route/TECHNIQUE.md` | `promoted` | `agent-workflows` | `handoff` | 1 | 1 | 3 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0105` | `techniques/proof/review-evidence/single-missing-evidence-request/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0106` | `techniques/proof/review-evidence/single-scoped-evidence-reference/TECHNIQUE.md` | `promoted` | `docs` | `artifact` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+| `AOA-T-0107` | `techniques/proof/review-evidence/single-locus-claim-challenge/TECHNIQUE.md` | `promoted` | `agent-workflows` | `guardrail` | 1 | 1 | 2 | `yes` | `match` | `inventory-pass` |
+
+## Next Gate
+
+Use this inventory to harden the audit rubric against direct reading. The next pass should test the rubric on representative canonical, promoted, portability-heavy, proof-adjacent, and runtime/tool-use-adjacent bundles before any leaf repair.
+
+## Stop Lines
+
+- Do not treat `inventory-pass` as a final quality verdict. It only says the mechanical baseline has no obvious presence/parity gap.
+- Do not repair `*-candidate` rows without direct bundle reading.
+- Do not move paths or add frontmatter from this packet.
+- Do not promote status from this packet.
+- Do not hand-edit generated surfaces from this packet.


### PR DESCRIPTION
## Summary
- add a post-tree bundle reform baseline inventory review packet over all 107 technique bundles
- record catalog/capsule/tree projection parity plus example/check/note presence for every bundle
- link the packet from the technique reform reviews index

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py

## Stop-lines
- no technique bundle edits
- no path movement
- no frontmatter, schema, generated, or status migration
- inventory labels are mechanical presence/parity signals, not final bundle quality verdicts