### PR TITLE
Close portability bridge long pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- closed the portability bridge long pass across all `43` `portability-watch`
+  rows with Waves A through C, a residual cross-wave scan, and a closeout
+  ledger, confirming standalone portability without source repairs,
+  route-away moves, schema/frontmatter changes, generated-surface changes, OS
+  Abyss adapter authority, or empirical model proof
 - started the portability bridge reform lane with a
   `continuity/handoff-continuation` mini-pilot, confirming all seven handoff
   leaves are standalone-portable with ordinary external adapter surfaces and

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -352,6 +352,10 @@ permission slip to remap techniques automatically.
   disposition complete
 - Agon handoff proof point: `3` gate-to-bundle routes landed, `8` ungated
   first-narrowing candidates remain in `first_narrowing_frontier`
+- portability bridge long pass: closed all `43` `portability-watch` rows
+  through one mini-pilot plus Waves A through C, accepting no source repairs,
+  no route-away moves, no schema/frontmatter changes, no generated-surface
+  changes, and no empirical model-proof claim
 
 ## Evidence Stack
 
@@ -482,6 +486,11 @@ permission slip to remap techniques automatically.
 | [Selector Relation Residual Cross-Wave Scan](reviews/selector-relation-residual-cross-wave-scan.md) | closes the residual singleton, low-density review-evidence shelf, and cross-wave relation scan with no additional source relation repair | relation schema migration, new relation types, `AOA-T-0065 requires AOA-T-0038`, review-evidence sequence edges, generated hand edits, status/domain/kind/path changes, or model proof |
 | [Selector Relation Long-Pass Closeout Ledger](reviews/selector-relation-long-pass-closeout-ledger.md) | closes Phase 15 with full current-corpus selector/relation coverage, accepted repair counts, held relation classes, generated rebuild posture, validation menu, and future schema/eval routes | temporary-plan removal, schema migration, new relation types, scout-axis frontmatter, generated hand edits, status/domain/kind/path changes, sibling-owner authority, or model proof |
 | [Portability Bridge Handoff-Continuation Mini-Pilot](reviews/portability-bridge-handoff-continuation-mini-pilot.md) | calibrates the first portability bridge rhythm over `continuity/handoff-continuation`, confirming all seven leaves are standalone-portable with ordinary external adapter surfaces | source rewrite, schema migration, a generic portability frontmatter axis, OS Abyss adapter authority, sibling-owner route, or empirical small-agent proof |
+| [Portability Bridge Wave A History Ingest Continuity Recovery Review](reviews/portability-bridge-wave-a-history-ingest-continuity-recovery-review.md) | closes `19` portability-watch rows across history artifacts, media ingest, donor harvest, and antifragility recovery with no source repair | OS Abyss memory, media-platform doctrine, donor-harvest authority, runtime incident doctrine, schema migration, generated-surface change, or empirical model proof |
+| [Portability Bridge Wave B Runtime Recovery Tool-Use Review](reviews/portability-bridge-wave-b-runtime-recovery-tool-use-review.md) | closes `6` runtime, recovery, and tool-use boundary rows while keeping local runtime handles, skill recovery, checkpoint repair, and MCP gateway substrates portable | runtime owner law, platform launcher doctrine, marketplace/install policy, scanner product authority, schema migration, or empirical model proof |
+| [Portability Bridge Wave C Owner Governance Knowledge Review](reviews/portability-bridge-wave-c-owner-governance-knowledge-review.md) | closes `11` source-lift, owner-truth, approval, automation, and promotion rows without importing KAG truth, proof verdicts, skill acceptance, or governance law | KAG substrate ownership, GitHub policy, release automation, live automation, skill activation, sibling-owner consent, or empirical model proof |
+| [Portability Bridge Residual Cross-Wave Scan](reviews/portability-bridge-residual-cross-wave-scan.md) | accounts for all `43` portability-watch rows and records repeated adapter needs as future guide candidates, not current defects | source repair, route-away movement, new portability field, adapter package, or generated catalog authority |
+| [Portability Bridge Long-Pass Closeout Ledger](reviews/portability-bridge-long-pass-closeout-ledger.md) | closes the portability bridge long pass and distills the temporary rhythm into durable review packets and next-lane guidance | small-model execution proof, schema/frontmatter migration, OS Abyss adapter authority, or sibling-owner authority |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -620,24 +629,21 @@ temporary plan. The durable ledger records full current-corpus coverage over
 `7` accepted direct relation repairs, explicit relation hold classes,
 generated rebuild posture, validation menu, and future schema/eval routes.
 
-Current latest portability bridge mini-pilot:
-`continuity/handoff-continuation` is closed as the first portability rhythm
-check. It confirmed that `AOA-T-0056` through `AOA-T-0062` are
-standalone-portable when an external adopter supplies ordinary adapter
-surfaces: channel storage, handoff artifact, receipt surface, git evidence,
-start-context surface, repo list, or checkpoint artifact. No bundle source
-repair, schema migration, OS Abyss adapter, or empirical model proof was
-accepted.
+Current latest portability bridge closeout: the long pass is closed. It
+reviewed all `43` `portability-watch` rows through the handoff-continuation
+mini-pilot plus Waves A through C, accepted no source repairs, no route-away
+moves, no schema/frontmatter changes, no generated-surface changes, and no
+empirical model-proof claim. The residual scan records repeated adapter needs
+as a future lightweight guide candidate, not as a current blocker.
 
-Next clean move: leave the selector/relation long pass closed and use the
-portability bridge mini-pilot to write the next long-pass rhythm before
-touching more shelves. Start the first portability wave from high-pressure
-portable shelves such as `history/history-artifacts`, `ingest/media-ingest`,
-`continuity/donor-harvest`, and `recovery/antifragility-recovery`. Do not
-restart a broad audit, do not add future relation names such as `follows`, do
-not promote scout axes into frontmatter without a separate decision and
-validator wave, and do not run local small-agent proof without an `aoa-evals`
-proof surface.
+Next clean move: leave portability closed and choose the next targeted reform
+lane. Best candidates are one owner-boundary bridge shelf review, one narrow
+template-modernization pilot where execution readability truly improves, or a
+small promotion-evidence cohort after owner-boundary pressure is clearer. Do
+not restart portability as a broad audit, do not add future relation names such
+as `follows`, do not promote scout axes into frontmatter without a separate
+decision and validator wave, and do not run local small-agent proof without an
+`aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -109,5 +109,10 @@ Current reviews:
 - [selector-relation-residual-cross-wave-scan](selector-relation-residual-cross-wave-scan.md)
 - [selector-relation-long-pass-closeout-ledger](selector-relation-long-pass-closeout-ledger.md)
 - [portability-bridge-handoff-continuation-mini-pilot](portability-bridge-handoff-continuation-mini-pilot.md)
+- [portability-bridge-wave-a-history-ingest-continuity-recovery-review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md)
+- [portability-bridge-wave-b-runtime-recovery-tool-use-review](portability-bridge-wave-b-runtime-recovery-tool-use-review.md)
+- [portability-bridge-wave-c-owner-governance-knowledge-review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+- [portability-bridge-residual-cross-wave-scan](portability-bridge-residual-cross-wave-scan.md)
+- [portability-bridge-long-pass-closeout-ledger](portability-bridge-long-pass-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-long-pass-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-long-pass-closeout-ledger.md
@@ -1,0 +1,134 @@
+# Portability Bridge Long-Pass Closeout Ledger
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Closeout stack:
+[Portability Bridge Handoff-Continuation Mini-Pilot](portability-bridge-handoff-continuation-mini-pilot.md),
+[Portability Bridge Wave A History Ingest Continuity Recovery Review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md),
+[Portability Bridge Wave B Runtime Recovery Tool-Use Review](portability-bridge-wave-b-runtime-recovery-tool-use-review.md),
+[Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md),
+[Portability Bridge Residual Cross-Wave Scan](portability-bridge-residual-cross-wave-scan.md)
+
+Status: long-pass closeout ledger, not bundle authority, not generated output,
+not schema migration, not empirical small-agent proof.
+
+## Verdict
+
+The portability bridge long pass is closed.
+
+All `43` `portability-watch` rows from bundle-anatomy synthesis were reviewed
+through one mini-pilot and three long-pass waves. The pass found no mandatory
+OS Abyss deployment dependency, no hidden sibling-owner dependency that blocks
+standalone use, and no source wording defect requiring immediate repair.
+
+The strongest result is not "everything is generic." The stronger result is
+that source-specific techniques remain portable when their substrate is named:
+OCR, Telegram export, local session indexes, runtime handles, GitHub-native
+owner tracks, generated-publish matrices, MCP gateways, and skill-proposal
+packets can all be used outside OS Abyss when an adopter supplies local
+equivalents and respects owner boundaries.
+
+## Accounting
+
+| scope | closed rows | source repair | route-away | generated/schema change |
+|---|---:|---:|---:|---:|
+| handoff-continuation mini-pilot | 7 | 0 | 0 | 0 |
+| Wave A history/ingest/continuity/recovery | 19 | 0 | 0 | 0 |
+| Wave B runtime/recovery/tool-use | 6 | 0 | 0 | 0 |
+| Wave C owner/governance/knowledge | 11 | 0 | 0 | 0 |
+| total | 43 | 0 | 0 | 0 |
+
+## What Changed
+
+New review surfaces:
+
+- [Portability Bridge Wave A History Ingest Continuity Recovery Review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md)
+- [Portability Bridge Wave B Runtime Recovery Tool-Use Review](portability-bridge-wave-b-runtime-recovery-tool-use-review.md)
+- [Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+- [Portability Bridge Residual Cross-Wave Scan](portability-bridge-residual-cross-wave-scan.md)
+- this closeout ledger
+
+Source disposition:
+
+- `TEMP_PORTABILITY_BRIDGE_LONG_PASS_PLAN.md` was removed after this ledger was
+  indexed;
+- the reform ingress README, review index, and changelog distill the temporary
+  rhythm into durable review surfaces.
+
+No technique bundle source changed.
+
+## What This Proves
+
+- `portability-watch` was useful as pressure, not as a defect label.
+- A technique can be AoA-shaped in provenance and still portable in execution.
+- Concrete substrates are acceptable when the atom is still one bounded move
+  and the substrate can be locally supplied.
+- Owner-boundary language works best when it is already inside the source's
+  natural contract, risks, adaptation notes, and route cards rather than as a
+  loud universal block.
+- External adopters need adapter context, not OS Abyss deployment.
+
+## What This Does Not Prove
+
+- It does not prove that small local models can execute every technique
+  reliably.
+- It does not replace `aoa-evals`.
+- It does not add a portability frontmatter field, selector axis, generated
+  catalog, or schema rule.
+- It does not create an OS Abyss adapter package.
+- It does not grant authority to `aoa-skills`, `aoa-evals`, `aoa-routing`,
+  `aoa-memo`, `aoa-kag`, `aoa-playbooks`, `aoa-agents`, runtime, or stats.
+- It does not make source-specific techniques generic by erasing useful
+  donor-shaped substrate.
+
+## Future Adapter-Card Candidate
+
+The repeated adapter needs justify a later lightweight guide candidate:
+
+- source artifact or authored source set;
+- derived reader or lookup surface;
+- receipt or reviewed evidence anchor;
+- runtime handle or local service surface;
+- approval, guard, or checkpoint seam;
+- owner map or receiving owner;
+- validation surface.
+
+That future guide should remain optional and small. It should help external
+adopters answer "what local equivalent do I supply?" without adding frontmatter
+fields, duplicating bridge law into every bundle, or importing AoA owner
+doctrine into the technique library.
+
+## Next Reform Lane
+
+With portability closed, the next honest reform lane is one targeted
+owner-boundary or template-shape pass, not another broad portability audit.
+
+Best next candidates:
+
+1. `Owner-Boundary Bridge Slice` over one shelf with high neighbor pressure,
+   because this pass repeatedly confirmed that sibling-owner authority must
+   stay held outside technique atoms.
+2. `Template Modernization Pilot` over one to three bundles only where
+   execution readability would improve, because the pass showed most bundles
+   already carry boundary posture naturally.
+3. `Promotion Evidence Slice` for a small cohort after owner-boundary review,
+   because promoted status and canonical readiness remain separate from
+   portability.
+
+Avoid starting empirical small-agent execution here until `aoa-evals` has a
+clean owner harness. Static portability review can prepare fixture ideas, but
+model execution proof belongs in eval ownership.
+
+## Validation
+
+Passed locally after closeout indexing and temporary-plan removal:
+
+1. `git diff --cached --check`
+2. public-share grep over changed review and index surfaces
+3. `python -m unittest tests.test_distillation_mechanics_topology`
+4. `python scripts/validate_repo.py`
+5. `python scripts/release_check.py`
+
+The pre-mutation public-share guard surfaced sanitization and explicit risk
+gates; this closeout satisfied them through the staged review scope, public
+grep, bounded source set, and repo-native validators.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-residual-cross-wave-scan.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-residual-cross-wave-scan.md
@@ -1,0 +1,92 @@
+# Portability Bridge Residual Cross-Wave Scan
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Prior portability packets:
+[Portability Bridge Handoff-Continuation Mini-Pilot](portability-bridge-handoff-continuation-mini-pilot.md),
+[Portability Bridge Wave A History Ingest Continuity Recovery Review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md),
+[Portability Bridge Wave B Runtime Recovery Tool-Use Review](portability-bridge-wave-b-runtime-recovery-tool-use-review.md),
+[Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+
+Status: residual accounting scan, not source rewrite, not schema migration,
+not generated surface change, not empirical small-agent proof.
+
+## Verdict
+
+The portability bridge long pass accounts for all `43` `portability-watch`
+rows from the bundle-anatomy synthesis:
+
+| packet | rows closed | scope |
+|---|---:|---|
+| handoff-continuation mini-pilot | 7 | channel, handoff, receipt, git evidence, opening ritual, repo map, episode loop |
+| Wave A | 19 | history artifacts, media ingest, donor harvest, antifragility recovery |
+| Wave B | 6 | compaction recovery, runtime truth, lifecycle, planning ladder, self-repair checkpoint, MCP gateway |
+| Wave C | 11 | source lift, owner-truth closeout, durable approval, first landing, promotion handoff |
+| total | 43 | all `portability-watch` rows closed |
+
+No residual `portability-watch` row remains unreviewed by this pass. No
+reviewed row produced a source repair, route-away, schema change, frontmatter
+change, generated-surface change, or empirical model-proof claim.
+
+## Covered IDs
+
+The long pass covers:
+
+`AOA-T-0026`, `AOA-T-0036`, `AOA-T-0038`, `AOA-T-0044`, `AOA-T-0045`,
+`AOA-T-0046`, `AOA-T-0047`, `AOA-T-0048`, `AOA-T-0053`, `AOA-T-0054`,
+`AOA-T-0055`, `AOA-T-0056`, `AOA-T-0057`, `AOA-T-0058`, `AOA-T-0059`,
+`AOA-T-0060`, `AOA-T-0061`, `AOA-T-0062`, `AOA-T-0065`, `AOA-T-0066`,
+`AOA-T-0067`, `AOA-T-0069`, `AOA-T-0070`, `AOA-T-0071`, `AOA-T-0072`,
+`AOA-T-0073`, `AOA-T-0074`, `AOA-T-0075`, `AOA-T-0077`, `AOA-T-0083`,
+`AOA-T-0084`, `AOA-T-0085`, `AOA-T-0087`, `AOA-T-0089`, `AOA-T-0091`,
+`AOA-T-0094`, `AOA-T-0095`, `AOA-T-0096`, `AOA-T-0097`, `AOA-T-0098`,
+`AOA-T-0099`, `AOA-T-0100`, and `AOA-T-0102`.
+
+## Repeated Adapter Needs
+
+The repeated needs are real, but they are ordinary adapter context rather than
+blocked portability:
+
+| repeated need | appears in | treatment |
+|---|---|---|
+| source artifact or authored source set | history, source lift, review surfaces | adopter supplies local source; technique routes meaning back to source |
+| derived reader or lookup surface | history index, KAG/source-lift, semantic review, template lift | derived surface stays subordinate and rebuildable |
+| receipt or reviewed evidence anchor | donor harvest, antifragility, quest promotion, owner closeout | evidence is local input, not proof verdict authority |
+| runtime handle or local service surface | runtime truth, lifecycle, isolated stop, MCP gateway | source-specific but portable when locally supplied |
+| approval, guard, or checkpoint seam | durable jobs, self-repair, workspace ingress, skill proposal | visible control posture, not live automation or governance law |
+| owner map or receiving owner | promotion, skill proposal, owner closeout, mirror parity | adapter examples allowed; downstream owner consent is not implied |
+| validation surface | generated publish, owner endcap, mirror parity, recovery closeout | local validation is required context, not `aoa-evals` proof authority |
+
+These repeated needs justify a future lightweight adapter-card guide or review
+aid, but not in this long pass. The current pass proves the rows are portable;
+it does not create a new frontmatter axis, schema field, generated catalog
+input, or universal bridge block.
+
+## Residual Holds
+
+Held, not defects:
+
+| hold | why it stays held |
+|---|---|
+| adapter-card guide | useful future surface once the next reform lane needs it; not required to close current portability accounting |
+| source-specific leaves | OCR, Telegram export, runtime lifecycle, GitHub endcap, generated-publish matrix, and MCP gateway are concrete portable substrates |
+| AoA provenance | allowed when it explains origin, examples, relations, or adaptation; not allowed as mandatory OS Abyss deployment |
+| sibling-owner authority | skills, evals, routing, memory, KAG, playbooks, agents, runtime, and stats remain owner-held outside technique atoms |
+| small-agent empirical proof | belongs to a later eval-owned harness; static portability review does not claim execution success by 2-4B models |
+
+## Public-Safety Read
+
+The new review packets name public repository paths, technique IDs, local
+adapter classes, and public route concepts. They do not add private tokens,
+credentials, unrevealed host topology, private URLs, raw terminal secrets, or
+operator-only state.
+
+The only workspace-shaped references are either existing public project names,
+already public AoA route examples, or explicit examples of what must not be
+treated as invariant. That keeps the pass aligned with the repository's dual
+role: portable technique library and AoA ecosystem organ.
+
+## Next Honest Move
+
+Write the closeout ledger, distill this pass into the reform ingress index,
+remove the temporary plan, and validate the full review packet set.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-a-history-ingest-continuity-recovery-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-a-history-ingest-continuity-recovery-review.md
@@ -1,0 +1,126 @@
+# Portability Bridge Wave A History Ingest Continuity Recovery Review
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Long-pass closeout:
+[Portability Bridge Long-Pass Closeout Ledger](portability-bridge-long-pass-closeout-ledger.md)
+
+Prior portability pilot:
+[Portability Bridge Handoff-Continuation Mini-Pilot](portability-bridge-handoff-continuation-mini-pilot.md)
+
+Status: Wave A portability bridge review, no source rewrite, no schema
+migration, no generated surface change, no empirical small-agent proof.
+
+## Verdict
+
+Wave A closes `19` portability-watch rows across high-pressure portable
+substrates:
+
+- `6` history artifact leaves;
+- `5` media ingest leaves;
+- `4` donor-harvest continuity leaves;
+- `4` antifragility recovery leaves.
+
+All `19` leaves are portable from static direct reading. None requires OS
+Abyss deployment, AoA constitutional authority, hidden memory, routing policy,
+KAG truth, eval verdicts, skill activation, playbook choreography, or one
+runtime platform as part of the invariant technique atom.
+
+No source repair is accepted. The useful portability work is adapter naming:
+external adopters must provide the local artifact, media source, reviewed
+session, or receipt/runtime surface that the technique already names.
+
+## Sources Read
+
+- `techniques/AGENTS.md`
+- `techniques/history/AGENTS.md`
+- `techniques/ingest/AGENTS.md`
+- `techniques/continuity/AGENTS.md`
+- `techniques/recovery/AGENTS.md`
+- all `TECHNIQUE.md` files in `history/history-artifacts`,
+  `ingest/media-ingest`, `continuity/donor-harvest`, and
+  `recovery/antifragility-recovery`
+- local `checks/`, `examples/`, and `notes/` for the scoped leaves
+- [Bundle Anatomy Remaining Shelves Review](bundle-anatomy-remaining-shelves-review.md)
+- [Bundle Anatomy Proof Continuity Governance Review](bundle-anatomy-proof-continuity-governance-review.md)
+- [Selector Relation Wave E Continuity Recovery Review](selector-relation-wave-e-continuity-recovery-review.md)
+- [Selector Relation Wave F Capability Media History Review](selector-relation-wave-f-capability-media-history-review.md)
+
+## Portability Read
+
+| technique | external adopter can take | adapter context needed | portability verdict |
+|---|---|---|---|
+| `AOA-T-0026` `session-capture-as-repo-artifact` | project-scoped session capture as saved artifacts | local artifact path, capture path, retention and review posture | `portable-ready`; not memory, cloud sync, or instruction policy |
+| `AOA-T-0044` `versionable-session-transcripts` | post-capture transcript packaging | saved session artifacts, grouping rule, readable export format, redaction path | `portable-ready`; not capture, hosted sharing, or rule derivation |
+| `AOA-T-0053` `local-first-session-index` | derivative local lookup over saved history | saved artifacts, local index store, metadata slice, source references | `source-specific-but-portable`; index stays rebuildable and not memory truth |
+| `AOA-T-0045` `witness-trace-as-reviewable-artifact` | one reviewable trace artifact for a bounded run | run identity, ordered steps, redaction posture, human summary path | `portable-ready-with-adapter-note`; writeback and promotion stay elsewhere |
+| `AOA-T-0066` `transcript-replay-artifact` | replayable derivative from saved session history | saved source artifact, replay renderer, flow cues, redaction posture | `source-specific-but-portable`; not hosted replay platform doctrine |
+| `AOA-T-0067` `transcript-linked-code-lineage` | code-to-session provenance links | saved evidence artifact, code anchor, stable reference, review surface | `portable-ready-with-adapter-note`; not repo analytics or retrieval product |
+| `AOA-T-0070` `two-stage-document-ocr-pipeline` | detect/layout -> recognize -> OCR handoff | image/page slice, OCR stage, region/layout handles, confidence surface | `source-specific-but-portable`; OCR engine can vary |
+| `AOA-T-0071` `template-backed-field-extraction-after-ocr` | bounded post-OCR field object | OCR handoff, explicit field set, templates/heuristics, conflict threshold | `source-specific-but-portable`; requires prior OCR handoff |
+| `AOA-T-0072` `perceptual-media-dedupe-with-threshold-review` | reviewable near-duplicate groups | bounded media set, perceptual similarity method, threshold bands | `source-specific-but-portable`; not delete/archive policy |
+| `AOA-T-0073` `semantic-media-bucketing-with-vision-plus-ocr` | bounded media classification with optional OCR side text | media set, explicit taxonomy, visual scoring, confidence gates | `source-specific-but-portable`; not moderation, deletion, or identity inference |
+| `AOA-T-0074` `telegram-export-normalization-to-local-store` | Telegram-source normalization into a resumable store | export/API batch, local store, media refs, resume markers | `source-specific-but-portable`; auth/session policy stays outside |
+| `AOA-T-0075` `session-donor-harvest` | reviewed-session donor pack extraction | reviewed artifact, reuse signals, evidence anchors, defer/hold posture | `portable-ready-with-adapter-note`; owner placement and promotion remain later seams |
+| `AOA-T-0077` `harvest-packet-contract` | bounded post-session harvest packet shape | reviewed session reference, extracts, reviewed artifacts, optional subordinate family fields | `portable-ready`; packet is not memory canon or routing authority |
+| `AOA-T-0084` `progression-evidence-lift` | multi-axis progression delta from reviewed evidence | reviewed session or harvest packet, evidence refs, axis vocabulary | `portable-ready-with-adapter-note`; descriptive, not rank or authority |
+| `AOA-T-0085` `multi-axis-quest-overlay` | adjunct quest/RPG reflection over reviewed evidence | progression or route base, optional hooks, owner/proof boundary reminder | `portable-ready-with-adapter-note`; flavor cannot grant authority |
+| `AOA-T-0097` `degrade-reground-recover` | bounded degraded continuation with regrounding and receipt | owner-local artifacts, current status, trustworthy source evidence, fallback policy | `portable-ready-with-adapter-note`; recovery stays receipt-led and weaker than normal path |
+| `AOA-T-0098` `receipt-first-failure-analysis` | evidence-led post-event failure review | source-owned receipts, run artifacts, optional eval reports | `portable-ready-with-adapter-note`; not dashboard mythology or eval verdict |
+| `AOA-T-0099` `isolated-service-stop-on-shared-substrate` | stop one named service while preserving substrate | target service, shared substrate set, stop handle, post-stop checks | `source-specific-but-portable`; runtime handle required but platform-specific names are not |
+| `AOA-T-0100` `stress-receipt-reground-closeout` | stress event receipt, regrounding, reviewed closeout | bounded stressor, owner surface, containment posture, evidence refs | `portable-ready-with-adapter-note`; later proof belongs to evals |
+
+## Boundary Findings
+
+History artifacts are portable when the adopter supplies saved artifacts and a
+review path. They do not become memory doctrine, retention law, hosted viewer
+policy, or transcript-as-instruction authority.
+
+Media ingest leaves are source-specific and portable. They require media,
+OCR, similarity, classification, or Telegram export surfaces, but they keep
+auth, session handling, storage policy, moderation, deletion, and downstream
+routing outside the invariant technique.
+
+Donor-harvest leaves are portable when the adopter supplies reviewed session
+evidence. Their AoA owner-map examples are adaptation examples, not mandatory
+OS Abyss topology.
+
+Antifragility leaves are portable as recovery techniques when the adopter
+supplies owner-local receipts, source artifacts, or named runtime handles. They
+do not compute proof verdicts, own incident-response doctrine, or replace
+runtime owners.
+
+## Repair Gate
+
+No source repair is accepted in Wave A.
+
+Held, not defects:
+
+| hold | reason |
+|---|---|
+| adapter card | repeated adapter needs are visible, but one wave is not enough to add a guide |
+| source-specific substrates | OCR engines, Telegram exports, local indexes, replay renderers, and runtime handles are concrete portable substrates, not defects |
+| owner-route pressure | memory, KAG, playbook, eval, routing, and runtime authority stay named as outside owners |
+| empirical proof | no local 2-4B model executed these techniques |
+
+## What This Does Not Do
+
+- no `TECHNIQUE.md` source changed;
+- no frontmatter, relation, status, kind, domain, path, or generated surface
+  changed;
+- no OS Abyss adapter was created;
+- no sibling owner accepted new authority from this packet;
+- no empirical model proof is claimed.
+
+## Next Honest Move
+
+Continue with Wave B:
+
+- `continuity/review-compaction` `AOA-T-0054`
+- `execution/runtime-truth-lifecycle` `AOA-T-0036`, `AOA-T-0038`
+- `execution/ready-work-graphs` `AOA-T-0055`
+- `recovery/diagnosis-repair` `AOA-T-0083`
+- `tool-use/tool-gateway` `AOA-T-0065`
+
+Wave B should focus on runtime, recovery, and tool-use boundary cases without
+turning them into generic runtime doctrine.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-b-runtime-recovery-tool-use-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-b-runtime-recovery-tool-use-review.md
@@ -1,0 +1,134 @@
+# Portability Bridge Wave B Runtime Recovery Tool-Use Review
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Long-pass closeout:
+[Portability Bridge Long-Pass Closeout Ledger](portability-bridge-long-pass-closeout-ledger.md)
+
+Prior portability packets:
+[Portability Bridge Handoff-Continuation Mini-Pilot](portability-bridge-handoff-continuation-mini-pilot.md),
+[Portability Bridge Wave A History Ingest Continuity Recovery Review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md)
+
+Status: Wave B portability bridge review, no source rewrite, no schema
+migration, no generated surface change, no empirical small-agent proof.
+
+## Verdict
+
+Wave B closes `6` portability-watch rows where the portable atom can be
+mistaken for runtime ownership, hidden skill recovery, broad planning
+methodology, self-repair governance, or MCP platform doctrine:
+
+- `1` continuity review-compaction leaf;
+- `3` execution leaves;
+- `1` recovery diagnosis-repair leaf;
+- `1` tool-use gateway leaf.
+
+All `6` leaves are portable from static direct reading. None requires OS Abyss
+deployment, AoA constitutional authority, hidden memory, KAG truth, routing
+policy, eval verdicts, playbook choreography, or one managed runtime platform
+as part of the invariant technique atom.
+
+No source repair is accepted. These leaves already carry the bridge in a
+better form than a loud generic bridge block would: each names the local
+substrate an adopter must provide and keeps the neighboring owner surface out
+of the core technique.
+
+## Sources Read
+
+- `techniques/AGENTS.md`
+- `techniques/continuity/AGENTS.md`
+- `techniques/execution/AGENTS.md`
+- `techniques/recovery/AGENTS.md`
+- `techniques/tool-use/AGENTS.md`
+- [AOA-T-0054 compaction-resilient-skill-loading](../../../../../techniques/continuity/review-compaction/compaction-resilient-skill-loading/TECHNIQUE.md)
+- [AOA-T-0036 render-truth-before-startup](../../../../../techniques/execution/runtime-truth-lifecycle/render-truth-before-startup/TECHNIQUE.md)
+- [AOA-T-0038 one-command-service-lifecycle](../../../../../techniques/execution/runtime-truth-lifecycle/one-command-service-lifecycle/TECHNIQUE.md)
+- [AOA-T-0055 requirements-design-tasks-ladder](../../../../../techniques/execution/ready-work-graphs/requirements-design-tasks-ladder/TECHNIQUE.md)
+- [AOA-T-0083 checkpoint-bound-self-repair](../../../../../techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/TECHNIQUE.md)
+- [AOA-T-0065 mcp-gateway-proxy](../../../../../techniques/tool-use/tool-gateway/mcp-gateway-proxy/TECHNIQUE.md)
+- local `checks/`, `examples/`, and `notes/second-context-adaptation.md`
+  for the scoped leaves
+- [Landed Review-Compaction Pilot Review](landed-review-compaction-pilot-review.md)
+- [Landed Runtime-Truth-Lifecycle Pilot Review](landed-runtime-truth-lifecycle-pilot-review.md)
+- [Landed Ready-Work-Graphs Pilot Review](landed-ready-work-graphs-pilot-review.md)
+- [Landed Diagnosis-Repair Pilot Review](landed-diagnosis-repair-pilot-review.md)
+- [Landed Tool-Gateway Pilot Review](landed-tool-gateway-pilot-review.md)
+- [Execution Profile Truth Boundary Pilot](execution-profile-truth-boundary-pilot.md)
+- [Selector Relation Wave C Execution Owner Review](selector-relation-wave-c-execution-owner-review.md)
+- [Selector Relation Wave E Continuity Recovery Review](selector-relation-wave-e-continuity-recovery-review.md)
+
+## Portability Read
+
+| technique | external adopter can take | adapter context needed | portability verdict |
+|---|---|---|---|
+| `AOA-T-0054` `compaction-resilient-skill-loading` | bounded post-compaction skill-availability recovery | canonical skill source or discoverable skill set, explicit compaction boundary, small bootstrap surface, reload path | `portable-ready-with-adapter-note`; not full context reconstruction, memory recall, marketplace install, or prompt replay |
+| `AOA-T-0036` `render-truth-before-startup` | read-only pre-start render review of the actual composed runtime view | selected profile or preset, composition engine, service-list or full-config render, local sensitive-output handling | `source-specific-but-portable`; not startup control, deployment orchestration, or readiness proof |
+| `AOA-T-0038` `one-command-service-lifecycle` | one visible local lifecycle entrypoint for a bounded service stack | named local stack, prerequisite or build checks, status output, stop path, child-process cleanup posture | `source-specific-but-portable`; not platform launcher, installer, remote deployment, or runtime owner law |
+| `AOA-T-0055` `requirements-design-tasks-ladder` | explicit pre-execution ladder from requirement to design to tasks | one requirement, one design response, one derived task set, optional review seams | `portable-ready`; not SDD methodology import, command suite, project memory, or execution workflow |
+| `AOA-T-0083` `checkpoint-bound-self-repair` | checkpoint posture around an already shaped self-repair | bounded repair shape, policy check, approval seam, rollback marker, health check, iteration limit, improvement-log target | `portable-ready-with-adapter-note`; not hidden self-healing, repair shaping, or general governance law |
+| `AOA-T-0065` `mcp-gateway-proxy` | one caller-facing gateway seam over configured upstream tool surfaces | upstream MCP/tool providers, gateway endpoint, metadata lookup, mediation and sanitization posture | `source-specific-but-portable`; not MCP marketplace, scanner product, registry doctrine, or lifecycle platform |
+
+## Boundary Findings
+
+Review-compaction is portable because it only needs canonical skill sources, a
+compaction boundary, and a visible reload path. It does not require the donor
+plugin runtime, semantic matching, embeddings, marketplace discovery, or hidden
+prompt-state replay.
+
+Runtime-truth lifecycle leaves are portable when the adopter supplies local
+runtime equivalents. `AOA-T-0036` owns pre-start rendered truth; `AOA-T-0038`
+owns start/stop lifecycle. Neither claims host readiness, smoke proof,
+deployment orchestration, or platform ownership.
+
+Ready-work graphs are portable when the adopter can distinguish requirement,
+design, and task layers. The source already prevents the ladder from becoming
+an imported methodology stack or implementation workflow.
+
+Checkpoint-bound repair is portable when the adopter supplies a local
+checkpoint packet around an already chosen repair. Approval, rollback,
+health-check, iteration, and improvement-log fields are adapter surfaces, not
+AoA-only mechanics.
+
+The MCP gateway leaf is source-specific and portable. It requires configured
+upstream tool surfaces and one caller-facing mediation seam, but it keeps
+scanner posture, reputation, registry publication, dashboards, tenancy,
+startup/shutdown, and wider security governance outside the invariant core.
+
+## Repair Gate
+
+No source repair is accepted in Wave B.
+
+Held, not defects:
+
+| hold | reason |
+|---|---|
+| runtime substrates | render engines, lifecycle wrappers, stop handles, and gateways are portable substrates when locally supplied |
+| sibling-owner boundaries | skills, evals, routing, memory, KAG, playbooks, runtime, and governance remain outside the technique atoms |
+| source-specific examples | examples keep the move concrete without becoming required OS Abyss deployment |
+| adapter card | repeated adapter needs are stronger after Wave B, but the guide candidate waits for the residual cross-wave scan |
+| empirical proof | no local small model executed these techniques |
+
+## What This Does Not Do
+
+- no `TECHNIQUE.md` source changed;
+- no frontmatter, relation, status, kind, domain, path, or generated surface
+  changed;
+- no OS Abyss adapter was created;
+- no sibling owner accepted new authority from this packet;
+- no empirical model proof is claimed.
+
+## Next Honest Move
+
+Continue with Wave C:
+
+- `knowledge-lift/kag-source-lift` `AOA-T-0046`, `AOA-T-0047`,
+  `AOA-T-0048`
+- `proof/owner-truth-closeout` `AOA-T-0091`, `AOA-T-0094`,
+  `AOA-T-0095`, `AOA-T-0096`
+- `governance/approval-evidence` `AOA-T-0069`
+- `governance/automation-readiness` `AOA-T-0087`
+- `governance/promotion-boundary` `AOA-T-0089`, `AOA-T-0102`
+
+Wave C should focus on owner-facing proof, governance, and knowledge-lift
+pressure without importing KAG truth, proof verdict authority, automation law,
+or promotion doctrine into technique meaning.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-c-owner-governance-knowledge-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/portability-bridge-wave-c-owner-governance-knowledge-review.md
@@ -1,0 +1,134 @@
+# Portability Bridge Wave C Owner Governance Knowledge Review
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Long-pass closeout:
+[Portability Bridge Long-Pass Closeout Ledger](portability-bridge-long-pass-closeout-ledger.md)
+
+Prior portability packets:
+[Portability Bridge Handoff-Continuation Mini-Pilot](portability-bridge-handoff-continuation-mini-pilot.md),
+[Portability Bridge Wave A History Ingest Continuity Recovery Review](portability-bridge-wave-a-history-ingest-continuity-recovery-review.md),
+[Portability Bridge Wave B Runtime Recovery Tool-Use Review](portability-bridge-wave-b-runtime-recovery-tool-use-review.md)
+
+Status: Wave C portability bridge review, no source rewrite, no schema
+migration, no generated surface change, no empirical small-agent proof.
+
+## Verdict
+
+Wave C closes `11` portability-watch rows where the portable atom sits near
+KAG/source-lift, owner-proof, approval, automation, and promotion authority:
+
+- `3` knowledge-lift source-lift leaves;
+- `4` proof owner-truth-closeout leaves;
+- `1` approval-evidence leaf;
+- `1` automation-readiness leaf;
+- `2` promotion-boundary leaves.
+
+All `11` leaves are portable from static direct reading. None requires OS
+Abyss deployment, AoA constitutional authority, hidden memory, KAG truth,
+routing policy, eval verdicts, skill activation, playbook choreography,
+runtime services, GitHub platform policy, or a sibling owner accepting new
+authority before the technique can be understood as one bounded move.
+
+No source repair is accepted. These leaves are exactly the kind of portable
+system practice `aoa-techniques` should keep: source-shaped, owner-aware, and
+explicit about what the technique does not authorize.
+
+## Sources Read
+
+- `techniques/AGENTS.md`
+- `techniques/knowledge-lift/AGENTS.md`
+- `techniques/proof/AGENTS.md`
+- `techniques/governance/AGENTS.md`
+- [AOA-T-0046 repo-doc-surface-lift](../../../../../techniques/knowledge-lift/kag-source-lift/repo-doc-surface-lift/TECHNIQUE.md)
+- [AOA-T-0047 github-review-template-lift](../../../../../techniques/knowledge-lift/kag-source-lift/github-review-template-lift/TECHNIQUE.md)
+- [AOA-T-0048 semantic-review-surface-lift](../../../../../techniques/knowledge-lift/kag-source-lift/semantic-review-surface-lift/TECHNIQUE.md)
+- [AOA-T-0091 workspace-root-ingress-and-mutation-gate](../../../../../techniques/proof/owner-truth-closeout/workspace-root-ingress-and-mutation-gate/TECHNIQUE.md)
+- [AOA-T-0094 canonical-owner-with-validated-mirror](../../../../../techniques/proof/owner-truth-closeout/canonical-owner-with-validated-mirror/TECHNIQUE.md)
+- [AOA-T-0095 github-only-owner-endcap-with-reality-sync](../../../../../techniques/proof/owner-truth-closeout/github-only-owner-endcap-with-reality-sync/TECHNIQUE.md)
+- [AOA-T-0096 pinned-validation-matrix-before-generated-publish](../../../../../techniques/proof/owner-truth-closeout/pinned-validation-matrix-before-generated-publish/TECHNIQUE.md)
+- [AOA-T-0069 approval-bound-durable-jobs](../../../../../techniques/governance/approval-evidence/approval-bound-durable-jobs/TECHNIQUE.md)
+- [AOA-T-0087 human-loop-to-first-landing](../../../../../techniques/governance/automation-readiness/human-loop-to-first-landing/TECHNIQUE.md)
+- [AOA-T-0089 quest-unit-promotion-review](../../../../../techniques/governance/promotion-boundary/quest-unit-promotion-review/TECHNIQUE.md)
+- [AOA-T-0102 skill-proposal-handoff-packet](../../../../../techniques/governance/promotion-boundary/skill-proposal-handoff-packet/TECHNIQUE.md)
+- local `checks/`, `examples/`, and `notes/second-context-adaptation.md`
+  where present for the scoped leaves
+- [Landed Kag-Source-Lift Pilot Review](landed-kag-source-lift-pilot-review.md)
+- [Landed Owner-Truth-Closeout Pilot Review](landed-owner-truth-closeout-pilot-review.md)
+- [Landed Approval-Evidence Pilot Review](landed-approval-evidence-pilot-review.md)
+- [Landed Automation-Readiness Pilot Review](landed-automation-readiness-pilot-review.md)
+- [Landed Promotion-Boundary Pilot Review](landed-promotion-boundary-pilot-review.md)
+
+## Portability Read
+
+| technique | external adopter can take | adapter context needed | portability verdict |
+|---|---|---|---|
+| `AOA-T-0046` `repo-doc-surface-lift` | bounded repo-doc routing surface derived from authored docs | explicit public docs/status source set, derived reader or manifest, route-back rule to authored markdown | `source-specific-but-portable`; not docs taxonomy, planning-doc routing, status policy, release policy, or KAG owner doctrine |
+| `AOA-T-0047` `github-review-template-lift` | bounded intake lookup over authored GitHub templates | authored issue/PR templates, derived inventory or manifest, prompt-shape scope | `source-specific-but-portable`; not approval policy, triage logic, workflow automation, or review-state registry |
+| `AOA-T-0048` `semantic-review-surface-lift` | derived lookup over authored semantic-review docs | review docs, cluster scope, derived review manifest, route-back rule | `source-specific-but-portable`; not scoring, automatic verdicts, status automation, relation cleanup, or graph semantics |
+| `AOA-T-0091` `workspace-root-ingress-and-mutation-gate` | explicit workspace ingress plus pre-mutation guard posture | workspace root, primary repo root, intent, structured ingress/guard report, mutation-surface labels | `portable-ready-with-adapter-note`; not workspace install doctrine, closeout automation, root law, or skill activation |
+| `AOA-T-0094` `canonical-owner-with-validated-mirror` | one canonical owner plus subordinate parity-checked mirrors | canonical contract, legal mirror copy, owner/reference metadata, vocabulary parity check, consumer validation | `portable-ready-with-adapter-note`; not cross-repo co-ownership, rollout playbook, publisher policy, or generic source-of-truth doctrine |
+| `AOA-T-0095` `github-only-owner-endcap-with-reality-sync` | remote-owner GitHub landing followed by coordination-layer reality sync | owner-side goal/non-goals, GitHub trail, owner-native checks, post-merge coordination update | `source-specific-but-portable`; not generic GitHub handbook, broad remediation choreography, or product/runtime proof |
+| `AOA-T-0096` `pinned-validation-matrix-before-generated-publish` | generated-publish validation against workflow-pinned inputs | generated outputs, pinned sibling refs or mirrors, rebuild or check path, publish/defer decision | `source-specific-but-portable`; not release automation, CI platform design, or split-wave playbook doctrine |
+| `AOA-T-0069` `approval-bound-durable-jobs` | durable job identity paused at an explicit approval seam | job identity, checkpoint/status store, approval record, resume path | `source-specific-but-portable`; not scheduler platform, queue product, fleet manager, or broad orchestration governance |
+| `AOA-T-0087` `human-loop-to-first-landing` | first honest landing verdict for one recurring human loop | reviewed route, readiness evidence, owner-layer options, rejected nearest-wrong target, optional advisory schedule hints | `portable-ready-with-adapter-note`; not live automation, scheduler authority, skill acceptance, or roadmap policy |
+| `AOA-T-0089` `quest-unit-promotion-review` | bounded promotion verdict for one repeated reviewed unit | reviewed repeated unit, evidence packet, repeat shape, owner candidates, defer/keep-quest posture | `portable-ready-with-adapter-note`; not quest canon, playbook authorship, role law, proof verdict, or memory write |
+| `AOA-T-0102` `skill-proposal-handoff-packet` | technique-side proposal packet for a receiving skill owner | named practice, execution pressure, technique refs, trigger sketch, workflow shape, risks, verification hints, non-acceptance stop-line | `portable-ready-with-adapter-note`; not skill acceptance, skill creation, skill activation, command install, proof verdict, or owner consent |
+
+## Boundary Findings
+
+Knowledge-lift leaves are portable because the source object stays authored and
+the derived reader surface stays subordinate. Their KAG wording is provenance
+and family pressure, not `aoa-kag` substrate ownership, graph authority,
+retrieval policy, scoring, proof authority, or generated truth.
+
+Owner-truth closeout leaves are portable when the adopter supplies local owner
+anchors and validation surfaces. They name proof-facing closure moves without
+becoming AoA constitutional authority, root `AGENTS.md` law, GitHub policy,
+release governance, public-share approval policy, or closeout automation.
+
+Approval and durable-job governance is portable when job identity, checkpoint
+state, approval, and resume are visible. The technique does not need the donor
+runtime package and does not become scheduler or queue doctrine.
+
+Automation readiness and promotion-boundary leaves are portable because their
+outputs are verdicts or proposal packets, not implementation authority.
+Schedule hints, owner-layer examples, quest language, and skill-owner examples
+remain adapter context unless they claim live automation, accepted skill
+status, or downstream owner consent.
+
+## Repair Gate
+
+No source repair is accepted in Wave C.
+
+Held, not defects:
+
+| hold | reason |
+|---|---|
+| KAG wording | current source keeps KAG/source-lift as derived-reader pressure, not KAG substrate authority |
+| owner examples | AoA owner maps, GitHub endcaps, pinned matrices, and skill-owner examples are adaptation examples or provenance |
+| proof and governance pressure | proof-facing and governance-facing leaves name bounded moves without claiming verdict authority |
+| proposal posture | `AOA-T-0102` already states that handoff packets do not accept, create, install, or activate skills |
+| empirical proof | no local small model executed these techniques |
+
+## What This Does Not Do
+
+- no `TECHNIQUE.md` source changed;
+- no frontmatter, relation, status, kind, domain, path, or generated surface
+  changed;
+- no OS Abyss adapter was created;
+- no sibling owner accepted new authority from this packet;
+- no empirical model proof is claimed.
+
+## Next Honest Move
+
+Run the residual cross-wave scan for all `43` portability-watch rows:
+
+- `7` closed by the handoff-continuation mini-pilot;
+- `19` closed by Wave A;
+- `6` closed by Wave B;
+- `11` closed by Wave C.
+
+The scan should check accounting, repeated adapter needs, public-share risk,
+and whether a future adapter card is justified. It should not reopen source
+rewrites unless a concrete unreviewed hidden dependency appears.


### PR DESCRIPTION
## Summary
- close the portability bridge long pass across all 43 portability-watch rows
- add Wave A, Wave B, Wave C, residual scan, and closeout ledger review packets
- update reform ingress indexes and changelog with the durable closeout surface

## Validation
- git diff --cached --check
- public-share grep over changed review/index surfaces
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_repo.py
- python scripts/release_check.py

## Notes
- no TECHNIQUE.md source changes
- no schema/frontmatter/generated-surface changes
- no empirical small-agent proof claimed