### PR TITLE
Review selector relation residual addendum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
-- continued the selector/relation long pass with the residual singleton and
-  cross-wave scan, keeping `AOA-T-0065 complements AOA-T-0038` and recording a
-  no-repair close before the final selector/relation ledger
+- continued the selector/relation long pass with the residual singleton,
+  `proof/review-evidence` addendum, and cross-wave scan, keeping
+  `AOA-T-0065 complements AOA-T-0038` plus the current review-evidence
+  complement edges and recording a no-repair close before the final
+  selector/relation ledger
 - continued the selector/relation long pass with Wave F over instruction
   capability, media-ingest, and history-artifact shelves, strengthening
   `AOA-T-0064 capability-discovery` from `complements AOA-T-0063` to

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -342,10 +342,10 @@ permission slip to remap techniques automatically.
   `requires AOA-T-0063` and adding
   `AOA-T-0071 requires AOA-T-0070`; no new relation types, graph behavior,
   status, domain, kind, or path changes
-- selector/relation residual scan: landed over `tool-use/tool-gateway` and
-  held candidates from Waves A through F, keeping
-  `AOA-T-0065 complements AOA-T-0038` and recording an explicit no-repair
-  verdict before closeout
+- selector/relation residual scan: landed over `tool-use/tool-gateway`,
+  `proof/review-evidence`, and held candidates from Waves A through F, keeping
+  `AOA-T-0065 complements AOA-T-0038` plus the current review-evidence
+  complement edges and recording an explicit no-repair verdict before closeout
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -475,7 +475,7 @@ permission slip to remap techniques automatically.
 | [Diagnosis-Repair Direct Relation Repair](reviews/diagnosis-repair-direct-relation-repair.md) | accepts `AOA-T-0082 requires AOA-T-0081` because repair-shape selection starts from the reviewed diagnosis-packet contract | `requires AOA-T-0080`, `requires AOA-T-0082` from checkpoint posture, relation schema migration, recovery mega-technique collapse, status/domain/kind/path changes, or model proof |
 | [Selector Relation Wave F Capability Media History Review](reviews/selector-relation-wave-f-capability-media-history-review.md) | tests selector prompts and relation posture over capability-registry, capability-boundary, skill-discovery, media-ingest, and history-artifacts shelves | relation schema migration, new relation types, registry product doctrine, installer behavior, media platform ownership, memory truth, status/domain/kind/path changes, or model proof |
 | [Capability Media Direct Relation Repair](reviews/capability-media-direct-relation-repair.md) | accepts `AOA-T-0064 requires AOA-T-0063` and `AOA-T-0071 requires AOA-T-0070` from direct object contracts | `requires AOA-T-0025`, `requires AOA-T-0041`, `requires AOA-T-0070` for media bucketing, strengthened history artifact chains, relation schema migration, product doctrine, status/domain/kind/path changes, or model proof |
-| [Selector Relation Residual Cross-Wave Scan](reviews/selector-relation-residual-cross-wave-scan.md) | closes the residual singleton and cross-wave relation scan with no additional source relation repair | relation schema migration, new relation types, `AOA-T-0065 requires AOA-T-0038`, generated hand edits, status/domain/kind/path changes, or model proof |
+| [Selector Relation Residual Cross-Wave Scan](reviews/selector-relation-residual-cross-wave-scan.md) | closes the residual singleton, low-density review-evidence shelf, and cross-wave relation scan with no additional source relation repair | relation schema migration, new relation types, `AOA-T-0065 requires AOA-T-0038`, review-evidence sequence edges, generated hand edits, status/domain/kind/path changes, or model proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -601,9 +601,11 @@ while accepting two exact object-dependency repairs:
 `AOA-T-0071 requires AOA-T-0070`.
 
 Current latest selector/relation residual scan: Phase 14 is closed over
-`tool-use/tool-gateway` and held candidates from Waves A through F. It keeps
-`AOA-T-0065 complements AOA-T-0038`, confirms generated relation parity for
-all accepted repairs, and records no additional relation repair.
+`tool-use/tool-gateway`, `proof/review-evidence`, and held candidates from
+Waves A through F. It keeps `AOA-T-0065 complements AOA-T-0038`, keeps the
+current review-evidence complement edges as non-sequential atoms, confirms
+generated relation parity for all accepted repairs, and records no additional
+relation repair.
 
 Next clean move: continue the long selector/relation pass with Phase 15:
 final closeout ledger. Count coverage, accepted repairs, holds, generated

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md
@@ -508,6 +508,7 @@ Landed result:
 Scope:
 
 - `tool-use/tool-gateway`
+- `proof/review-evidence`
 - any low-density shelves not adequately covered by earlier waves
 - relation candidates held from Waves A through F
 
@@ -537,6 +538,9 @@ Landed result:
 - re-read the `tool-use/tool-gateway` singleton and kept
   `AOA-T-0065 complements AOA-T-0038` because the gateway proxy seam does not
   require the exact local service lifecycle technique;
+- re-read `proof/review-evidence` and kept `AOA-T-0105`, `AOA-T-0106`, and
+  `AOA-T-0107` relation edges as complements because the shelf contains three
+  separate one-use review-evidence atoms, not a fixed execution chain;
 - re-scanned held relation pressure from Waves A through F and found no
   additional direct object dependency;
 - confirmed accepted relation repairs are represented in generated relation

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/selector-relation-residual-cross-wave-scan.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/selector-relation-residual-cross-wave-scan.md
@@ -8,8 +8,8 @@ Temporary plan:
 Prior wave:
 [Selector Relation Wave F Capability Media History Review](selector-relation-wave-f-capability-media-history-review.md)
 
-Status: Phase 14 residual singleton and cross-wave scan, no accepted direct
-relation repair.
+Status: Phase 14 residual singleton, low-density proof shelf, and cross-wave
+scan, no accepted direct relation repair.
 
 ## Verdict
 
@@ -22,6 +22,13 @@ for this pass. `AOA-T-0065 mcp-gateway-proxy` should keep
 discipline, but it does not require the exact one-command lifecycle technique
 as its producer or prerequisite.
 
+The late addendum over `proof/review-evidence` is also relation-clean.
+`AOA-T-0105`, `AOA-T-0106`, and `AOA-T-0107` form one bounded review-evidence
+neighborhood, but they remain separate one-use atoms: request one missing
+object, offer one scoped reference, or challenge one claim locus. Strengthening
+their current `complements` edges into `requires` would falsely turn the shelf
+into a sequence.
+
 The held relation candidates from Waves A through F still sort into stable
 hold classes: optional input, equivalent upstream evidence, sibling-owner
 boundary, selector adjacency, or future vocabulary pressure. No held candidate
@@ -32,7 +39,7 @@ behavior, status movement, path movement, or empirical small-agent proof.
 
 ## Sources Read
 
-Residual singleton:
+Residual singleton and low-density shelf:
 
 - [AOA-T-0065 mcp-gateway-proxy](../../../../../techniques/tool-use/tool-gateway/mcp-gateway-proxy/TECHNIQUE.md)
 - [AOA-T-0065 checklist](../../../../../techniques/tool-use/tool-gateway/mcp-gateway-proxy/checks/mcp-gateway-proxy-checklist.md)
@@ -40,6 +47,24 @@ Residual singleton:
 - [Tool-use route card](../../../../../techniques/tool-use/AGENTS.md)
 - [Tool-Gateway Direct-Read Singleton Review](tool-gateway-direct-read-singleton-review.md)
 - [Landed Tool-Gateway Pilot Review](landed-tool-gateway-pilot-review.md)
+- [AOA-T-0105 single-missing-evidence-request](../../../../../techniques/proof/review-evidence/single-missing-evidence-request/TECHNIQUE.md)
+- [AOA-T-0105 checklist](../../../../../techniques/proof/review-evidence/single-missing-evidence-request/checks/single-missing-evidence-request-checklist.md)
+- [AOA-T-0105 example](../../../../../techniques/proof/review-evidence/single-missing-evidence-request/examples/minimal-single-missing-evidence-request.md)
+- [AOA-T-0105 origin evidence](../../../../../techniques/proof/review-evidence/single-missing-evidence-request/notes/origin-evidence.md)
+- [AOA-T-0105 canonical readiness](../../../../../techniques/proof/review-evidence/single-missing-evidence-request/notes/canonical-readiness.md)
+- [AOA-T-0106 single-scoped-evidence-reference](../../../../../techniques/proof/review-evidence/single-scoped-evidence-reference/TECHNIQUE.md)
+- [AOA-T-0106 checklist](../../../../../techniques/proof/review-evidence/single-scoped-evidence-reference/checks/single-scoped-evidence-reference-checklist.md)
+- [AOA-T-0106 example](../../../../../techniques/proof/review-evidence/single-scoped-evidence-reference/examples/minimal-single-scoped-evidence-reference.md)
+- [AOA-T-0106 origin evidence](../../../../../techniques/proof/review-evidence/single-scoped-evidence-reference/notes/origin-evidence.md)
+- [AOA-T-0106 canonical readiness](../../../../../techniques/proof/review-evidence/single-scoped-evidence-reference/notes/canonical-readiness.md)
+- [AOA-T-0107 single-locus-claim-challenge](../../../../../techniques/proof/review-evidence/single-locus-claim-challenge/TECHNIQUE.md)
+- [AOA-T-0107 checklist](../../../../../techniques/proof/review-evidence/single-locus-claim-challenge/checks/single-locus-claim-challenge-checklist.md)
+- [AOA-T-0107 example](../../../../../techniques/proof/review-evidence/single-locus-claim-challenge/examples/minimal-single-locus-claim-challenge.md)
+- [AOA-T-0107 origin evidence](../../../../../techniques/proof/review-evidence/single-locus-claim-challenge/notes/origin-evidence.md)
+- [AOA-T-0107 canonical readiness](../../../../../techniques/proof/review-evidence/single-locus-claim-challenge/notes/canonical-readiness.md)
+- [Proof route card](../../../../../techniques/proof/AGENTS.md)
+- [Review-Evidence Direct-Read Migration Review](review-evidence-direct-read-migration-review.md)
+- [Landed Review-Evidence Pilot Review](landed-review-evidence-pilot-review.md)
 
 Selector/relation wave packets and repair packets:
 
@@ -69,6 +94,18 @@ No singleton repair is needed. The current edge points to the closest
 runtime-adjacent neighbor without pretending local start/stop discipline is a
 strict prerequisite for every gateway proxy seam.
 
+## Low-Density Review-Evidence Read
+
+| technique | current relation | verdict | reason |
+|---|---|---|---|
+| `AOA-T-0105` | `complements AOA-T-0081`, `complements AOA-T-0032` | keep | one missing-evidence request can happen before diagnosis or CI context reporting; it names one absent object without requiring either adjacent proof surface |
+| `AOA-T-0106` | `complements AOA-T-0105`, `complements AOA-T-0043`, `complements AOA-T-0034` | keep | one scoped reference can be offered without a prior missing-evidence request, multi-source provenance split, or sanitization transform |
+| `AOA-T-0107` | `complements AOA-T-0105`, `complements AOA-T-0106`, `complements AOA-T-0081` | keep | one claim challenge can ask for support or use a reference, but it does not require the exact request, reference, or diagnosis leaves |
+
+No review-evidence repair is needed. The shelf is coherent because the three
+leaves share one bounded review-evidence posture, not because they must execute
+in a fixed order.
+
 ## Accepted Repair Parity
 
 | source | accepted relation | generated parity |
@@ -88,9 +125,9 @@ The scan found no accepted repair missing from generated relation consumers.
 | class | examples | residual verdict |
 |---|---|---|
 | optional or equivalent upstream evidence | `AOA-T-0044 requires AOA-T-0026`, `AOA-T-0077 requires AOA-T-0075`, `AOA-T-0104 requires AOA-T-0103` | keep held; the needed object can come from equivalent reviewed evidence |
-| useful planning or sequencing neighbor | `AOA-T-0049 requires AOA-T-0055`, `AOA-T-0055 requires AOA-T-0001`, `AOA-T-0087 requires AOA-T-0086` | keep held; sequence pressure is not a strict object dependency |
+| useful planning or sequencing neighbor | `AOA-T-0049 requires AOA-T-0055`, `AOA-T-0055 requires AOA-T-0001`, `AOA-T-0087 requires AOA-T-0086`, `AOA-T-0106 requires AOA-T-0105`, `AOA-T-0107 requires AOA-T-0106` | keep held; sequence pressure is not a strict object dependency |
 | sibling-owner boundary | `AOA-T-0093 requires AOA-T-0042`, `AOA-T-0065 requires AOA-T-0038`, lifecycle and runtime-adjacent pressures | keep held; do not import installer, runtime, routing, memory, proof, or product authority |
-| contract-adjacent but not same contract | `AOA-T-0015 shares_contract_with AOA-T-0017`, `AOA-T-0034` relation to approval evidence | keep held; adding edges would make selector noise rather than clarify execution |
+| contract-adjacent but not same contract | `AOA-T-0015 shares_contract_with AOA-T-0017`, `AOA-T-0034` relation to approval evidence, `AOA-T-0105 requires AOA-T-0081` | keep held; adding edges would make selector noise rather than clarify execution |
 | future vocabulary pressure | `follows`, `precedes`, `produces`, `consumes`, lifecycle, receipt-chain, or indexing edges | keep held; no new relation vocabulary is authorized in this long pass |
 
 ## No-Repair Decisions
@@ -105,7 +142,8 @@ The scan found no accepted repair missing from generated relation consumers.
 
 ## What Changed
 
-- added this residual scan packet;
+- updated this residual scan packet with the late `proof/review-evidence`
+  addendum;
 - closed Phase 14 with an explicit no-repair verdict;
 - confirmed accepted relation repairs are represented in generated relation
   consumers;


### PR DESCRIPTION
## Summary
- add the missed proof/review-evidence residual addendum to the selector/relation Phase 14 packet
- record that AOA-T-0105, AOA-T-0106, and AOA-T-0107 keep complement relations because the shelf contains separate one-use atoms, not a fixed sequence
- update the ingress README, temporary long-pass plan, and changelog so Phase 15 closeout starts from complete coverage

## Verification
- git diff --check
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- public-safety grep over the tracked diff found no matches
- aoa checkpoint review-note /srv/AbyssOS/aoa-techniques --commit-ref 20b7bf12f2cd31351b5157e34b0be5b9b2baf57a --auto --root /srv/AbyssOS

## Risk
No technique frontmatter, generated surfaces, relation schema, path placement, or status changed. The addendum only repairs review memory and route summaries before final closeout.