### PR TITLE
Review owner-boundary bridge wave C

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -381,6 +381,14 @@ permission slip to remap techniques automatically.
   scoped references, and claim challenges bounded; no source repairs,
   schema/frontmatter changes, generated-surface changes, or empirical
   small-agent proof
+- owner-boundary bridge Wave C: landed over `instruction/instruction-surface`,
+  `instruction/docs-boundary`, `instruction/capability-registry`,
+  `instruction/capability-boundary`, `instruction/skill-discovery`, and
+  `proof/skill-support`, confirming `22` instruction, skill-adjacent,
+  capability, docs-boundary, and proof-support leaves keep source, target,
+  registry, command, discovery, contract, context, and invariant authority
+  bounded; no source repairs, schema/frontmatter changes, generated-surface
+  changes, or empirical small-agent proof
 
 ## Evidence Stack
 
@@ -520,6 +528,7 @@ permission slip to remap techniques automatically.
 | [Owner-Boundary Bridge Practice-Adoption-Lifecycle Pilot](reviews/owner-boundary-bridge-practice-adoption-lifecycle-pilot.md) | confirms the second owner-boundary bridge rhythm over `governance/practice-adoption-lifecycle`: local adoption, retention, and obsolescence leaves keep authority bounded without source repair | source repair, Method-growth law import, deletion/deprecation execution, permanent retention, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Wave A Governance Owner Proof Review](reviews/owner-boundary-bridge-wave-a-governance-owner-proof-review.md) | confirms the first long-pass wave over owner-facing governance and proof shelves: `13` leaves keep route, approval, automation, ingress, owner-proof, GitHub-owner, generated-publish, and mirror-parity authority bounded | source repair, route policy, approval policy, live automation, eval verdict authority, GitHub platform policy, release governance, workspace install doctrine, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Wave B Proof Publication Review](reviews/owner-boundary-bridge-wave-b-proof-publication-review.md) | confirms the second long-pass wave over proof, publication, and review-evidence shelves: `10` leaves keep summary, gate, CI report, published-summary, remediation, integrity, rendering, evidence request, evidence reference, and claim challenge authority bounded | source repair, eval-suite ownership, proof verdict authority, CI platform policy, release policy, generated truth, archive governance, review-board workflow, Agon move law, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
+| [Owner-Boundary Bridge Wave C Skill Instruction Capability Review](reviews/owner-boundary-bridge-wave-c-skill-instruction-capability-review.md) | confirms the third long-pass wave over instruction, skill-adjacent, capability, docs-boundary, and proof-support shelves: `22` leaves keep source/target, registry, command, discovery, contract, context-map, and invariant authority bounded | source repair, accepted skill workflow, command behavior, marketplace acceptance, registry product doctrine, routing policy, source-of-truth governance, runtime role law, eval-suite authority, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -665,20 +674,21 @@ moves, no schema/frontmatter changes, no generated-surface changes, and no
 empirical model-proof claim. The residual scan records repeated adapter needs
 as a future lightweight guide candidate, not as a current blocker.
 
-Current latest owner-boundary bridge wave: Wave B is closed over
-`proof/evaluation-chain`, `proof/published-summary`, and
-`proof/review-evidence`. It confirms that proof, publication, and
-review-evidence leaves can hold without source repair when summary contracts,
-staged gates, CI reports, latest/history storage, remediation and integrity
-snapshots, required/optional rendering, evidence requests, scoped references,
-and claim challenges stop before proof verdict, generated truth, CI policy,
-review-board authority, and Agon move law.
-
-Next clean move: continue the owner-boundary bridge long pass with Wave C over
+Current latest owner-boundary bridge wave: Wave C is closed over
 `instruction/instruction-surface`, `instruction/docs-boundary`,
 `instruction/capability-registry`, `instruction/capability-boundary`,
-`instruction/skill-discovery`, and `proof/skill-support`. Do not restart
-portability as a broad audit, do not add future relation names such as
+`instruction/skill-discovery`, and `proof/skill-support`. It confirms that
+instruction, skill-adjacent, capability, docs-boundary, and proof-support
+leaves can hold without source repair when source/target, registry, command,
+discovery, contract, context-map, and invariant moves stop before accepted
+skill workflows, command behavior, marketplace acceptance, registry product
+doctrine, routing policy, source-of-truth governance, runtime role law, and
+eval-suite authority.
+
+Next clean move: continue the owner-boundary bridge long pass with Wave D over
+`execution/agent-workflows-core`, `execution/intent-chain`,
+`execution/ready-work-graphs`, and `execution/runtime-truth-lifecycle`. Do not
+restart portability as a broad audit, do not add future relation names such as
 `follows`, do not promote scout axes into frontmatter without a separate
 decision and validator wave, and do not run local small-agent proof without an
 `aoa-evals` proof surface.

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
@@ -149,7 +149,7 @@ Use this exact loop for every wave:
 - [x] Phase 1: create and verify this temporary plan.
 - [x] Phase 2: Wave A owner-facing governance/proof review.
 - [x] Phase 3: Wave B proof and publication authority review.
-- [ ] Phase 4: Wave C skill, instruction, and capability authority review.
+- [x] Phase 4: Wave C skill, instruction, and capability authority review.
 - [ ] Phase 5: Wave D execution and runtime-adjacent authority review.
 - [ ] Phase 6: Wave E continuity, checkpoint, recovery, and donor authority
   review.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -118,5 +118,6 @@ Current reviews:
 - [owner-boundary-bridge-practice-adoption-lifecycle-pilot](owner-boundary-bridge-practice-adoption-lifecycle-pilot.md)
 - [owner-boundary-bridge-wave-a-governance-owner-proof-review](owner-boundary-bridge-wave-a-governance-owner-proof-review.md)
 - [owner-boundary-bridge-wave-b-proof-publication-review](owner-boundary-bridge-wave-b-proof-publication-review.md)
+- [owner-boundary-bridge-wave-c-skill-instruction-capability-review](owner-boundary-bridge-wave-c-skill-instruction-capability-review.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-wave-c-skill-instruction-capability-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-wave-c-skill-instruction-capability-review.md
@@ -1,0 +1,239 @@
+# Owner-Boundary Bridge Wave C Skill Instruction Capability Review
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Temporary plan:
+[Temporary Owner-Boundary Bridge Long-Pass Plan](../TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md)
+
+Prior wave:
+[Owner-Boundary Bridge Wave B Proof Publication Review](owner-boundary-bridge-wave-b-proof-publication-review.md)
+
+Status: owner-boundary bridge Wave C, no source rewrite, no generated surface
+change, no schema/frontmatter change, no empirical small-agent proof.
+
+## Verdict
+
+Wave C holds.
+
+This wave covers the instruction and skill-adjacent shelves where technique
+language can easily overgrow into neighboring owners: skill packaging,
+command behavior, marketplace acceptance, registry product doctrine, routing
+policy, source-of-truth governance, runtime role law, and eval framework
+authority. Direct reading confirms the current twenty-two leaves stay on the
+technique side of that line.
+
+`instruction-surface` owns source, target, fragment, layer, mirror, and
+profile composition moves. `docs-boundary` owns compact document-role,
+status, decision, and public-share moves. `capability-registry` owns a
+spec-entry-query chain without product registry authority. `capability-boundary`
+owns guardrails around skill-command, source-priority, and
+recommendation-actionability splits. `skill-discovery` owns editorial
+discoverability and upstream source readiness without installer or acceptance
+power. `proof/skill-support` owns the support triangle of vocabulary map,
+consumer-visible contract, and invariant coverage without becoming an eval
+suite.
+
+No source repair is accepted. The current wording already keeps these leaves
+atomic, portable, and readable as techniques while sending stronger authority
+to the relevant owner only as a stop-line.
+
+## Sources Read
+
+Route and plan surfaces:
+
+- `AGENTS.md`
+- `mechanics/AGENTS.md`
+- `mechanics/distillation/AGENTS.md`
+- `mechanics/distillation/parts/AGENTS.md`
+- [Technique Reform Ingress](../README.md)
+- [Temporary Owner-Boundary Bridge Long-Pass Plan](../TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md)
+- `techniques/AGENTS.md`
+- `techniques/instruction/AGENTS.md`
+- `techniques/proof/AGENTS.md`
+
+Direct bundle and support reads:
+
+- [AOA-T-0012 deterministic-context-composition](../../../../../techniques/instruction/instruction-surface/deterministic-context-composition/TECHNIQUE.md)
+- [AOA-T-0013 single-source-rule-distribution](../../../../../techniques/instruction/instruction-surface/single-source-rule-distribution/TECHNIQUE.md)
+- [AOA-T-0024 upstream-mirroring-with-provenance](../../../../../techniques/instruction/instruction-surface/upstream-mirroring-with-provenance/TECHNIQUE.md)
+- [AOA-T-0027 cross-agent-skill-propagation](../../../../../techniques/instruction/instruction-surface/cross-agent-skill-propagation/TECHNIQUE.md)
+- [AOA-T-0029 nested-rule-loading](../../../../../techniques/instruction/instruction-surface/nested-rule-loading/TECHNIQUE.md)
+- [AOA-T-0030 fragmented-agent-context](../../../../../techniques/instruction/instruction-surface/fragmented-agent-context/TECHNIQUE.md)
+- [AOA-T-0035 profile-preset-composition](../../../../../techniques/instruction/instruction-surface/profile-preset-composition/TECHNIQUE.md)
+- [AOA-T-0002 source-of-truth-layout](../../../../../techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md)
+- [AOA-T-0009 lightweight-status-snapshot](../../../../../techniques/instruction/docs-boundary/lightweight-status-snapshot/TECHNIQUE.md)
+- [AOA-T-0033 decision-rationale-recording](../../../../../techniques/instruction/docs-boundary/decision-rationale-recording/TECHNIQUE.md)
+- [AOA-T-0034 public-safe-artifact-sanitization](../../../../../techniques/instruction/docs-boundary/public-safe-artifact-sanitization/TECHNIQUE.md)
+- [AOA-T-0025 capability-spec-versioning](../../../../../techniques/instruction/capability-registry/capability-spec-versioning/TECHNIQUE.md)
+- [AOA-T-0063 versioned-agent-registry-contract](../../../../../techniques/instruction/capability-registry/versioned-agent-registry-contract/TECHNIQUE.md)
+- [AOA-T-0064 capability-discovery](../../../../../techniques/instruction/capability-registry/capability-discovery/TECHNIQUE.md)
+- [AOA-T-0040 skill-vs-command-boundary](../../../../../techniques/instruction/capability-boundary/skill-vs-command-boundary/TECHNIQUE.md)
+- [AOA-T-0043 multi-source-primary-input-provenance](../../../../../techniques/instruction/capability-boundary/multi-source-primary-input-provenance/TECHNIQUE.md)
+- [AOA-T-0093 recommendation-truth-vs-host-actionability](../../../../../techniques/instruction/capability-boundary/recommendation-truth-vs-host-actionability/TECHNIQUE.md)
+- [AOA-T-0041 skill-marketplace-curation](../../../../../techniques/instruction/skill-discovery/skill-marketplace-curation/TECHNIQUE.md)
+- [AOA-T-0042 upstream-skill-health-checking](../../../../../techniques/instruction/skill-discovery/upstream-skill-health-checking/TECHNIQUE.md)
+- [AOA-T-0015 contract-test-design](../../../../../techniques/proof/skill-support/contract-test-design/TECHNIQUE.md)
+- [AOA-T-0016 bounded-context-map](../../../../../techniques/proof/skill-support/bounded-context-map/TECHNIQUE.md)
+- [AOA-T-0017 property-invariants](../../../../../techniques/proof/skill-support/property-invariants/TECHNIQUE.md)
+- local `checks/`, `examples/`, and `notes/second-context-adaptation.md`,
+  `notes/origin-evidence.md`, `notes/external-origin.md`,
+  `notes/external-import-review.md`, `notes/canonical-readiness.md`, or
+  `notes/adverse-effects-review.md` where present for the scoped leaves.
+
+Prior review packets:
+
+- [Instruction-Surface Direct-Read Migration Review](instruction-surface-direct-read-migration-review.md)
+- [Landed Instruction-Surface Pilot Review](landed-instruction-surface-pilot-review.md)
+- [Docs-Boundary Direct-Read Migration Review](docs-boundary-direct-read-migration-review.md)
+- [Landed Docs-Boundary Pilot Review](landed-docs-boundary-pilot-review.md)
+- [Capability-Registry Direct-Read Migration Review](capability-registry-direct-read-migration-review.md)
+- [Landed Capability-Registry Pilot Review](landed-capability-registry-pilot-review.md)
+- [Capability-Boundary Direct-Read Migration Review](capability-boundary-direct-read-migration-review.md)
+- [Landed Capability-Boundary Pilot Review](landed-capability-boundary-pilot-review.md)
+- [Skill-Discovery Direct-Read Migration Review](skill-discovery-direct-read-migration-review.md)
+- [Landed Skill-Discovery Pilot Review](landed-skill-discovery-pilot-review.md)
+- [Skill-Support Direct-Read Migration Review](skill-support-direct-read-migration-review.md)
+- [Landed Skill-Support Pilot Review](landed-skill-support-pilot-review.md)
+- [Selector Relation Wave B Instruction Knowledge Review](selector-relation-wave-b-instruction-knowledge-review.md)
+- [Selector Relation Wave F Capability Media History Review](selector-relation-wave-f-capability-media-history-review.md)
+- [Capability Media Direct Relation Repair](capability-media-direct-relation-repair.md)
+- [Portability Bridge Wave C Owner Governance Knowledge Review](portability-bridge-wave-c-owner-governance-knowledge-review.md)
+
+## Boundary Map
+
+| technique | technique-local atom | allowed bridge | authority held outside | verdict |
+|---|---|---|---|---|
+| `AOA-T-0012` `deterministic-context-composition` | many source fragments compose into one deterministic generated context artifact | gives reviewable traceability from output back to source fragments | generated-context authority, prompt control, runtime loader behavior, multi-target propagation, source-of-truth governance | holds; no repair |
+| `AOA-T-0013` `single-source-rule-distribution` | one canonical local rule source refreshes multiple managed instruction targets | lets agent-facing files share rule meaning without copy-paste drift | per-agent product behavior, skill activation, MCP propagation, nested loading, target-file authority | holds; no repair |
+| `AOA-T-0024` `upstream-mirroring-with-provenance` | upstream-owned content mirrors locally with manifest and attribution | preserves origin ownership for curated local copies | marketplace policy, installer behavior, registry generation, upstream ownership transfer, sync-platform doctrine | holds; no repair |
+| `AOA-T-0027` `cross-agent-skill-propagation` | one shared skill or rule core propagates into multiple managed agent-facing targets | keeps target files subordinate to a canonical shared core | accepted skill workflow, role semantics, marketplace curation, MCP propagation, target-local source truth | holds; no repair |
+| `AOA-T-0029` `nested-rule-loading` | hierarchical rule layers load with explicit precedence | lets nested additions stay subordinate to the owning layer | AoA law, role contract doctrine, broad instruction framework, runtime loader platform, source-of-truth governance | holds; no repair |
+| `AOA-T-0030` `fragmented-agent-context` | agent context stays in bounded source fragments before assembly | makes fragment ownership reviewable before a generated artifact exists | generated artifact authority, final context composition engine, token-report platform, runtime prompt control | holds; no repair |
+| `AOA-T-0035` `profile-preset-composition` | modules, profiles, and presets resolve into inspectable runtime posture definitions | keeps composition reviewable before launch | rendered runtime truth, launcher doctrine, service lifecycle, deployment roots, host-specific command behavior | holds; no repair |
+| `AOA-T-0002` `source-of-truth-layout` | recurring document roles get distinct canonical homes and update routes | gives a repository a readable doc-role map | universal source-of-truth governance, AoA constitutional law, architecture taxonomy, owner consent, runtime policy | holds; no repair |
+| `AOA-T-0009` `lightweight-status-snapshot` | entrypoint status docs stay short and link-driven | routes detailed status and history to existing canonical homes | deletion of detail, repo-wide status authority, CI truth, archive governance, operational runbook ownership | holds; no repair |
+| `AOA-T-0033` `decision-rationale-recording` | one meaningful decision gets context, options, rationale, and consequences | preserves why a choice was made for future review | decision authority, source-of-truth governance, boundary mapping, architecture taxonomy, backlog ownership | holds; no repair |
+| `AOA-T-0034` `public-safe-artifact-sanitization` | sensitive technical material becomes a shareable artifact | keeps the technical lesson while reducing unsafe detail | sharing approval, execution planning, incident response, security policy, public-release governance | holds; no repair |
+| `AOA-T-0025` `capability-spec-versioning` | one named capability has a versioned reviewable contract | lets implementations stay subordinate to the capability spec | routing policy, registry product doctrine, persistent agent store, orchestration, provider runtime behavior | holds; no repair |
+| `AOA-T-0063` `versioned-agent-registry-contract` | one registry-facing entry publishes a named versioned record | gives discovery a bounded published-entry object | capability meaning itself, discovery ranking, marketplace page, trust policy, signature system, runtime registry product | holds; no repair |
+| `AOA-T-0064` `capability-discovery` | one bounded query surface looks up already-published entries | depends on the published-entry contract without owning publication | ranking, curation, trust scoring, graph traversal, marketplace product, runtime resolver | holds; no repair |
+| `AOA-T-0040` `skill-vs-command-boundary` | reusable skill meaning stays separate from command invocation | lets capability artifacts stay portable across command surfaces | command syntax, argument policy, shell doctrine, skill package acceptance, command workflow ownership | holds; no repair |
+| `AOA-T-0043` `multi-source-primary-input-provenance` | one primary input and supporting inputs stay visible in a combined surface | gives downstream synthesis a priority order to preserve | KAG graph semantics, relation doctrine, ranking, retrieval policy, bridge architecture program | holds; no repair |
+| `AOA-T-0093` `recommendation-truth-vs-host-actionability` | recommendation truth and host executability are annotated separately | keeps relevant but non-executable guidance visible | routing policy, host install doctrine, runtime action authority, skill activation, inventory product ownership | holds; no repair |
+| `AOA-T-0041` `skill-marketplace-curation` | a local editorial layer makes upstream-owned skills discoverable | gives selection a curated public index without claiming source ownership | installer behavior, marketplace acceptance, sync substrate, capability meaning, registry governance, trust scoring | holds; no repair |
+| `AOA-T-0042` `upstream-skill-health-checking` | upstream skill sources are checked for availability and manifest readiness | marks whether a skill source is surfaceable before local discovery | security-scanner doctrine, generic monitoring, skill acceptance, installer policy, registry governance | holds; no repair |
+| `AOA-T-0015` `contract-test-design` | one consumer-visible boundary gets explicit input/output/failure contract checks | gives downstream consumers a bounded validation surface | eval-suite authority, mandatory testing doctrine, hidden internal correctness, broad invariant coverage | holds; no repair |
+| `AOA-T-0016` `bounded-context-map` | neighboring responsibilities and handoff interfaces become visible | gives future work a scoping map before implementation or proof widens | architecture program, DDD formalism, source-of-truth governance, owner authority, eval verdict | holds; no repair |
+| `AOA-T-0017` `property-invariants` | one meaningful stable truth becomes invariant-oriented checks | broadens validation beyond handpicked examples | eval framework ownership, proof verdict, generator theater, contract-boundary design, policy enforcement | holds; no repair |
+
+## Cross-Owner Read
+
+Wave C keeps technique atoms useful without importing the owning systems that
+often surround them.
+
+The local atom may name a source, target, profile, document role, capability
+contract, registry entry, discovery query, command boundary, source priority,
+recommendation gap, curated skill entry, contract check, context map, or
+invariant. It may not accept a skill, install a command, decide a route, prove
+an eval, own a registry product, mutate host inventory, govern AoA law, or
+turn generated outputs into source truth.
+
+Adjacent split:
+
+- `aoa-skills` owns accepted skill workflows, skill packages, triggers,
+  activation, and command execution shape.
+- `aoa-routing` owns route products and recommendation policy; a technique may
+  preserve recommendation truth but not decide dispatch law.
+- `aoa-evals` owns empirical proof surfaces, eval bundles, pass/fail verdicts,
+  and report authority.
+- `aoa-kag` owns graph or retrieval substrate meaning; source-priority and
+  registry-entry techniques stay below graph semantics.
+- `aoa-agents` owns role contracts, profiles as agent-layer contract surfaces,
+  checkpoint contracts, and progression/recurrence meaning.
+- runtime owners such as `abyss-stack` own launchers, services, host lifecycle,
+  deployment roots, and local operator behavior.
+- `Agents-of-Abyss` owns constitutional center doctrine and ecosystem law.
+
+## Wave Findings
+
+`instruction-surface` holds because each leaf keeps source and target authority
+visible. Generated context, rule fan-out, upstream mirroring, shared skill/rule
+propagation, nested precedence, fragments, and profile/preset resolution stay
+as surface-management moves rather than instruction doctrine or runtime law.
+
+`docs-boundary` holds because the leaves remain small document-practice atoms.
+Role layout, short status snapshots, decision notes, and public-safe share
+preparation help a repository stay readable, but they do not decide owner
+truth, architecture taxonomy, approval, or execution.
+
+`capability-registry` holds because the spec-entry-query chain stays layered.
+`AOA-T-0064 requires AOA-T-0063` is already a direct relation repair from the
+selector/relation lane, and this wave does not widen it: lookup needs a
+published entry object, not a registry product doctrine.
+
+`capability-boundary` holds because each guardrail is explicit about the stop.
+Skill meaning is not command invocation, source priority is not graph ranking,
+and host actionability is not recommendation truth.
+
+`skill-discovery` holds because discoverability is editorial and readiness is
+pre-surface. Neither leaf accepts, installs, activates, signs, trusts, ranks,
+or executes a skill.
+
+`proof/skill-support` holds because the shelf supports proof-facing work
+without becoming proof authority. A context map scopes language, a contract
+test checks a consumer-visible boundary, and an invariant constrains a stable
+truth. None creates an eval suite or a proof verdict.
+
+## Repair Gate
+
+No source repair is accepted.
+
+Held, not defects:
+
+| hold | reason |
+|---|---|
+| skill wording in instruction leaves | current contracts keep skill/rule propagation, marketplace curation, and upstream health distinct from accepted `aoa-skills` workflow authority |
+| registry and capability wording | current registry leaves separate capability spec, published entry, and lookup while refusing product registry, trust, ranking, graph, and runtime resolution authority |
+| source-of-truth wording | doc-role and snapshot leaves are repository-local patterns, not universal AoA law or owner acceptance |
+| command and host-actionability examples | the examples explain boundaries around invocation and executability without becoming shell policy or runtime law |
+| proof-support canonical status | canonical technique readiness does not mean eval-suite ownership or empirical proof verdict authority |
+| existing relation repair | `AOA-T-0064 requires AOA-T-0063` remains a selector/relation repair; owner-boundary prose does not add hidden sequence or new relation vocabulary |
+| empirical proof | no local small model executed these techniques in this wave |
+
+## What Changed
+
+- added this Wave C review packet;
+- recorded `holds; no repair` for all twenty-two Wave C leaves;
+- updated the review index, source packet contour, and temporary plan status.
+
+## What Did Not Change
+
+- no `TECHNIQUE.md`, checklist, example, or note source changed;
+- no generated catalog, capsule, manifest, source-lift, KAG export, or reader
+  surface changed;
+- no frontmatter, schema, path, status, `domain`, `kind`, maturity, evidence,
+  owner, or relation changed;
+- no sibling owner accepted new authority from this packet;
+- no empirical small-agent proof is claimed;
+- no universal `Law / Local Form / Bridges` block was added.
+
+## Public-Safety Read
+
+This packet uses public bundle text, route cards, and landed review packets. It
+does not publish credentials, private hosts, internal runtime state, local
+operator procedures, non-public donor text, or sibling implementation detail.
+Skill, command, registry, routing, KAG, runtime, source-of-truth, public-share,
+and eval terms are review subjects only.
+
+## Next Honest Move
+
+Continue the temporary plan with Wave D:
+
+- `execution/agent-workflows-core`;
+- `execution/intent-chain`;
+- `execution/ready-work-graphs`;
+- `execution/runtime-truth-lifecycle`.
+
+Wave D should keep execution and runtime-adjacent leaves from becoming accepted
+skill workflows, shell policy, service lifecycle law, deployment ownership,
+runtime truth, playbook choreography, or routing products.


### PR DESCRIPTION
## Summary
- add the owner-boundary Wave C review packet for instruction, docs-boundary, capability, skill-discovery, and skill-support shelves
- record 22/22 Wave C leaves as `holds; no repair` with no bundle/source/generated/schema/frontmatter changes
- update the review index, ingress contour, evidence stack, current next move, and temporary plan status

## Validation
- `git diff --check`
- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- public-safety grep over touched files; only prohibition/scope language and thematic `token-report` subject text matched

## Public Safety
Review-only mechanics docs. No credentials, private hosts, local operator procedures, non-public donor text, sibling implementation detail, generated hand edits, or empirical model-proof claims.