### PR TITLE
Review promotion-boundary owner boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- landed the first owner-boundary bridge pilot over
+  `governance/promotion-boundary`, confirming `AOA-T-0089`, `AOA-T-0090`,
+  and `AOA-T-0102` keep destination authority outside the technique atom
+  without source repairs, schema/frontmatter changes, generated-surface
+  changes, sibling-owner acceptance, or empirical small-agent proof
 - closed the portability bridge long pass across all `43` `portability-watch`
   rows with Waves A through C, a residual cross-wave scan, and a closeout
   ledger, confirming standalone portability without source repairs,

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -356,6 +356,11 @@ permission slip to remap techniques automatically.
   through one mini-pilot plus Waves A through C, accepting no source repairs,
   no route-away moves, no schema/frontmatter changes, no generated-surface
   changes, and no empirical model-proof claim
+- owner-boundary bridge pilot: landed over
+  `governance/promotion-boundary`, confirming `AOA-T-0089`, `AOA-T-0090`,
+  and `AOA-T-0102` hold technique-local atoms while destination authority
+  stays with the relevant sibling owner; no source repairs, schema/frontmatter
+  changes, generated-surface changes, or empirical small-agent proof
 
 ## Evidence Stack
 
@@ -491,6 +496,7 @@ permission slip to remap techniques automatically.
 | [Portability Bridge Wave C Owner Governance Knowledge Review](reviews/portability-bridge-wave-c-owner-governance-knowledge-review.md) | closes `11` source-lift, owner-truth, approval, automation, and promotion rows without importing KAG truth, proof verdicts, skill acceptance, or governance law | KAG substrate ownership, GitHub policy, release automation, live automation, skill activation, sibling-owner consent, or empirical model proof |
 | [Portability Bridge Residual Cross-Wave Scan](reviews/portability-bridge-residual-cross-wave-scan.md) | accounts for all `43` portability-watch rows and records repeated adapter needs as future guide candidates, not current defects | source repair, route-away movement, new portability field, adapter package, or generated catalog authority |
 | [Portability Bridge Long-Pass Closeout Ledger](reviews/portability-bridge-long-pass-closeout-ledger.md) | closes the portability bridge long pass and distills the temporary rhythm into durable review packets and next-lane guidance | small-model execution proof, schema/frontmatter migration, OS Abyss adapter authority, or sibling-owner authority |
+| [Owner-Boundary Bridge Promotion-Boundary Pilot](reviews/owner-boundary-bridge-promotion-boundary-pilot.md) | confirms the first owner-boundary bridge rhythm over `governance/promotion-boundary`: the three leaves name allowed bridges while keeping destination authority outside the technique atom | source repair, universal bridge blocks, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -636,14 +642,17 @@ moves, no schema/frontmatter changes, no generated-surface changes, and no
 empirical model-proof claim. The residual scan records repeated adapter needs
 as a future lightweight guide candidate, not as a current blocker.
 
-Next clean move: leave portability closed and choose the next targeted reform
-lane. Best candidates are one owner-boundary bridge shelf review, one narrow
-template-modernization pilot where execution readability truly improves, or a
-small promotion-evidence cohort after owner-boundary pressure is clearer. Do
-not restart portability as a broad audit, do not add future relation names such
-as `follows`, do not promote scout axes into frontmatter without a separate
-decision and validator wave, and do not run local small-agent proof without an
-`aoa-evals` proof surface.
+Current latest owner-boundary bridge pilot: `governance/promotion-boundary`
+is closed as the first shelf-level rhythm. `AOA-T-0089`, `AOA-T-0090`, and
+`AOA-T-0102` hold without source repair because each bundle names one
+technique-local atom and keeps destination authority outside the technique.
+
+Next clean move: run the next owner-boundary bridge pilot on
+`governance/practice-adoption-lifecycle`, then decide whether the rhythm is
+strong enough for a long pass. Do not restart portability as a broad audit, do
+not add future relation names such as `follows`, do not promote scout axes into
+frontmatter without a separate decision and validator wave, and do not run
+local small-agent proof without an `aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -114,5 +114,6 @@ Current reviews:
 - [portability-bridge-wave-c-owner-governance-knowledge-review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
 - [portability-bridge-residual-cross-wave-scan](portability-bridge-residual-cross-wave-scan.md)
 - [portability-bridge-long-pass-closeout-ledger](portability-bridge-long-pass-closeout-ledger.md)
+- [owner-boundary-bridge-promotion-boundary-pilot](owner-boundary-bridge-promotion-boundary-pilot.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-promotion-boundary-pilot.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-promotion-boundary-pilot.md
@@ -1,0 +1,157 @@
+# Owner-Boundary Bridge Promotion-Boundary Pilot
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Prior shelf review:
+[Promotion-Boundary Direct-Read Migration Review](promotion-boundary-direct-read-migration-review.md)
+
+Landed shelf review:
+[Landed Promotion-Boundary Pilot Review](landed-promotion-boundary-pilot-review.md)
+
+Portability precedent:
+[Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+
+Selector precedent:
+[Selector Relation Wave D Governance Split Review](selector-relation-wave-d-governance-split-review.md)
+
+Status: owner-boundary bridge pilot, no source rewrite, no generated surface
+change, no schema/frontmatter change, no empirical small-agent proof.
+
+## Verdict
+
+The `governance/promotion-boundary` shelf holds as the first
+owner-boundary bridge pilot.
+
+All three leaves are already shaped as technique atoms rather than destination
+authority. `AOA-T-0089` reviews one repeated quest-shaped unit and emits one
+bounded owner-placement verdict. `AOA-T-0090` strengthens one already chosen
+verdict by rejecting the nearest plausible wrong target. `AOA-T-0102` packages
+one skill-shaped pressure as a proposal packet for a receiving skill owner.
+
+No source repair is accepted. The current bundle wording already keeps the
+bridge light: examples and adaptation notes name adjacent owners, while the
+contracts keep authorship, acceptance, activation, proof, memory, routing,
+scenario, role, runtime, KAG, and AoA-center authority outside the technique.
+
+## Sources Read
+
+- `AGENTS.md`
+- `mechanics/AGENTS.md`
+- `mechanics/distillation/AGENTS.md`
+- `mechanics/distillation/parts/AGENTS.md`
+- [Technique Reform Ingress](../README.md)
+- `techniques/AGENTS.md`
+- `techniques/governance/AGENTS.md`
+- [AOA-T-0089 quest-unit-promotion-review](../../../../../techniques/governance/promotion-boundary/quest-unit-promotion-review/TECHNIQUE.md)
+- [AOA-T-0089 checklist](../../../../../techniques/governance/promotion-boundary/quest-unit-promotion-review/checks/quest-unit-promotion-review-checklist.md)
+- [AOA-T-0089 example](../../../../../techniques/governance/promotion-boundary/quest-unit-promotion-review/examples/minimal-quest-unit-promotion-review.md)
+- [AOA-T-0089 second-context adaptation](../../../../../techniques/governance/promotion-boundary/quest-unit-promotion-review/notes/second-context-adaptation.md)
+- [AOA-T-0090 nearest-wrong-target-rejection](../../../../../techniques/governance/promotion-boundary/nearest-wrong-target-rejection/TECHNIQUE.md)
+- [AOA-T-0090 checklist](../../../../../techniques/governance/promotion-boundary/nearest-wrong-target-rejection/checks/nearest-wrong-target-rejection-checklist.md)
+- [AOA-T-0090 example](../../../../../techniques/governance/promotion-boundary/nearest-wrong-target-rejection/examples/minimal-nearest-wrong-target-rejection.md)
+- [AOA-T-0090 second-context adaptation](../../../../../techniques/governance/promotion-boundary/nearest-wrong-target-rejection/notes/second-context-adaptation.md)
+- [AOA-T-0102 skill-proposal-handoff-packet](../../../../../techniques/governance/promotion-boundary/skill-proposal-handoff-packet/TECHNIQUE.md)
+- [AOA-T-0102 checklist](../../../../../techniques/governance/promotion-boundary/skill-proposal-handoff-packet/checks/skill-proposal-handoff-packet-checklist.md)
+- [AOA-T-0102 example](../../../../../techniques/governance/promotion-boundary/skill-proposal-handoff-packet/examples/minimal-skill-proposal-handoff-packet.md)
+- [AOA-T-0102 second-context adaptation](../../../../../techniques/governance/promotion-boundary/skill-proposal-handoff-packet/notes/second-context-adaptation.md)
+- [Promotion-Boundary Direct-Read Migration Review](promotion-boundary-direct-read-migration-review.md)
+- [Landed Promotion-Boundary Pilot Review](landed-promotion-boundary-pilot-review.md)
+- [Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+- [Selector Relation Wave D Governance Split Review](selector-relation-wave-d-governance-split-review.md)
+- AoA sibling owner route cards for center, skills, playbooks, evals, memo,
+  agents, routing, and KAG boundaries
+
+## Boundary Map
+
+| technique | technique-local atom | allowed bridge | authority held outside | verdict |
+|---|---|---|---|---|
+| `AOA-T-0089` `quest-unit-promotion-review` | one bounded keep-or-promote verdict for one repeated reviewed quest unit | names the chosen owner repo and next surface as a destination for later owner work | quest canon, playbook authorship, skill workflow, role law, proof verdict, memory write, routing policy, runtime behavior, owner consent | holds; no repair |
+| `AOA-T-0090` `nearest-wrong-target-rejection` | one adjacent plausible wrong target plus one boundary reason | sharpens an existing verdict without replacing that verdict workflow | owner placement decision, anti-pattern doctrine, route policy, proof authority, playbook doctrine, skill acceptance | holds; no repair |
+| `AOA-T-0102` `skill-proposal-handoff-packet` | one pre-acceptance proposal packet for one receiving skill owner | gives the receiving skill owner trigger, workflow-shape, risk, rollback, and verification context | skill acceptance, skill creation, skill activation, command install, runtime authority, proof verdict, scenario composition, memory truth, owner consent | holds; no repair |
+
+## Cross-Owner Read
+
+`aoa-techniques` owns the reusable practice atom and the public-safe wording
+that lets another system reuse it. The bridge should therefore say enough for
+the next owner to understand the handoff, but stop before importing that
+owner's contract.
+
+Adjacent owner split:
+
+- `Agents-of-Abyss` owns the constitutional and ecosystem-center lane.
+- `aoa-skills` owns accepted skill workflow, trigger contract, packaging,
+  validation, and activation discipline.
+- `aoa-playbooks` owns scenario composition, recurring route shape, fallback,
+  rollback, return, and reanchor posture.
+- `aoa-evals` owns bounded proof claims, verdict shape, categories, reports,
+  caveats, and generated proof surfaces.
+- `aoa-memo` owns memory-object structure, recall posture, temporal relevance,
+  and writeback semantics.
+- `aoa-agents` owns role contracts, profiles, handoff posture, progression,
+  recurrence, and checkpoint contract surfaces at the agent layer.
+- `aoa-routing` owns advisory navigation and dispatch hints, not source
+  meaning or activation authority.
+- `aoa-kag` owns derived provenance-aware knowledge substrates, not authored
+  technique meaning.
+
+This pilot does not need new local doctrine blocks because the bundle contracts
+already express the bridge in ordinary technique language.
+
+## Repair Gate
+
+No source repair is accepted.
+
+Held, not defects:
+
+| hold | reason |
+|---|---|
+| AoA owner examples | they are adaptation examples and do not become invariant repo topology |
+| quest and promotion words | current wording keeps `quest`, `keep-quest`, and `defer` as verdict posture, not live quest sovereignty |
+| skill proposal fields | trigger, workflow shape, risk, rollback, and verification fields remain proposal context, not skill body |
+| nearest-wrong rejection | the rejection remains paired to one verdict and does not become a broad anti-pattern essay |
+| empirical proof | no local small model executed these techniques in this pilot |
+
+## Repeatable Long-Pass Rhythm
+
+Use this rhythm for the future owner-boundary bridge long pass:
+
+1. Pick one shelf, not the whole corpus.
+2. Read every bundle body plus local checklist, example, and adaptation note.
+3. Read the nearest route cards and the prior shelf review packets.
+4. Name the technique-local atom in one sentence.
+5. Name adjacent owners only where the atom actually touches them.
+6. Separate allowed bridge wording from authority held outside.
+7. Repair source only when the bundle text itself smuggles destination
+   authority, hides a nearest owner, or leaves a small agent unable to stop.
+8. Otherwise write a review packet with `holds; no repair` and move on.
+
+## Public-Safety Read
+
+This packet uses public repository wording, route cards, and already-landed
+review packets. It does not publish credentials, private hosts, internal
+runtime state, local operator procedures, non-public donor text, or sibling
+repo implementation detail. Owner names are boundary markers, not claims that
+those owners accepted new work.
+
+## What This Does Not Do
+
+- no `TECHNIQUE.md` source changed;
+- no checklists, examples, notes, generated outputs, or technique catalogs
+  changed;
+- no frontmatter, relation, maturity, status, path, domain, kind, or export
+  posture changed;
+- no sibling owner accepted new authority from this packet;
+- no empirical small-agent proof is claimed;
+- no new owner-boundary schema or universal template section is introduced.
+
+## Next Honest Move
+
+Run the next owner-boundary bridge pilot on
+`governance/practice-adoption-lifecycle`.
+
+That shelf is the natural follow-up because it sits next to
+`promotion-boundary` but has a different object: local adoption, retention, and
+obsolescence posture. The next pass should confirm whether those three leaves
+keep local owner consent, retention evidence, deprecation execution, proof,
+memory, runtime, routing, and Method-growth authority outside the technique
+atom without inserting heavy bridge blocks.


### PR DESCRIPTION
## Summary

- Adds an owner-boundary bridge pilot review for `governance/promotion-boundary`.
- Records that `AOA-T-0089`, `AOA-T-0090`, and `AOA-T-0102` hold without source repair while destination authority stays with sibling owners.
- Updates the technique reform ingress README, review index, and changelog.

## Validation

- `git diff --check`
- public-safety grep over changed docs; only negative safety wording matched
- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- `python scripts/release_check.py`

## Notes

No technique source, frontmatter, generated surface, schema, or sibling-owner authority changed.