### PR TITLE
Close bundle anatomy reform pass

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,8 +133,8 @@ surfaces keep checked mechanic landings. `CHANGELOG.md` keeps released history.
 
 | Field | Direction |
 |---|---|
-| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` now names the current root tree as trunks, shelves, and leaf bundles. The first full pass landed all `107` bundles under `techniques/<trunk>/<shelf>/<slug>/`, across `10` trunks and `28` shelves, with `28/28` root legacy receipts, `107/107` current paths matching generated projection paths, no remaining split, singleton, or unassigned hold rows, validator-backed route cards for all current trunks plus retained frontmatter lanes, and a final migration ledger distilling the temporary plan into permanent route surfaces. |
-| Next honest move | Start technique-bundle reform with a corpus-wide bundle anatomy and small-agent usability audit before changing individual leaves. |
+| Current posture | `docs/TECHNIQUE_TREE_CONTRACT.md` now names the current root tree as trunks, shelves, and leaf bundles. The first full pass landed all `107` bundles under active `techniques/<trunk>/<shelf>/<slug>/` paths, across `10` active bundle trunks and `28` shelves, with `28/28` root legacy receipts, `107/107` current paths matching generated projection paths, no remaining split, singleton, or unassigned hold rows, validator-backed route cards for all current trunks plus retained frontmatter lanes, a final migration ledger, and a completed bundle anatomy closeout that audited all `107` bundles. |
+| Next honest move | Choose one bounded targeted reform slice from the closed bundle anatomy evidence, keeping old-template, owner-boundary, portability, and promotion-hold labels as review pressure rather than automatic rewrite queues. |
 | Guardrail | Do not move all bundles in one wave, make `tree_path` required frontmatter prematurely, or copy the mechanics package shape into technique leaves. |
 
 Historical tree migration breadcrumb row preserved for parity; current closeout above supersedes it as direction:
@@ -157,6 +157,15 @@ Current latest final tree ledger: the final tree migration ledger validates
 generated parity, `28/28` shelf receipt coverage, temporary-plan distillation,
 and the transition from path migration into technique-bundle reform.
 Previous final-ledger breadcrumb preserved for parity: Run the final migration ledger and generated parity pass before another path movement, schema promotion, or reform slice.
+
+Current latest bundle anatomy closeout: the final bundle reform ledger validates
+the first post-tree anatomy pass over all `107` bundles, closes the lone
+capsule-reader repair cohort, records no schema, path, promotion, route-away,
+or legacy receipt tail, and moves next direction toward one chosen targeted
+reform slice.
+Previous bundle-anatomy breadcrumb preserved for parity: Start
+technique-bundle reform with a corpus-wide bundle anatomy and small-agent
+usability audit before changing individual leaves.
 
 Current latest tree migration: the `tool-gateway` pilot moved exactly
 `AOA-T-0065` into `techniques/tool-use/tool-gateway/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -276,6 +276,11 @@ permission slip to remap techniques automatically.
 - final tree migration ledger: landed, with generated parity, `28/28` shelf
   receipt coverage, temporary-plan distillation, and next direction toward
   technique-bundle reform confirmed
+- bundle anatomy reform closeout: landed, with all `107` bundles audited,
+  `105/107` left untouched, the `2/107` generated-reader capsule gaps repaired
+  through the builder, no remaining route-away or promotion action, no
+  frontmatter or schema migration, and next direction moved from broad audit
+  into targeted reform slices
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -381,6 +386,11 @@ permission slip to remap techniques automatically.
 | [Whole-Tree Closeout Review](reviews/whole-tree-closeout-review.md) | validates the current tree as `107` bundles, `10` trunks, `28` shelves, `107/107` current path parity, `28/28` root receipts, and zero split/singleton/unassigned holds | route-card consolidation, path movement, `tree_path` frontmatter, family promotion, new required axes, frontmatter remap, canonical promotion, generated projection authority, sibling-owner authority, or final topology for future imports |
 | [Nested AGENTS Validator](../../../../scripts/validate_nested_agents.py) | checks the current trunk route cards and retained frontmatter lanes remain present and shaped | bundle meaning, path movement, frontmatter remap, generated projection authority, or future topology acceptance |
 | [Final Tree Migration Ledger](reviews/final-tree-migration-ledger.md) | closes the tree migration program with generated parity, receipt coverage, temporary-plan disposition, and next reform direction | path movement, `tree_path` frontmatter, frontmatter remap, family promotion, bundle rewrite authority, generated projection authority, or future topology acceptance |
+| [Bundle Anatomy Corpus Synthesis](reviews/bundle-anatomy-corpus-synthesis.md) | reviews all `107` bundle anatomy rows and chooses the only concrete first repair cohort | leaf rewrite authority, template migration, status promotion, or route-away movement |
+| [Bundle Anatomy Capsule Gap Repair Cohort](reviews/bundle-anatomy-capsule-gap-repair-cohort.md) | repairs wrapped list extraction for generated capsule readability without changing technique source | bundle meaning change, generated hand-edit authority, or template modernization |
+| [Bundle Anatomy Post-Repair Follow-Through](reviews/bundle-anatomy-post-repair-follow-through.md) | closes repair-wave, topology-scout, capsule, promotion, and route-away follow-through gates | new schema fields, promotion, route-away handoff, or old-template backlog authority |
+| [Bundle Anatomy Legacy And Provenance Hygiene](reviews/bundle-anatomy-legacy-provenance-hygiene.md) | confirms no new root or mechanic-local legacy receipt is needed for this reform pass | permission to add placeholder receipts or move active review packets into legacy |
+| [Bundle Anatomy Final Closeout Ledger](reviews/bundle-anatomy-final-closeout-ledger.md) | closes the first post-tree bundle reform pass and distills the temporary rhythm plan | broad leaf rewrite, frontmatter migration, status promotion, or automatic next cohort authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -435,6 +445,17 @@ It should continue one bounded slice at a time:
 - [ ] Run the narrow builders touched by the slice plus `python scripts/release_check.py`.
 
 ## Next Honest Move
+
+Current latest bundle anatomy closeout: the first post-tree bundle reform pass
+is closed. It audited all `107` bundles, repaired the only generated-reader
+capsule defect found by the audit, left `105` healthy bundles untouched,
+declined broad template/schema/status churn, and removed the temporary rhythm
+plan after distilling it into the final closeout ledger.
+
+Next clean move: choose one bounded targeted reform slice from the closeout
+evidence. Do not restart a broad audit, do not mass-rewrite old-template
+bundles, and do not promote scout axes into frontmatter without a separate
+decision and validator wave.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -82,5 +82,6 @@ Current reviews:
 - [bundle-anatomy-template-contract-feedback](bundle-anatomy-template-contract-feedback.md)
 - [bundle-anatomy-post-repair-follow-through](bundle-anatomy-post-repair-follow-through.md)
 - [bundle-anatomy-legacy-provenance-hygiene](bundle-anatomy-legacy-provenance-hygiene.md)
+- [bundle-anatomy-final-closeout-ledger](bundle-anatomy-final-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-final-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-final-closeout-ledger.md
@@ -1,0 +1,113 @@
+# Bundle Anatomy Final Closeout Ledger
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Status: final closeout ledger for the post-tree bundle anatomy reform pass.
+
+## Verdict
+
+Close the first full post-tree technique bundle reform pass.
+
+The pass audited all `107` authored technique bundles after the tree migration,
+validated the corpus as healthy enough for the next reform direction, repaired
+the only generated-reader defect found by the audit, and refused broad churn
+where the evidence did not justify it.
+
+Final state:
+
+- `107` authored technique bundles.
+- `10` active bundle trunks with techniques.
+- `28` active shelves with techniques.
+- `25` canonical bundles and `82` promoted bundles.
+- `107/107` generated catalog and capsule presence.
+- `107/107` examples, checks, and notes present.
+- `105/107` bundles needed no repair in this pass.
+- `2/107` capsule gaps were repaired through the builder.
+- `0/107` route-away, split, merge, deprecation, path movement, frontmatter
+  migration, or status promotion actions remain open from this pass.
+
+Retained frontmatter-lane route directories `agent-workflows`, `docs`, and
+`evaluation` still exist under `techniques/`, but they carry no active bundle
+leaves. Active bundle paths are under the `10` generated/catalogued trunks.
+
+## Landed Packets
+
+| packet | result |
+|---|---|
+| [Bundle Anatomy Baseline Inventory](bundle-anatomy-baseline-inventory.md) | counted all bundles, paths, generated presence, examples, checks, and notes |
+| [Bundle Anatomy Rubric Hardening](bundle-anatomy-rubric-hardening.md) | turned the audit into repeatable labels and repair-action posture |
+| [Bundle Anatomy Wave A Review](bundle-anatomy-wave-a-review.md) | audited execution and instruction shelves |
+| [Bundle Anatomy Wave B Review](bundle-anatomy-wave-b-review.md) | audited proof, continuity, and governance shelves |
+| [Bundle Anatomy Wave C Review](bundle-anatomy-wave-c-review.md) | audited knowledge-lift, ingest, history, recovery, and tool-use shelves |
+| [Bundle Anatomy Corpus Synthesis](bundle-anatomy-corpus-synthesis.md) | synthesized all `107` rows and chose the first repair cohort |
+| [Bundle Anatomy Capsule Gap Repair Cohort](bundle-anatomy-capsule-gap-repair-cohort.md) | repaired wrapped Markdown list extraction for generated capsules |
+| [Bundle Anatomy Template And Contract Feedback](bundle-anatomy-template-contract-feedback.md) | recorded that no template, Atom, Topology, Tree, or ADR change was needed |
+| [Bundle Anatomy Post-Repair Follow-Through](bundle-anatomy-post-repair-follow-through.md) | closed repair waves, topology scout, capsule, promotion, and route-away gates |
+| [Bundle Anatomy Legacy And Provenance Hygiene](bundle-anatomy-legacy-provenance-hygiene.md) | confirmed no new legacy receipt or mechanic-local legacy update was needed |
+
+## Repair Closed
+
+The audit found two concrete generated-reader failures:
+
+- `AOA-T-0095` capsule validation shortened a wrapped bullet into `before the;`.
+- `AOA-T-0096` capsule risk ended at `older or.`
+
+The source techniques were coherent. The defect was in capsule extraction:
+wrapped Markdown list items were not preserving indented continuation lines.
+
+The landed repair changed builder behavior, added regression coverage,
+documented capsule extraction expectations, and regenerated capsule reader
+surfaces. The repair affected `11` generated entries where wrapped sentence
+tails had previously been dropped.
+
+No generated file was hand-edited. No technique source was changed for cosmetic
+reader reasons.
+
+## No-Change Decisions
+
+These were reviewed and intentionally left unchanged:
+
+- no path movement
+- no `tree_path` frontmatter
+- no `family`, `capability_class`, `substrate`, `execution_profile`, or
+  `risk_posture` frontmatter promotion
+- no `domain` or `kind` remap
+- no old-template mass rewrite
+- no bundle status promotion
+- no route-away handoff
+- no new root legacy receipt
+- no new mechanic-local legacy receipt
+- no ADR
+- no root Questbook update
+
+`ROADMAP.md` is updated by this closeout because repo-level direction moved:
+the next honest move is no longer "start bundle anatomy audit"; it is to choose
+the next bounded reform slice from this closed evidence.
+
+## Next Direction
+
+The next clean direction is targeted reform, not corpus churn.
+
+Good candidate lanes:
+
+- choose one concrete technique-bundle reform slice from direct evidence;
+- improve a bundle-local template shape only when a target bundle already
+  needs nearby work;
+- prepare future topology or generated selector work only through a separate
+  decision, builder, and validator wave;
+- keep generated capsules and compact cards tuned for small-agent execution
+  after orchestration has selected the technique and packed context.
+
+Do not turn `old-template-watch`, `owner-boundary-watch`,
+`promotion-evidence-hold`, or `portability-watch` into automatic work queues.
+They are review pressure, not authority.
+
+## Validation
+
+Final closeout validation:
+
+1. `python scripts/release_check.py`
+2. `python scripts/validate_repo.py`
+
+The temporary rhythm plan was distilled into this ledger and removed from the
+working tree. It was local scratch, not source truth.


### PR DESCRIPTION
## Summary
- add the final bundle anatomy closeout ledger for the post-tree reform pass
- update Technique Reform Ingress and ROADMAP so the next direction moves from broad audit into one bounded targeted reform slice
- link the final ledger from the reform review index and remove the local temporary rhythm plan

## Validation
- python scripts/release_check.py
- python scripts/validate_repo.py