### PR TITLE
Review handoff portability bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- started the portability bridge reform lane with a
+  `continuity/handoff-continuation` mini-pilot, confirming all seven handoff
+  leaves are standalone-portable with ordinary external adapter surfaces and
+  recording the repeatable rhythm for the future portability long pass without
+  source rewrites, schema migration, OS Abyss adapter authority, or empirical
+  model proof
 - removed the retired selector/relation temporary long-pass plan after the
   Phase 15 closeout ledger became the durable resume surface
 - closed Phase 15 of the selector/relation long pass with a durable ledger

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -481,6 +481,7 @@ permission slip to remap techniques automatically.
 | [Capability Media Direct Relation Repair](reviews/capability-media-direct-relation-repair.md) | accepts `AOA-T-0064 requires AOA-T-0063` and `AOA-T-0071 requires AOA-T-0070` from direct object contracts | `requires AOA-T-0025`, `requires AOA-T-0041`, `requires AOA-T-0070` for media bucketing, strengthened history artifact chains, relation schema migration, product doctrine, status/domain/kind/path changes, or model proof |
 | [Selector Relation Residual Cross-Wave Scan](reviews/selector-relation-residual-cross-wave-scan.md) | closes the residual singleton, low-density review-evidence shelf, and cross-wave relation scan with no additional source relation repair | relation schema migration, new relation types, `AOA-T-0065 requires AOA-T-0038`, review-evidence sequence edges, generated hand edits, status/domain/kind/path changes, or model proof |
 | [Selector Relation Long-Pass Closeout Ledger](reviews/selector-relation-long-pass-closeout-ledger.md) | closes Phase 15 with full current-corpus selector/relation coverage, accepted repair counts, held relation classes, generated rebuild posture, validation menu, and future schema/eval routes | temporary-plan removal, schema migration, new relation types, scout-axis frontmatter, generated hand edits, status/domain/kind/path changes, sibling-owner authority, or model proof |
+| [Portability Bridge Handoff-Continuation Mini-Pilot](reviews/portability-bridge-handoff-continuation-mini-pilot.md) | calibrates the first portability bridge rhythm over `continuity/handoff-continuation`, confirming all seven leaves are standalone-portable with ordinary external adapter surfaces | source rewrite, schema migration, a generic portability frontmatter axis, OS Abyss adapter authority, sibling-owner route, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -619,13 +620,24 @@ temporary plan. The durable ledger records full current-corpus coverage over
 `7` accepted direct relation repairs, explicit relation hold classes,
 generated rebuild posture, validation menu, and future schema/eval routes.
 
-Next clean move: leave the selector/relation long pass closed and choose the
-next technique reform lane from the durable closeout threads: relation
-vocabulary, selector-rationale schema, eval-owner small-agent proof, or
-targeted bundle-local repair. Do not restart a broad audit, do not add future
-relation names such as `follows`, do not promote scout axes into frontmatter
-without a separate decision and validator wave, and do not run local
-small-agent proof without an `aoa-evals` proof surface.
+Current latest portability bridge mini-pilot:
+`continuity/handoff-continuation` is closed as the first portability rhythm
+check. It confirmed that `AOA-T-0056` through `AOA-T-0062` are
+standalone-portable when an external adopter supplies ordinary adapter
+surfaces: channel storage, handoff artifact, receipt surface, git evidence,
+start-context surface, repo list, or checkpoint artifact. No bundle source
+repair, schema migration, OS Abyss adapter, or empirical model proof was
+accepted.
+
+Next clean move: leave the selector/relation long pass closed and use the
+portability bridge mini-pilot to write the next long-pass rhythm before
+touching more shelves. Start the first portability wave from high-pressure
+portable shelves such as `history/history-artifacts`, `ingest/media-ingest`,
+`continuity/donor-harvest`, and `recovery/antifragility-recovery`. Do not
+restart a broad audit, do not add future relation names such as `follows`, do
+not promote scout axes into frontmatter without a separate decision and
+validator wave, and do not run local small-agent proof without an `aoa-evals`
+proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -108,5 +108,6 @@ Current reviews:
 - [capability-media-direct-relation-repair](capability-media-direct-relation-repair.md)
 - [selector-relation-residual-cross-wave-scan](selector-relation-residual-cross-wave-scan.md)
 - [selector-relation-long-pass-closeout-ledger](selector-relation-long-pass-closeout-ledger.md)
+- [portability-bridge-handoff-continuation-mini-pilot](portability-bridge-handoff-continuation-mini-pilot.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-handoff-continuation-mini-pilot.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-handoff-continuation-mini-pilot.md
@@ -1,0 +1,151 @@
+# Portability Bridge Handoff-Continuation Mini-Pilot
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Prior shelf reviews:
+[Handoff-Continuation Direct-Read Migration Review](handoff-continuation-direct-read-migration-review.md),
+[Landed Handoff-Continuation Pilot Review](landed-handoff-continuation-pilot-review.md),
+[Topology Selector Handoff-Continuation Mini-Pilot](topology-selector-handoff-continuation-mini-pilot.md),
+[Relations Composition Handoff-Continuation Pilot](relations-composition-handoff-continuation-pilot.md),
+[Handoff-Continuation Direct Relation Repair](handoff-continuation-direct-relation-repair.md)
+
+Status: targeted portability bridge mini-pilot, not source rewrite, not schema
+migration, not OS Abyss adapter, not empirical small-agent proof.
+
+## Verdict
+
+The `continuity/handoff-continuation` shelf is a good first portability bridge
+pilot because it carries real AoA-shaped pressure without needing AoA as a
+runtime dependency. All seven leaves can be taken by an outside user when the
+orchestrator supplies ordinary local equivalents: a channel, a handoff artifact,
+a visible receipt surface, git evidence, a start-context surface, a repo list,
+or an episode checkpoint.
+
+No technique bundle needs repair in this mini-pilot. The current text already
+keeps the portable atom separate from donor-system details. Project-shaped
+references remain acceptable when they are provenance, relation IDs, examples,
+or cautions. They would become defects only if a technique required OS Abyss,
+Agents-of-Abyss doctrine, hidden memory, routing, KAG, evals, skills, runtime
+services, or a specific agent platform to execute the atomic move.
+
+This establishes the rhythm for the future portability long pass: direct-read a
+shelf, name the generic adapter surfaces an external adopter must supply, check
+for hidden system dependencies, and patch technique source only when standalone
+execution is actually blocked.
+
+## Sources Read
+
+- [AOA-T-0056 channelized-agent-mailbox](../../../../../techniques/continuity/handoff-continuation/channelized-agent-mailbox/TECHNIQUE.md)
+- [AOA-T-0057 structured-handoff-before-compaction](../../../../../techniques/continuity/handoff-continuation/structured-handoff-before-compaction/TECHNIQUE.md)
+- [AOA-T-0058 receipt-confirmed-handoff-packet](../../../../../techniques/continuity/handoff-continuation/receipt-confirmed-handoff-packet/TECHNIQUE.md)
+- [AOA-T-0059 git-verified-handoff-claims](../../../../../techniques/continuity/handoff-continuation/git-verified-handoff-claims/TECHNIQUE.md)
+- [AOA-T-0060 session-opening-ritual-before-work](../../../../../techniques/continuity/handoff-continuation/session-opening-ritual-before-work/TECHNIQUE.md)
+- [AOA-T-0061 cross-repo-resource-map-bootstrap](../../../../../techniques/continuity/handoff-continuation/cross-repo-resource-map-bootstrap/TECHNIQUE.md)
+- [AOA-T-0062 episode-bounded-agent-loop](../../../../../techniques/continuity/handoff-continuation/episode-bounded-agent-loop/TECHNIQUE.md)
+- repo and nested `AGENTS.md` route cards for `aoa-techniques`, mechanics,
+  Distillation technique-reform ingress, and continuity techniques
+- supporting `checks/`, `examples/`, and `notes/` files for the seven bundles
+- [Bundle Anatomy Corpus Synthesis](bundle-anatomy-corpus-synthesis.md)
+- [Execution Profile Truth Boundary Pilot](execution-profile-truth-boundary-pilot.md)
+- [Selector Relation Long-Pass Closeout Ledger](selector-relation-long-pass-closeout-ledger.md)
+
+## Portability Read
+
+| technique | external adopter can take | adapter context needed | hidden dependency verdict |
+|---|---|---|---|
+| `AOA-T-0056` `channelized-agent-mailbox` | a durable named message channel with replay and explicit ack | storage for ordered messages, replay cursor, and ack state | portable-ready; no donor `.acomm`, MCP, SDK, or messaging platform required |
+| `AOA-T-0057` `structured-handoff-before-compaction` | one pre-boundary handoff packet before context loss | artifact location plus completed, blocked, next, and reference fields | portable-ready; no OS Abyss memory, compactor, or agent runtime required |
+| `AOA-T-0058` `receipt-confirmed-handoff-packet` | explicit receiver acceptance before continuation | existing packet, receiver identity, and visible receipt surface | portable-ready; receipt is not tied to a chat system or task tracker |
+| `AOA-T-0059` `git-verified-handoff-claims` | git-backed trust check over handoff claims | local repo state, diff, commit, or file anchors to verify | portable-ready for git-backed work; do not use when no version-control evidence exists |
+| `AOA-T-0060` `session-opening-ritual-before-work` | resumed-session baseline read before first mutation | current task context plus a visible state check such as branch, files, or worktree | portable-ready; no Nightcrawler, AoA state file, or launch ritual required |
+| `AOA-T-0061` `cross-repo-resource-map-bootstrap` | task-bounded first-look map across several repos | repo names, owner hints, relevant paths, and first-read notes | portable-ready; not a Code Relay resource map or workspace encyclopedia |
+| `AOA-T-0062` `episode-bounded-agent-loop` | long work segmented into checkpoints and continue/stop/escalate decisions | episode goal, checkpoint artifact, stop rule, and escalation target | portable-ready; not runtime supervision, budget law, or autonomous platform control |
+
+## Boundary Read
+
+Acceptable local references:
+
+- `AOA-T-*` relation IDs and bundle identifiers;
+- `8Dionysus` or AoA provenance where it explains where the technique came
+  from;
+- project-shaped examples that are clearly examples, not required substrate;
+- cautions that prevent hidden runtime, memory, routing, eval, or skill
+  authority from being smuggled into technique meaning.
+
+Not acceptable as mandatory execution context:
+
+- OS Abyss deployment, workspace bootstrap, or AoA constitutional authority;
+- hidden memory, KAG truth, routing policy, playbook choreography, or eval
+  verdicts;
+- Nightcrawler, Code Relay, AgenticComm, AGOR, aX, launchd, or any other donor
+  runtime service;
+- a sibling repo becoming owner of the technique atom before the technique is
+  explicitly routed there.
+
+This shelf currently stays on the acceptable side. Its AoA-shaped language is
+mostly lineage, relation, or example context. The portable atom remains the
+local move an external system can adapt.
+
+## Repair Gate
+
+No bundle-local repair is accepted by this mini-pilot.
+
+Held, not defects:
+
+| hold | why it stays held |
+|---|---|
+| standard adapter card | useful if the long pass finds repeated external-adopter confusion, but not justified from one shelf |
+| bundle source wording | current seven leaves already separate invariant move from project-shaped detail |
+| empirical small-agent proof | belongs to a later eval-owned harness, not a portability review packet |
+| generated scout updates | no source input changed and no generated portability field exists |
+
+## Repeatable Portability Rhythm
+
+Use this rhythm for the future portability long pass:
+
+1. choose one shelf with real `portability-watch` pressure;
+2. read its route cards, all leaf `TECHNIQUE.md` files, and supporting
+   `checks/`, `examples/`, and `notes/`;
+3. read prior migration, bundle-anatomy, selector, relation, and closeout
+   packets for that shelf;
+4. for each leaf, name the external-adopter object, the adapter context needed,
+   and the hidden dependency test;
+5. separate acceptable provenance and examples from mandatory donor-system
+   dependencies;
+6. patch source only when the atom cannot be executed outside OS Abyss;
+7. record held owner routes without importing skill, eval, routing, memory,
+   runtime, or playbook authority;
+8. update the reform ingress index and run the narrow mechanics validation;
+9. commit, push, PR, wait for repo validation, merge, and return to clean
+   `main`.
+
+## Stop Lines
+
+- Do not remove AoA provenance merely to look generic.
+- Do not add a loud bridge block to every technique.
+- Do not promote a portability axis into frontmatter from this packet.
+- Do not claim empirical 2-4B execution proof.
+- Do not route technique meaning to `aoa-skills`, `aoa-evals`, `aoa-routing`,
+  `aoa-memo`, `aoa-kag`, `aoa-playbooks`, or runtime owners from review
+  pressure alone.
+- Do not convert examples into mandatory platform requirements.
+
+## Next Honest Move
+
+Create the portability long-pass rhythm plan from this packet, then start with
+the highest-pressure shelves rather than all `portability-watch` rows at once.
+Good first wave candidates are `history/history-artifacts`,
+`ingest/media-ingest`, `continuity/donor-harvest`, and
+`recovery/antifragility-recovery`, because each has portable technique value
+plus visible risk of being mistaken for memory, media-platform, donor-harvest,
+or runtime doctrine.
+
+## Validation
+
+Passed locally:
+
+1. `git diff --check`
+2. public-share grep over the changed review surfaces
+3. `python -m unittest tests.test_distillation_mechanics_topology`
+4. `python scripts/validate_repo.py`
+5. `python scripts/release_check.py`


### PR DESCRIPTION
## Summary
- add a portability bridge mini-pilot review packet for continuity/handoff-continuation
- record external adapter surfaces and hidden dependency boundaries for AOA-T-0056 through AOA-T-0062
- update reform ingress navigation and changelog for the next portability long-pass rhythm

## Validation
- git diff --check
- public-share grep over changed review surfaces
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py