### PR TITLE
Close execution profile long pass

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -285,6 +285,11 @@ permission slip to remap techniques automatically.
   `continuity/handoff-continuation`, confirming `execution_profile` as scout
   suitability rather than empirical small-agent proof and setting the rhythm
   for a future long pass
+- execution-profile long pass: landed over all `107` current bundles, with
+  `33/33` small-agent fixture sketches, `21/21` medium rows calibrated,
+  `53/53` orchestration boundaries reviewed, `AOA-T-0095` carried as the only
+  profile-pressure repair edge, and empirical model proof routed to
+  `aoa-evals`
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -396,6 +401,11 @@ permission slip to remap techniques automatically.
 | [Bundle Anatomy Legacy And Provenance Hygiene](reviews/bundle-anatomy-legacy-provenance-hygiene.md) | confirms no new root or mechanic-local legacy receipt is needed for this reform pass | permission to add placeholder receipts or move active review packets into legacy |
 | [Bundle Anatomy Final Closeout Ledger](reviews/bundle-anatomy-final-closeout-ledger.md) | closes the first post-tree bundle reform pass and distills the temporary rhythm plan | broad leaf rewrite, frontmatter migration, status promotion, or automatic next cohort authority |
 | [Execution Profile Truth Boundary Pilot](reviews/execution-profile-truth-boundary-pilot.md) | calibrates `execution_profile` as scout suitability, not empirical small-agent proof, using `continuity/handoff-continuation` as the pilot shelf | required frontmatter, local-agent eval verdicts, mass relabeling, or technique leaf edits |
+| [Execution Profile Fixture Sketch Ledger](reviews/execution-profile-fixture-sketch-ledger.md) | defines future fixture sketches for all `33` current `small-agent` scout candidates | empirical model proof, eval harness authority, or profile relabeling |
+| [Execution Profile Registry Calibration Review](reviews/execution-profile-registry-calibration-review.md) | explains why registry wording, generated scout rules, schema, and leaves stay unchanged after review | permission to keep ignoring future eval evidence or overfit a generated keyword rule |
+| [Execution Profile Repair Queue Review](reviews/execution-profile-repair-queue-review.md) | carries `AOA-T-0095` as the single profile-pressure repair candidate and closes broad repair pressure | broad leaf rewrite, mass relabeling, or proof that GitHub-facing rows all require orchestration |
+| [Execution Profile Empirical Harness Decision](reviews/execution-profile-empirical-harness-decision.md) | routes real local small-agent proof to `aoa-evals` and names `AOA-T-0056` as the first future pilot | model verdicts, fixture execution, or eval bundle authority inside `aoa-techniques` |
+| [Execution Profile Long-Pass Closeout Ledger](reviews/execution-profile-long-pass-closeout-ledger.md) | closes the execution-profile long pass with `107/107` review coverage and temporary-plan distillation | frontmatter migration, generated scout mutation, technique leaf edits, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -457,16 +467,17 @@ capsule defect found by the audit, left `105` healthy bundles untouched,
 declined broad template/schema/status churn, and removed the temporary rhythm
 plan after distilling it into the final closeout ledger.
 
-Current latest execution-profile pilot: `continuity/handoff-continuation` is
-reviewed as the first truth-boundary slice. The pass keeps current scout
-profiles, clarifies that `small-agent` is not empirical proof, and prepares the
-future long pass to collect fixture sketches before any local small-agent
-harness.
+Current latest execution-profile closeout: the long pass is closed. It reviewed
+all `107` current bundles through the generated execution-profile scout surface,
+kept current profile counts unchanged, produced fixture sketches for all `33`
+current `small-agent` rows, carried `AOA-T-0095` as the only profile-pressure
+repair edge, and routed empirical local model proof to `aoa-evals`.
 
-Next clean move: choose one bounded targeted reform slice from the closeout
-evidence. Do not restart a broad audit, do not mass-rewrite old-template
-bundles, and do not promote scout axes into frontmatter without a separate
-decision and validator wave.
+Next clean move: choose one bounded targeted slice from the closeout evidence.
+Do not restart a broad audit, do not mass-rewrite old-template bundles, do not
+promote scout axes into frontmatter without a separate decision and validator
+wave, and do not run local small-agent proof without an `aoa-evals` proof
+surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -92,5 +92,6 @@ Current reviews:
 - [execution-profile-registry-calibration-review](execution-profile-registry-calibration-review.md)
 - [execution-profile-repair-queue-review](execution-profile-repair-queue-review.md)
 - [execution-profile-empirical-harness-decision](execution-profile-empirical-harness-decision.md)
+- [execution-profile-long-pass-closeout-ledger](execution-profile-long-pass-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/execution-profile-long-pass-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/execution-profile-long-pass-closeout-ledger.md
@@ -1,0 +1,148 @@
+# Execution Profile Long-Pass Closeout Ledger
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Status: final closeout for the execution-profile long pass. The temporary
+scratch plan was distilled into this ledger and removed in the same closeout
+wave.
+
+## Verdict
+
+The execution-profile truth-boundary long pass is complete.
+
+All `107/107` current technique bundles were covered through direct-read review
+packets grouped by the generated `execution_profile` scout surface:
+
+- `33/33` current `small-agent` rows reviewed and given fixture sketches;
+- `21/21` current `medium-agent` rows reviewed;
+- `53/53` current `orchestration-required` rows reviewed;
+- `1` profile-pressure edge, `AOA-T-0095`, carried as a future targeted repair
+  queue item;
+- `0` local model runs claimed;
+- `0` frontmatter, schema, registry, generated scout rule, capsule builder, or
+  technique leaf changes made from this pass.
+
+The current execution-profile counts remain unchanged:
+
+| profile | count |
+|---|---:|
+| `small-agent` | 33 |
+| `medium-agent` | 21 |
+| `orchestration-required` | 53 |
+
+## Landed Packets
+
+| phase | packet | result |
+|---|---|---|
+| pilot | [execution-profile-truth-boundary-pilot](execution-profile-truth-boundary-pilot.md) | calibrated `execution_profile` as scout suitability, not empirical proof |
+| Phase 1A | [execution-profile-small-agent-wave-a-review](execution-profile-small-agent-wave-a-review.md) | reviewed first `small-agent` shelves and established packed-fixture discipline |
+| Phase 1B | [execution-profile-small-agent-wave-b-review](execution-profile-small-agent-wave-b-review.md) | completed remaining `small-agent` rows and carried fixture sketch pressure forward |
+| Phase 2 | [execution-profile-medium-agent-calibration-review](execution-profile-medium-agent-calibration-review.md) | reviewed all medium rows and flagged `AOA-T-0095` as the one profile edge |
+| Phase 3 | [execution-profile-orchestration-boundary-review](execution-profile-orchestration-boundary-review.md) | reviewed all orchestration rows and confirmed the wrapper/authority boundary |
+| Phase 4 | [execution-profile-fixture-sketch-ledger](execution-profile-fixture-sketch-ledger.md) | collected fixture sketches for all `33/33` small-agent rows |
+| Phase 5 | [execution-profile-registry-calibration-review](execution-profile-registry-calibration-review.md) | decided not to mutate registry, builder, generated scout, schema, or leaves |
+| Phase 6 | [execution-profile-repair-queue-review](execution-profile-repair-queue-review.md) | recorded one repair queue item, `AOA-T-0095`, and no broad repair wave |
+| Phase 7 | [execution-profile-empirical-harness-decision](execution-profile-empirical-harness-decision.md) | deferred real model proof to `aoa-evals` and named `AOA-T-0056` as first future pilot |
+
+## Verdict Counts
+
+These counts are review verdicts, not frontmatter or schema truth.
+
+| verdict | count | note |
+|---|---:|---|
+| `scout-confirmed` | 106 | current static scout profile is understandable from direct reading |
+| `scout-needs-review` | 1 | `AOA-T-0095` remains the one medium profile-pressure edge |
+| `empirical-fixture-needed` | 33 | every current `small-agent` row needs real local model proof before success claims |
+| `orchestration-boundary-confirmed` | 53 | all generated `orchestration-required` rows keep an outer workflow, authority, tool, or safety wrapper |
+| `repair-slice-needed` | 1 | future targeted review for `AOA-T-0095`, not a broken-bundle repair |
+| `owner-route-needed` | 1 | empirical harness and verdict authority belong in `aoa-evals` |
+
+## What Changed
+
+Durable review surfaces changed:
+
+- review packets under
+  `mechanics/distillation/parts/technique-reform-ingress/reviews/`;
+- the review index at
+  `mechanics/distillation/parts/technique-reform-ingress/reviews/README.md`;
+- this closeout update in the parent ingress README.
+
+The temporary scratch plan was removed after its stage log, counts, stop lines,
+and useful threads were distilled here and into the landed packets.
+
+## What Did Not Change
+
+No technique meaning or generated source truth moved:
+
+- no `TECHNIQUE.md` leaf edits;
+- no examples, checks, or notes edits under `techniques/`;
+- no `domain`, `kind`, status, ID, relations, or source-lift changes;
+- no `execution_profile` frontmatter;
+- no schema migration;
+- no `config/technique_topology_axes.yaml` change;
+- no `scripts/build_topology_scout.py` rule change;
+- no generated scout, capsule, catalog, section, checklist, evidence-note, or
+  KAG output changes beyond release-check parity rewrites that produced no
+  durable diff;
+- no local small-agent model run.
+
+## Main Conclusions
+
+- `small-agent` remains a future execution candidate after orchestration packs
+  facts, frame, stop line, and output shape.
+- `small-agent` does not mean autonomous technique selection or proven 2-4B
+  success.
+- `orchestration-required` is not a quality demotion. It marks an authority,
+  side-effect, public-share, owner-route, tool, runtime, or safety wrapper.
+- Current registry wording and generated scout logic are coarse but adequate
+  for scout pressure; direct review packets now carry the needed nuance.
+- `AOA-T-0095` is the only named profile-pressure edge. It is coherent as a
+  promoted bundle, but future work should clarify its execution envelope before
+  any relabel or empirical run.
+- Real local model validation should start in `aoa-evals`, not here.
+
+## Next Owner Route
+
+The clean next cross-repo slice is an `aoa-evals` design pass for a tiny local
+small-agent proof pilot using `AOA-T-0056`
+`channelized-agent-mailbox`.
+
+That future pass should produce a bounded eval bundle or draft proof surface
+with:
+
+- public-safe synthetic fixture family;
+- named local model and version;
+- exact prompt packet;
+- forbidden hidden context;
+- runner assumptions;
+- per-case captured output;
+- pass/fail or categorical verdict;
+- failure-mode notes;
+- report artifact and interpretation limits.
+
+Inside `aoa-techniques`, the clean next technique-side move is not another
+broad audit. It is one targeted slice selected from closeout evidence, most
+likely either:
+
+- a narrow `AOA-T-0095` execution-envelope repair review; or
+- support for the `aoa-evals` `AOA-T-0056` pilot by exporting only the needed
+  technique-facing fixture contract.
+
+## Stop Lines Preserved
+
+- Do not promote scout axes into frontmatter from this pass.
+- Do not mass-relabel profiles from generated reports.
+- Do not claim empirical small-agent proof from review packets.
+- Do not run model fixtures without a proof owner surface.
+- Do not import `aoa-evals`, `aoa-skills`, `aoa-routing`, `aoa-memo`,
+  `aoa-playbooks`, `aoa-agents`, `aoa-stats`, runtime, or AoA center authority
+  into technique bundle meaning.
+
+## Validation
+
+Required before landing this closeout wave:
+
+1. `python scripts/build_topology_scout.py`
+2. `python -m unittest tests.test_distillation_mechanics_topology`
+3. `python scripts/validate_repo.py`
+4. `python scripts/release_check.py`


### PR DESCRIPTION
## Summary
- add the final execution-profile long-pass closeout ledger
- update technique reform ingress surfaces with the completed 107/107 profile review result
- distill and remove the temporary execution-profile scratch plan

## Validation
- python scripts/build_topology_scout.py
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py