### PR TITLE
Close selector relation long pass ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- closed Phase 15 of the selector/relation long pass with a durable ledger
+  covering all `28` shelves and `107` current bundles, `103` selector prompts
+  or selector scenarios, `7` accepted direct relation repairs, explicit hold
+  classes, generated rebuild posture, validation rhythm, and Phase 16
+  temporary-plan disposition
 - continued the selector/relation long pass with the residual singleton,
   `proof/review-evidence` addendum, and cross-wave scan, keeping
   `AOA-T-0065 complements AOA-T-0038` plus the current review-evidence

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -346,6 +346,10 @@ permission slip to remap techniques automatically.
   `proof/review-evidence`, and held candidates from Waves A through F, keeping
   `AOA-T-0065 complements AOA-T-0038` plus the current review-evidence
   complement edges and recording an explicit no-repair verdict before closeout
+- selector/relation closeout ledger: landed with coverage for all `28`
+  shelves and all `107` current bundles, `103` selector prompts or selector
+  scenarios, `7` accepted direct relation repairs, and Phase 16 temporary-plan
+  disposition queued
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
 
@@ -476,6 +480,7 @@ permission slip to remap techniques automatically.
 | [Selector Relation Wave F Capability Media History Review](reviews/selector-relation-wave-f-capability-media-history-review.md) | tests selector prompts and relation posture over capability-registry, capability-boundary, skill-discovery, media-ingest, and history-artifacts shelves | relation schema migration, new relation types, registry product doctrine, installer behavior, media platform ownership, memory truth, status/domain/kind/path changes, or model proof |
 | [Capability Media Direct Relation Repair](reviews/capability-media-direct-relation-repair.md) | accepts `AOA-T-0064 requires AOA-T-0063` and `AOA-T-0071 requires AOA-T-0070` from direct object contracts | `requires AOA-T-0025`, `requires AOA-T-0041`, `requires AOA-T-0070` for media bucketing, strengthened history artifact chains, relation schema migration, product doctrine, status/domain/kind/path changes, or model proof |
 | [Selector Relation Residual Cross-Wave Scan](reviews/selector-relation-residual-cross-wave-scan.md) | closes the residual singleton, low-density review-evidence shelf, and cross-wave relation scan with no additional source relation repair | relation schema migration, new relation types, `AOA-T-0065 requires AOA-T-0038`, review-evidence sequence edges, generated hand edits, status/domain/kind/path changes, or model proof |
+| [Selector Relation Long-Pass Closeout Ledger](reviews/selector-relation-long-pass-closeout-ledger.md) | closes Phase 15 with full current-corpus selector/relation coverage, accepted repair counts, held relation classes, generated rebuild posture, validation menu, and future schema/eval routes | temporary-plan removal, schema migration, new relation types, scout-axis frontmatter, generated hand edits, status/domain/kind/path changes, sibling-owner authority, or model proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -607,11 +612,19 @@ current review-evidence complement edges as non-sequential atoms, confirms
 generated relation parity for all accepted repairs, and records no additional
 relation repair.
 
-Next clean move: continue the long selector/relation pass with Phase 15:
-final closeout ledger. Count coverage, accepted repairs, holds, generated
-rebuilds, validations, and future schema-pressure threads. Do not restart a
-broad audit, do not add future relation names such as `follows`, do not promote
-scout axes into frontmatter without a separate decision and validator wave,
+Current latest selector/relation closeout: Phase 15 is closed by the
+selector/relation long-pass closeout ledger. It records full current-corpus
+coverage over `28` shelves and `107` bundles, `103` selector prompts or
+selector scenarios, `7` accepted direct relation repairs, explicit relation
+hold classes, generated rebuild posture, validation menu, and future
+schema/eval routes.
+
+Next clean move: continue the long selector/relation pass with Phase 16:
+temporary plan disposition. Confirm the closeout ledger is linked from route
+surfaces, remove `TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md`, and land that
+removal as its own durable wave. Do not restart a broad audit, do not add
+future relation names such as `follows`, do not promote scout axes into
+frontmatter without a separate decision and validator wave,
 and do not run local small-agent proof without an `aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md
@@ -189,7 +189,7 @@ Use statuses: `pending`, `active`, `blocked`, `landed`, `distilled`.
 | 12 Wave F selector/relation review | landed | [selector-relation-wave-f-capability-media-history-review](reviews/selector-relation-wave-f-capability-media-history-review.md) |
 | 13 Wave F repair gate | landed | [capability-media-direct-relation-repair](reviews/capability-media-direct-relation-repair.md) |
 | 14 residual singleton and cross-wave scan | landed | [selector-relation-residual-cross-wave-scan](reviews/selector-relation-residual-cross-wave-scan.md) |
-| 15 closeout ledger | pending | final selector/relation closeout |
+| 15 closeout ledger | landed | [selector-relation-long-pass-closeout-ledger](reviews/selector-relation-long-pass-closeout-ledger.md) |
 | 16 temporary plan disposition | pending | this file removed after distillation |
 
 ## Phase 00: Plan Seed
@@ -579,6 +579,19 @@ Steps:
 
 Exit condition: durable review surfaces explain the long pass without needing
 this temporary plan.
+
+Landed result:
+
+- wrote the final selector/relation closeout ledger with coverage for all `28`
+  shelves and all `107` current bundles;
+- counted `103` selector prompts or selector scenarios and `7` accepted direct
+  relation repairs;
+- preserved the relation holds, generated rebuild posture, validation menu,
+  future schema-pressure threads, and eval-owner route without changing
+  schema, paths, status, `domain`, `kind`, relation vocabulary, or scout-axis
+  frontmatter;
+- left this temporary plan in place for Phase 16 removal after the durable
+  ledger is linked from route surfaces.
 
 ## Phase 16: Temporary Plan Disposition
 

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -107,5 +107,6 @@ Current reviews:
 - [selector-relation-wave-f-capability-media-history-review](selector-relation-wave-f-capability-media-history-review.md)
 - [capability-media-direct-relation-repair](capability-media-direct-relation-repair.md)
 - [selector-relation-residual-cross-wave-scan](selector-relation-residual-cross-wave-scan.md)
+- [selector-relation-long-pass-closeout-ledger](selector-relation-long-pass-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/selector-relation-long-pass-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/selector-relation-long-pass-closeout-ledger.md
@@ -1,0 +1,218 @@
+# Selector Relation Long-Pass Closeout Ledger
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Temporary plan:
+[Temporary Selector Relation Long-Pass Plan](../TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md)
+
+Residual scan:
+[Selector Relation Residual Cross-Wave Scan](selector-relation-residual-cross-wave-scan.md)
+
+Status: Phase 15 closeout ledger, not schema migration, not frontmatter
+promotion, not relation vocabulary expansion, not empirical model proof.
+
+## Verdict
+
+Close the selector/relation long pass as durable review memory.
+
+The pass now covers all `28` current shelves and all `107` current technique
+bundles. It wrote `103` selector prompts or selector scenarios, accepted `7`
+direct relation repairs, and held the rest as adjacency, optional upstream
+evidence, equivalent source-contract evidence, sibling-owner boundary, future
+vocabulary pressure, or eval-owner work.
+
+The final posture is deliberately conservative. The long pass improved
+selection and relation topology without adding schema fields, new relation
+types, generated graph behavior, path changes, status changes, `domain` or
+`kind` changes, scout-axis frontmatter, canonical promotions, or model-proof
+claims.
+
+## Sources Read
+
+- [Topology Selector Handoff-Continuation Mini-Pilot](topology-selector-handoff-continuation-mini-pilot.md)
+- [Handoff-Continuation Direct Relation Repair](handoff-continuation-direct-relation-repair.md)
+- [Selector Relation Wave A Proof Execution Review](selector-relation-wave-a-proof-execution-review.md)
+- [Ready-Work-Graphs Direct Relation Repair](ready-work-graphs-direct-relation-repair.md)
+- [Selector Relation Wave B Instruction Knowledge Review](selector-relation-wave-b-instruction-knowledge-review.md)
+- [Selector Relation Wave C Execution Owner Review](selector-relation-wave-c-execution-owner-review.md)
+- [Selector Relation Wave D Governance Split Review](selector-relation-wave-d-governance-split-review.md)
+- [Practice-Adoption-Lifecycle Direct Relation Repair](practice-adoption-lifecycle-direct-relation-repair.md)
+- [Selector Relation Wave E Continuity Recovery Review](selector-relation-wave-e-continuity-recovery-review.md)
+- [Diagnosis-Repair Direct Relation Repair](diagnosis-repair-direct-relation-repair.md)
+- [Selector Relation Wave F Capability Media History Review](selector-relation-wave-f-capability-media-history-review.md)
+- [Capability Media Direct Relation Repair](capability-media-direct-relation-repair.md)
+- [Selector Relation Residual Cross-Wave Scan](selector-relation-residual-cross-wave-scan.md)
+- [Technique Selection](../../../../../docs/TECHNIQUE_SELECTION.md)
+- [Technique Catalog](../../../../../generated/technique_catalog.json)
+- current technique tree under `techniques/`
+
+## Coverage Ledger
+
+| slice | shelves | bundles | selector rows | accepted repairs | result |
+|---|---:|---:|---:|---:|---|
+| handoff-continuation precursor | 1 | 7 | 7 | 2 | selector pilot plus direct relation repair |
+| Wave A proof and execution | 4 | 12 | 12 | 1 | one ready-work dependency repair |
+| Wave B instruction and knowledge | 4 | 22 | 22 | 0 | no-repair relation hold |
+| Wave C execution and owner truth | 4 | 16 | 16 | 0 | no-repair relation hold |
+| Wave D governance split | 4 | 12 | 12 | 1 | one practice-adoption pairing repair |
+| Wave E continuity and recovery | 4 | 15 | 15 | 1 | one diagnosis-repair dependency repair |
+| Wave F capability, media, and history | 5 | 19 | 19 | 2 | two direct object-dependency repairs |
+| Phase 14 residual singleton and low-density proof shelf | 2 | 4 | 0 | 0 | no-repair residual scan |
+| total | 28 | 107 | 103 | 7 | full current corpus coverage |
+
+The `107` reviewed IDs match the current `107` `TECHNIQUE.md` bundles. The
+long pass therefore closes as full-corpus selector/relation review coverage
+for the current tree.
+
+## Accepted Relation Repairs
+
+| source | old edge | accepted edge | why |
+|---|---|---|---|
+| handoff-continuation | `AOA-T-0058 complements AOA-T-0057` | `AOA-T-0058 requires AOA-T-0057` | receipt confirmation needs the existing handoff packet contract |
+| handoff-continuation | `AOA-T-0059 complements AOA-T-0057` | `AOA-T-0059 requires AOA-T-0057` | git-backed claim verification starts from concrete handoff claims |
+| Wave A | `AOA-T-0050 complements AOA-T-0049` | `AOA-T-0050 requires AOA-T-0049` | ready-work queue derivation needs an existing blocker graph |
+| Wave D | no direct edge | `AOA-T-0103 used_together_for AOA-T-0104` | retention review can route to the bounded obsolescence packet without requiring it |
+| Wave E | `AOA-T-0082 complements AOA-T-0081` | `AOA-T-0082 requires AOA-T-0081` | repair-shape selection starts from one reviewed diagnosis packet |
+| Wave F | `AOA-T-0064 complements AOA-T-0063` | `AOA-T-0064 requires AOA-T-0063` | capability discovery operates over already-published local registry entries |
+| Wave F | no direct edge | `AOA-T-0071 requires AOA-T-0070` | template-backed field extraction consumes the structured OCR handoff |
+
+These are the only accepted repairs. Each one uses an existing relation type
+and names a direct local object dependency or bounded operating pair.
+
+## Held Relation Pressure
+
+The pass recorded:
+
+- `48` shelf-level held candidate rows across Waves A through F;
+- `5` residual hold classes in Phase 14;
+- `5` explicit residual no-repair decisions;
+- `26` direct-repair receipt hold rows that preserve local stop-lines and
+  intentionally overlap with the wave-level holds.
+
+The held pressure is not empty work. It is the evidence that the tree now needs
+future composition language, but not as a hidden mutation inside this pass.
+
+Primary hold classes:
+
+- optional or equivalent upstream evidence;
+- useful planning or sequencing neighbor;
+- sibling-owner boundary;
+- contract-adjacent but not same contract;
+- future vocabulary pressure.
+
+## Selector Lessons
+
+- `domain` and `kind` still work as current frontmatter truth, but they are not
+  enough to select one leaf inside dense shelves.
+- The tree path and shelf name are useful first-stage navigation, not
+  replacement frontmatter.
+- Selector prompts are the most honest pressure test for whether a bundle can
+  be picked after the shelf is known.
+- `capability_class`, `substrate`, `execution_profile`, and `risk_posture`
+  are useful review axes, but they remain scout/design axes until a separate
+  schema and validator decision exists.
+- Static selector review can show whether a technique is shaped for small
+  agents, but it cannot prove execution by a 2-4B model. That proof still
+  routes to `aoa-evals`.
+
+## Relation Lessons
+
+- `requires` should stay reserved for exact local object or contract
+  dependency.
+- `complements` is correct when two techniques strengthen each other but can
+  start from equivalent evidence or operate independently.
+- `used_together_for` is useful for a common operating pair that should not be
+  overclaimed as a prerequisite chain.
+- `shares_contract_with` should not become a generic "nearby" edge.
+- Sequence, lifecycle, producer-consumer, and receipt-chain pressure exists,
+  but adding that vocabulary needs a later relation-contract decision and
+  validator wave.
+
+## Generated And Validation Ledger
+
+Full release checks rebuilt the standard generated builder families during the
+durable relation-repair waves:
+
+- repo-doc surface manifest;
+- technique catalog;
+- kind manifest;
+- topology scout;
+- tree projection;
+- capsules;
+- full sections;
+- section manifest;
+- checklist manifest;
+- example manifest;
+- evidence-note manifest;
+- GitHub review template manifest;
+- semantic review manifest;
+- shadow review manifest;
+- promotion readiness;
+- source-owned KAG export.
+
+Generated outputs were treated as consumers, not authority. They were rebuilt
+from source whenever relation frontmatter changed, and no generated hand edit
+was accepted.
+
+Validation across the pass used the same bounded menu repeatedly:
+
+- `git diff --check`;
+- `python -m unittest tests.test_distillation_mechanics_topology`;
+- `python scripts/validate_repo.py`;
+- `python scripts/release_check.py`;
+- public-safety grep on public-share diffs before publishing review surfaces.
+
+The final residual addendum also passed checkpoint review after commit.
+
+## Future Threads
+
+Future relation vocabulary pressure:
+
+- sequence language such as `follows` or `precedes`;
+- producer-consumer language such as `produces` or `consumes`;
+- lifecycle or receipt-chain language where current edges understate order
+  without proving strict dependency.
+
+Future selector pressure:
+
+- preserve selector prompts as review evidence;
+- add generated selector rationale only through a schema/validator decision;
+- avoid frontmatter expansion until the axis proves durable across more than
+  one reform lane.
+
+Future eval-owner route:
+
+- model execution proof for 2-4B agents belongs in `aoa-evals`;
+- `aoa-techniques` can prepare fixtures, checklists, and small-agent shape,
+  but should not claim empirical pass/fail evidence from static review.
+
+Future bundle-local repair:
+
+- repair individual bundle wording only when a selector prompt exposes a real
+  pick-and-execute failure;
+- do not run broad template modernization as cosmetic cleanup;
+- keep relation rationale in review packets until a relation-rationale schema
+  exists.
+
+## Unauthorized Changes Not Made
+
+- no relation schema migration;
+- no new relation type;
+- no generated graph traversal, scoring, ranking, or relation rationale field;
+- no technique path movement;
+- no `domain`, `kind`, status, maturity, evidence, owner, or canonical
+  promotion change;
+- no `family`, `capability_class`, `substrate`, `execution_profile`,
+  `risk_posture`, or `tree_path` frontmatter;
+- no sibling-owner authority import from skills, evals, routing, memory,
+  runtime, KAG, playbooks, agents, stats, or the AoA center;
+- no empirical small-agent proof claim.
+
+## Next Honest Move
+
+Run Phase 16: temporary plan disposition.
+
+Before removing
+`mechanics/distillation/parts/technique-reform-ingress/TEMP_SELECTOR_RELATION_LONG_PASS_PLAN.md`,
+confirm this ledger is linked from the ingress README and reviews index, then
+delete the temporary plan and land that removal as its own durable wave.


### PR DESCRIPTION
## Summary
- add the Phase 15 selector/relation long-pass closeout ledger
- record full current-corpus coverage: 28 shelves, 107 bundles, 103 selector prompts/scenarios, and 7 accepted direct relation repairs
- update technique-reform ingress route surfaces, reviews index, temporary plan stage log, and changelog so Phase 16 can remove the scratch plan cleanly

## Verification
- git diff --check
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py
- public-safety grep over tracked diff and the new ledger found no matches
- aoa checkpoint review-note /srv/AbyssOS/aoa-techniques --commit-ref b1782541ba51a137766ecd22d3dca419bcc58799 --auto --root /srv/AbyssOS

## Risk
No technique frontmatter, relation source, generated hand edit, relation schema, path, status, domain, kind, or model-proof claim changed. This PR only lands the durable closeout memory before the temporary plan disposition wave.