### PR TITLE
Calibrate execution profile truth boundary

### DIFF
--- a/config/technique_topology_axes.yaml
+++ b/config/technique_topology_axes.yaml
@@ -4,7 +4,9 @@ status: scout-foundation
 authority_note: >
   This registry defines scout values for non-authoritative topology projection.
   It does not add required frontmatter fields, does not replace domain or kind,
-  and must not remap bundle meaning automatically.
+  and must not remap bundle meaning automatically. Execution-profile values are
+  static suitability estimates from authored technique shape, not empirical
+  proof from a local small-agent harness.
 source_of_truth:
   - docs/TECHNIQUE_TOPOLOGY_CONTRACT.md
   - mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -173,25 +175,26 @@ axes:
   - id: execution_profile
     status: design-axis-scout
     cardinality: exactly-one
-    purpose: What execution envelope can perform the selected atomic move.
+    purpose: What execution envelope appears suitable for the selected atomic move before empirical agent validation.
     values:
       - id: tiny-card
-        summary: Executable from a compact card or short section with obvious inputs.
+        summary: Scout-estimated executable from a compact card or short section with obvious inputs.
         choose_when:
           - a small packed prompt can carry the whole move
           - local context and stop line are simple
       - id: small-agent
-        summary: Suitable for a 2-4B model after orchestration supplies facts, frame, and output shape.
+        summary: Scout candidate for 2-4B model execution after orchestration supplies facts, frame, and output shape.
         choose_when:
           - the move needs local reasoning but stays narrow
           - selection and context packing happen outside the technique
+          - empirical small-agent success is not claimed unless a separate local eval records it
       - id: medium-agent
-        summary: Requires broader comparison, multi-file awareness, or careful judgment while staying one move.
+        summary: Scout-estimated to require broader comparison, multi-file awareness, or careful judgment while staying one move.
         choose_when:
           - the move is still atomic but too context-sensitive for a tiny card
           - review or synthesis depth matters
       - id: orchestration-required
-        summary: Atomic in meaning, but safe execution requires an outer workflow, approval gate, or tool choreography.
+        summary: Atomic in meaning, but safe execution appears to require an outer workflow, approval gate, or tool choreography.
         choose_when:
           - the move crosses risky, multi-tool, public-share, or owner-boundary surfaces
           - a larger agent or skill must supply gating and sequencing

--- a/docs/TECHNIQUE_TOPOLOGY_CONTRACT.md
+++ b/docs/TECHNIQUE_TOPOLOGY_CONTRACT.md
@@ -210,6 +210,10 @@ catch-all domains.
 `execution_profile` should answer what kind of agent can execute the technique
 after selection.
 
+Until a local model harness records empirical results, execution-profile values
+are scout suitability estimates from authored bundle shape. They are not proof
+that a given small model has already executed the technique successfully.
+
 Likely profiles include:
 
 - `tiny-card`: executable from a capsule or one short section with obvious

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -281,6 +281,10 @@ permission slip to remap techniques automatically.
   through the builder, no remaining route-away or promotion action, no
   frontmatter or schema migration, and next direction moved from broad audit
   into targeted reform slices
+- execution-profile truth boundary pilot: landed over
+  `continuity/handoff-continuation`, confirming `execution_profile` as scout
+  suitability rather than empirical small-agent proof and setting the rhythm
+  for a future long pass
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -391,6 +395,7 @@ permission slip to remap techniques automatically.
 | [Bundle Anatomy Post-Repair Follow-Through](reviews/bundle-anatomy-post-repair-follow-through.md) | closes repair-wave, topology-scout, capsule, promotion, and route-away follow-through gates | new schema fields, promotion, route-away handoff, or old-template backlog authority |
 | [Bundle Anatomy Legacy And Provenance Hygiene](reviews/bundle-anatomy-legacy-provenance-hygiene.md) | confirms no new root or mechanic-local legacy receipt is needed for this reform pass | permission to add placeholder receipts or move active review packets into legacy |
 | [Bundle Anatomy Final Closeout Ledger](reviews/bundle-anatomy-final-closeout-ledger.md) | closes the first post-tree bundle reform pass and distills the temporary rhythm plan | broad leaf rewrite, frontmatter migration, status promotion, or automatic next cohort authority |
+| [Execution Profile Truth Boundary Pilot](reviews/execution-profile-truth-boundary-pilot.md) | calibrates `execution_profile` as scout suitability, not empirical small-agent proof, using `continuity/handoff-continuation` as the pilot shelf | required frontmatter, local-agent eval verdicts, mass relabeling, or technique leaf edits |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -451,6 +456,12 @@ is closed. It audited all `107` bundles, repaired the only generated-reader
 capsule defect found by the audit, left `105` healthy bundles untouched,
 declined broad template/schema/status churn, and removed the temporary rhythm
 plan after distilling it into the final closeout ledger.
+
+Current latest execution-profile pilot: `continuity/handoff-continuation` is
+reviewed as the first truth-boundary slice. The pass keeps current scout
+profiles, clarifies that `small-agent` is not empirical proof, and prepares the
+future long pass to collect fixture sketches before any local small-agent
+harness.
 
 Next clean move: choose one bounded targeted reform slice from the closeout
 evidence. Do not restart a broad audit, do not mass-rewrite old-template

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -83,5 +83,6 @@ Current reviews:
 - [bundle-anatomy-post-repair-follow-through](bundle-anatomy-post-repair-follow-through.md)
 - [bundle-anatomy-legacy-provenance-hygiene](bundle-anatomy-legacy-provenance-hygiene.md)
 - [bundle-anatomy-final-closeout-ledger](bundle-anatomy-final-closeout-ledger.md)
+- [execution-profile-truth-boundary-pilot](execution-profile-truth-boundary-pilot.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/execution-profile-truth-boundary-pilot.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/execution-profile-truth-boundary-pilot.md
@@ -1,0 +1,100 @@
+# Execution Profile Truth Boundary Pilot
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Status: scout calibration pilot, no local small-agent eval, no frontmatter
+change, no schema migration, no technique leaf repair.
+
+## Verdict
+
+Treat `execution_profile` as a scout suitability estimate until a real local
+small-agent harness proves execution.
+
+This pilot reviewed `continuity/handoff-continuation` because the shelf has a
+useful mix of `small-agent` and `orchestration-required` projections while
+staying inside one semantic family. Direct reading supports the current scout
+split, but only as static review truth:
+
+- `small-agent` means "candidate for 2-4B execution after orchestration packs
+  facts, frame, stop line, and output shape."
+- It does not mean "already proven by a 2-4B local model."
+- `orchestration-required` stays valid when the atomic move is safe only inside
+  a guard, approval, tool, or episode-control wrapper.
+
+The registry wording is clarified so future readers do not confuse scout
+projection with empirical validation.
+
+## Reviewed Surfaces
+
+Reviewed:
+
+- `docs/TECHNIQUE_ATOM_CONTRACT.md`
+- `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
+- `config/technique_topology_axes.yaml`
+- `reports/technique_topology_scout.md`
+- `docs/TECHNIQUE_CAPSULES.md`
+- `techniques/continuity/AGENTS.md`
+- all `TECHNIQUE.md`, `examples/`, `checks/`, and `notes/` files under
+  `techniques/continuity/handoff-continuation/`
+
+## Shelf Calibration
+
+| technique | current profile | pilot verdict | future local fixture |
+|---|---|---|---|
+| `AOA-T-0056` `channelized-agent-mailbox` | `small-agent` | keep as scout candidate: bounded replay and ack state are explicit, read-only, and capsule-shaped | named channel, two ordered messages, `last_seen`, expected replay plus `acked_through` |
+| `AOA-T-0057` `structured-handoff-before-compaction` | `small-agent` | keep as scout candidate: one pre-boundary handoff artifact with clear fields | compaction boundary state with done/blocked/next refs, expected structured packet |
+| `AOA-T-0058` `receipt-confirmed-handoff-packet` | `small-agent` | keep as scout candidate: existing packet plus visible receipt state keeps the move narrow | handoff packet and receiver, expected receipt record before continuation |
+| `AOA-T-0059` `git-verified-handoff-claims` | `small-agent` | keep as scout candidate, but fixture must provide controlled git evidence | handoff claims plus local git fixture, expected verified/mismatch/unverifiable rows |
+| `AOA-T-0060` `session-opening-ritual-before-work` | `orchestration-required` | keep: the move is pre-mutation and depends on an outer guard around first work | handed-off session start with current-state surfaces, expected baseline note and no mutation before check |
+| `AOA-T-0061` `cross-repo-resource-map-bootstrap` | `small-agent` | keep as scout candidate when the repo list and task frame are supplied | bounded cross-repo task with three repos, expected role and first-look map |
+| `AOA-T-0062` `episode-bounded-agent-loop` | `orchestration-required` | keep: episode boundaries and continue/stop/escalate need outer control to avoid open-ended autonomy | fixed episode goal, checkpoint criterion, and stop rule, expected checkpoint plus decision |
+
+No profile changes are opened by this pilot. The point is to define the truth
+boundary before scaling the pass.
+
+## Future Long-Pass Rhythm
+
+Use this rhythm for the long execution-profile pass:
+
+1. Choose one bounded cohort from `reports/technique_topology_scout.md`.
+2. Read every target `TECHNIQUE.md` directly.
+3. Read examples, checks, notes, and capsule text for each target.
+4. Record whether the current profile is `scout-confirmed`,
+   `scout-needs-review`, or `empirical-fixture-needed`.
+5. Write a tiny future fixture sketch for each `small-agent` candidate.
+6. Do not call any profile empirically validated without running a real local
+   small-agent harness.
+7. Change registry wording or generated projection rules only when the pilot
+   finds repeated confusion.
+8. Rebuild generated scout surfaces only from source inputs.
+9. Run `python scripts/release_check.py` and `python scripts/validate_repo.py`
+   for any registry, generated, or broad reader-surface change.
+
+Recommended order for the long pass:
+
+1. all `small-agent` scout candidates;
+2. all `medium-agent` scout candidates;
+3. sampled `orchestration-required` rows;
+4. only then a real local small-agent harness with model, fixture, and verdict
+   surfaces.
+
+## Stop Lines
+
+- Do not run fake small-agent validation through the reviewing model.
+- Do not promote `execution_profile` into required frontmatter.
+- Do not change technique status from execution-profile review.
+- Do not mass-relabel profiles from generated reports alone.
+- Do not mutate technique leaves during this calibration pass.
+- Do not let small-agent suitability imply autonomous technique selection.
+
+## Validation
+
+Passed locally:
+
+1. `python scripts/build_topology_scout.py`
+2. `python -m unittest tests.test_distillation_mechanics_topology`
+3. `python scripts/validate_repo.py`
+4. `python scripts/release_check.py`
+
+`build_topology_scout.py` rewrote the generated scout files without producing
+a tracked generated diff.


### PR DESCRIPTION
## Summary
- Clarify `execution_profile` as scout suitability, not empirical proof from local small-agent runs.
- Add a direct-read pilot over `continuity/handoff-continuation`.
- Record the future long-pass rhythm and fixture-sketch expectations before any local small-agent harness.

## Validation
- `python scripts/build_topology_scout.py`
- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- `python scripts/release_check.py`