### PR TITLE
Record post-repair follow-through

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -80,5 +80,6 @@ Current reviews:
 - [bundle-anatomy-corpus-synthesis](bundle-anatomy-corpus-synthesis.md)
 - [bundle-anatomy-capsule-gap-repair-cohort](bundle-anatomy-capsule-gap-repair-cohort.md)
 - [bundle-anatomy-template-contract-feedback](bundle-anatomy-template-contract-feedback.md)
+- [bundle-anatomy-post-repair-follow-through](bundle-anatomy-post-repair-follow-through.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-post-repair-follow-through.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-post-repair-follow-through.md
@@ -1,0 +1,86 @@
+# Bundle Anatomy Post-Repair Follow-Through
+
+Source packets:
+
+- [Bundle Anatomy Corpus Synthesis](bundle-anatomy-corpus-synthesis.md)
+- [Bundle Anatomy Capsule Gap Repair Cohort](bundle-anatomy-capsule-gap-repair-cohort.md)
+- [Bundle Anatomy Template And Contract Feedback](bundle-anatomy-template-contract-feedback.md)
+
+Status: post-repair-follow-through, no technique leaf repair, no schema change,
+no path movement, no frontmatter migration, no status promotion.
+
+## Verdict
+
+Close the post-repair follow-through gates after the first repair cohort.
+
+The corpus has no remaining open repair cohort from the bundle anatomy audit.
+The only concrete gap found by synthesis was the wrapped-bullet capsule
+extraction defect, and that repair has landed. The remaining watch labels are
+review posture, not work queues.
+
+## Phase Outcomes
+
+| phase | outcome | evidence |
+|---|---|---|
+| Phase 10 repair waves | closed with no additional repair waves | synthesis found `105` no-repair bundles and the single capsule repair cohort is landed |
+| Phase 11 topology scout | no schema or registry change | topology registry and scout report remain scout-only and already warn against frontmatter or schema authority |
+| Phase 12 capsule/generated reader | closed | all audit capsule gaps route to the wrapped-bullet repair; generated capsule surfaces were rebuilt |
+| Phase 13 promotion separation | no promotion action | repair improved generated readability but did not add canonical evidence or status readiness |
+| Phase 14 route-away | no route-away handoff | synthesis found `0/107` route-away, split, merge, deprecation, or path-move needs |
+
+## Topology Scout Review
+
+Reviewed:
+
+- `config/technique_topology_axes.yaml`
+- `reports/technique_topology_scout.md`
+
+No change is needed. The registry already says scout axes do not add required
+frontmatter, do not replace `domain` or `kind`, and must not automatically
+remap bundle meaning. The report repeats the same boundary and is current for
+`107` techniques.
+
+The anatomy audit did produce useful selection pressure:
+
+- `owner-boundary-watch`
+- `portability-watch`
+- `old-template-watch`
+- `promotion-evidence-hold`
+
+Those are review labels, not new topology fields. They can inform future
+selection work, but they do not justify schema, validator, or frontmatter
+migration now.
+
+## Capsule Follow-Through Review
+
+The capsule gap cohort is closed.
+
+The repair changed the builder so wrapped Markdown list items preserve indented
+continuation lines, added a regression test, documented the behavior in the
+capsule guide, and regenerated the capsule JSON plus reader surfaces.
+
+No authored technique source was changed. No generated capsule was hand-edited.
+
+## Promotion And Evidence Separation
+
+No promoted bundle becomes canonical-ready from this repair alone.
+
+The repair changed derived reader quality, not source evidence, second-context
+reuse, canonical readiness notes, or promotion review. Any later status move
+must go through the repo's promotion-readiness and canonical review surfaces.
+
+## Route-Away Follow-Through
+
+No route-away packet is needed.
+
+The audit found many owner-boundary watches, but none of them collapsed into a
+sibling-owner route. The techniques remain portable atoms that bridge to
+stronger organs without importing their authority.
+
+## Stop Lines
+
+- Do not open more repair waves without a new direct finding.
+- Do not promote scout axes into frontmatter from watch labels.
+- Do not promote bundles from generated-reader repair.
+- Do not create sibling-owner handoffs when there is no route-away finding.
+- Do not treat old-template watch as a backlog for mass rewriting.


### PR DESCRIPTION
## Summary
- add the post-repair follow-through review packet for bundle anatomy phases 10-14
- record that no additional repair cohort, topology schema change, promotion, generated rebuild, or route-away handoff is open from the audit
- link the new review from the technique reform reviews index

## Validation
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py