### PR TITLE
Review owner-boundary residual scan

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -414,6 +414,10 @@ permission slip to remap techniques automatically.
   local indexing, witness trace, replay, code lineage, and MCP gateway
   authority bounded; no source repairs, schema/frontmatter changes,
   generated-surface changes, or empirical small-agent proof
+- owner-boundary bridge residual scan: landed over the two calibration pilots
+  and Waves A through F, accounting for `28/28` shelves and `107/107`
+  bundles, confirming `107` unique boundary rows, finding no hidden source or
+  relation repair, and leaving the owner-boundary repair queue empty
 
 ## Evidence Stack
 
@@ -557,6 +561,7 @@ permission slip to remap techniques automatically.
 | [Owner-Boundary Bridge Wave D Execution Runtime Review](reviews/owner-boundary-bridge-wave-d-execution-runtime-review.md) | confirms the fourth long-pass wave over execution and runtime-adjacent shelves: `14` leaves keep workflow, slice, single-shot, confirmation, shell, intent, graph, ready-work, render, host-doctor, lifecycle, and benchmark authority bounded | source repair, accepted skill workflow, shell policy, host command law, dispatch ownership, scheduler product, playbook choreography, runtime deployment, service platform policy, monitor ownership, benchmark-suite governance, eval verdict authority, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Wave E Continuity Recovery Review](reviews/owner-boundary-bridge-wave-e-continuity-recovery-review.md) | confirms the fifth long-pass wave over continuity and recovery shelves: `22` leaves keep review, compaction, handoff, donor, diagnosis, checkpoint, degraded recovery, receipt analysis, service stop, and stress closeout authority bounded | source repair, memory truth, agent-role law, checkpoint doctrine, quest/progression authority, accepted skill behavior, routing policy, KAG substrate ownership, playbook choreography, runtime incident doctrine, service-operation ownership, eval verdict authority, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Wave F Knowledge Ingest History Tool Review](reviews/owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md) | confirms the sixth long-pass wave over knowledge-lift, ingest, history, and tool-use shelves: `20` leaves keep source-lift, media ingest, history artifact, and MCP gateway authority bounded | source repair, KAG graph truth, retrieval policy, media-platform doctrine, cleanup/deletion policy, auth/session doctrine, memory truth, transcript canon, hosted viewer product, repo analytics, MCP platform law, marketplace ownership, scanner/trust scoring, runtime deployment, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
+| [Owner-Boundary Bridge Residual Cross-Wave Scan](reviews/owner-boundary-bridge-residual-cross-wave-scan.md) | accounts for the two calibration pilots plus Waves A through F as `28/28` shelves, `107/107` bundles, `107` unique boundary rows, and an empty owner-boundary repair queue | source repair, direct relation repair, schema/frontmatter migration, generated-surface change, universal bridge blocks, sibling-owner acceptance, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -714,14 +719,19 @@ auth/session doctrine, memory truth, transcript canon, hosted viewer products,
 repo analytics, MCP platform law, marketplace ownership, scanner/trust
 scoring, runtime deployment, and eval verdict authority.
 
-Next clean move: run the owner-boundary bridge residual cross-wave scan. Account
-for all `28` shelves and all `107` bundles across the two calibration pilots
-and Waves A through F, confirm no source repair or relation repair is hidden in
-review prose, and decide whether the long pass can close without a repair
-queue. Do not restart portability as a broad audit, do not add future relation
-names such as `follows`, do not promote scout axes into frontmatter without a
-separate decision and validator wave, and do not run local small-agent proof
-without an `aoa-evals` proof surface.
+Current latest owner-boundary bridge residual scan: the scan is closed over the
+two calibration pilots and Waves A through F. It accounts for all `28` active
+shelves and all `107` current bundles, confirms `107` unique boundary rows,
+finds no missing or extra `AOA-T-*` IDs, accepts no source repair, accepts no
+owner-boundary relation repair, and leaves the owner-boundary repair queue
+empty.
+
+Next clean move: close the owner-boundary bridge long pass with a durable
+ledger, mark the temporary plan superseded, update the ingress evidence stack,
+and choose the next reform lane. Do not restart portability as a broad audit,
+do not add future relation names such as `follows`, do not promote scout axes
+into frontmatter without a separate decision and validator wave, and do not run
+local small-agent proof without an `aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
@@ -155,7 +155,7 @@ Use this exact loop for every wave:
   review.
 - [x] Phase 7: Wave F knowledge, ingest, history, and tool-use authority
   review.
-- [ ] Phase 8: residual cross-wave scan and repair queue decision.
+- [x] Phase 8: residual cross-wave scan and repair queue decision.
 - [ ] Phase 9: closeout ledger, temporary-plan disposition, and next lane.
 
 ## Calibration Pilots Accounted Set

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -122,5 +122,6 @@ Current reviews:
 - [owner-boundary-bridge-wave-d-execution-runtime-review](owner-boundary-bridge-wave-d-execution-runtime-review.md)
 - [owner-boundary-bridge-wave-e-continuity-recovery-review](owner-boundary-bridge-wave-e-continuity-recovery-review.md)
 - [owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review](owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md)
+- [owner-boundary-bridge-residual-cross-wave-scan](owner-boundary-bridge-residual-cross-wave-scan.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-residual-cross-wave-scan.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-residual-cross-wave-scan.md
@@ -1,0 +1,144 @@
+# Owner-Boundary Bridge Residual Cross-Wave Scan
+
+Status: residual accounting scan, not source rewrite, not generated surface
+change, not schema or frontmatter migration, not empirical small-agent proof.
+
+## Verdict
+
+The owner-boundary bridge long pass now accounts for every active technique
+shelf and every current technique bundle:
+
+- `28/28` active shelves are covered by either a calibration pilot or Wave A
+  through Wave F.
+- `107/107` current `TECHNIQUE.md` bundles have one owner-boundary boundary
+  row.
+- `107` boundary rows were found across the two calibration pilots and six
+  waves.
+- `107` unique `AOA-T-*` IDs were found in those boundary rows.
+- no duplicate boundary row ID was found.
+- no current technique ID is missing from the owner-boundary packets.
+- no non-current technique ID appears in the owner-boundary packets.
+
+No source repair is accepted. The owner-boundary repair queue is empty.
+
+No direct relation repair is accepted by this owner-boundary pass. The seven
+already-landed selector/relation repairs remain separate source changes from
+the selector/relation lane, not hidden owner-boundary edits.
+
+## Sources Read
+
+- [Temporary Owner-Boundary Bridge Long-Pass Plan](../TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md)
+- [Owner-Boundary Bridge Promotion-Boundary Pilot](owner-boundary-bridge-promotion-boundary-pilot.md)
+- [Owner-Boundary Bridge Practice-Adoption-Lifecycle Pilot](owner-boundary-bridge-practice-adoption-lifecycle-pilot.md)
+- [Owner-Boundary Bridge Wave A Governance Owner Proof Review](owner-boundary-bridge-wave-a-governance-owner-proof-review.md)
+- [Owner-Boundary Bridge Wave B Proof Publication Review](owner-boundary-bridge-wave-b-proof-publication-review.md)
+- [Owner-Boundary Bridge Wave C Skill Instruction Capability Review](owner-boundary-bridge-wave-c-skill-instruction-capability-review.md)
+- [Owner-Boundary Bridge Wave D Execution Runtime Review](owner-boundary-bridge-wave-d-execution-runtime-review.md)
+- [Owner-Boundary Bridge Wave E Continuity Recovery Review](owner-boundary-bridge-wave-e-continuity-recovery-review.md)
+- [Owner-Boundary Bridge Wave F Knowledge Ingest History Tool Review](owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md)
+- [Selector Relation Residual Cross-Wave Scan](selector-relation-residual-cross-wave-scan.md)
+- [Selector Relation Long-Pass Closeout Ledger](selector-relation-long-pass-closeout-ledger.md)
+- [Portability Bridge Residual Cross-Wave Scan](portability-bridge-residual-cross-wave-scan.md)
+- [Portability Bridge Long-Pass Closeout Ledger](portability-bridge-long-pass-closeout-ledger.md)
+- [Bundle Anatomy Final Closeout Ledger](bundle-anatomy-final-closeout-ledger.md)
+
+## Coverage Ledger
+
+| slice | shelves | bundles | result |
+|---|---:|---:|---|
+| promotion-boundary calibration | 1 | 3 | covered and held with no repair |
+| practice-adoption-lifecycle calibration | 1 | 3 | covered and held with no repair |
+| Wave A governance owner proof | 4 | 13 | covered and held with no repair |
+| Wave B proof publication | 3 | 10 | covered and held with no repair |
+| Wave C skill instruction capability | 6 | 22 | covered and held with no repair |
+| Wave D execution runtime | 4 | 14 | covered and held with no repair |
+| Wave E continuity recovery | 5 | 22 | covered and held with no repair |
+| Wave F knowledge ingest history tool | 4 | 20 | covered and held with no repair |
+| total | 28 | 107 | full current corpus coverage |
+
+The active tree still has retained frontmatter-lane route directories
+`agent-workflows`, `docs`, and `evaluation`, but they contain no current
+technique leaves. They are not missing owner-boundary shelves; active bundle
+paths are under the `10` catalogued trunks and `28` active shelves.
+
+## Shelf Account
+
+| slice | shelves |
+|---|---|
+| calibration | `governance/promotion-boundary`; `governance/practice-adoption-lifecycle` |
+| Wave A | `governance/decision-routing`; `governance/approval-evidence`; `governance/automation-readiness`; `proof/owner-truth-closeout` |
+| Wave B | `proof/evaluation-chain`; `proof/published-summary`; `proof/review-evidence` |
+| Wave C | `instruction/instruction-surface`; `instruction/docs-boundary`; `instruction/capability-registry`; `instruction/capability-boundary`; `instruction/skill-discovery`; `proof/skill-support` |
+| Wave D | `execution/agent-workflows-core`; `execution/intent-chain`; `execution/ready-work-graphs`; `execution/runtime-truth-lifecycle` |
+| Wave E | `continuity/review-compaction`; `continuity/handoff-continuation`; `continuity/donor-harvest`; `recovery/diagnosis-repair`; `recovery/antifragility-recovery` |
+| Wave F | `knowledge-lift/kag-source-lift`; `ingest/media-ingest`; `history/history-artifacts`; `tool-use/tool-gateway` |
+
+No shelf appears in two slices. No current shelf is absent.
+
+## Parity Checks
+
+The current active technique tree contains `107` `TECHNIQUE.md` files.
+
+The owner-boundary packet row check found:
+
+- `107` boundary rows with an `AOA-T-*` row prefix;
+- `107` unique row IDs;
+- no duplicate row IDs.
+
+The current-source ID comparison was empty in both directions:
+
+- no `AOA-T-*` ID present in current `TECHNIQUE.md` files is absent from the
+  owner-boundary packets;
+- no `AOA-T-*` ID present in owner-boundary boundary rows is absent from
+  current `TECHNIQUE.md` files.
+
+## Repair Queue Decision
+
+The owner-boundary repair queue is empty.
+
+The pass found recurring authority pressure, but each case was already held by
+the local technique atom, support notes, and wave packet stop-lines:
+
+| pressure class | decision |
+|---|---|
+| owner routing vs route policy | hold; technique may name an owner target without owning route law |
+| approval and automation | hold; technique may shape evidence or readiness without granting execution |
+| proof, CI, and publication | hold; technique may emit reviewable summaries without claiming eval verdict authority |
+| skill and capability surfaces | hold; technique may describe proposal, discovery, or registry objects without owning accepted skill workflow, marketplace, or command behavior |
+| runtime and service lifecycle | hold; technique may shape local checks or lifecycle objects without becoming deployment policy |
+| continuity, donor, checkpoint, and recovery | hold; technique may preserve evidence and restartability without owning memory truth, agent-role law, quest/progression authority, or incident doctrine |
+| KAG, media, history, and tool-use | hold; technique may lift source, media, artifact, or gateway objects without becoming graph truth, media-platform law, transcript canon, or MCP platform ownership |
+
+## Relation Repair Parity
+
+The selector/relation lane already accepted exactly seven direct relation
+repairs:
+
+- `AOA-T-0058 requires AOA-T-0057`
+- `AOA-T-0059 requires AOA-T-0057`
+- `AOA-T-0050 requires AOA-T-0049`
+- `AOA-T-0103 used_together_for AOA-T-0104`
+- `AOA-T-0082 requires AOA-T-0081`
+- `AOA-T-0064 requires AOA-T-0063`
+- `AOA-T-0071 requires AOA-T-0070`
+
+This residual scan does not add, remove, strengthen, or weaken any of them.
+They remain source-owned relation repairs from the selector/relation lane.
+
+## Unauthorized Changes Not Made
+
+- no `TECHNIQUE.md` source rewrite;
+- no generated catalog or generated compact-card edit;
+- no schema or validator migration;
+- no frontmatter, status, maturity, path, `domain`, or `kind` change;
+- no relation source change;
+- no universal `Law / Local Form / Bridges` block;
+- no sibling owner acceptance claim;
+- no empirical small-agent proof claim.
+
+## Next Honest Move
+
+Close the owner-boundary bridge long pass with a durable closeout ledger. The
+closeout should mark the temporary plan superseded, update the ingress evidence
+stack, preserve the no-repair verdict, and choose the next reform lane without
+turning this residual scan into bundle authority.


### PR DESCRIPTION
## Summary
- Add the owner-boundary residual cross-wave scan for the two calibration pilots plus Waves A through F.
- Account for all `28/28` active shelves and `107/107` current bundles with `107` unique boundary rows.
- Record an empty owner-boundary repair queue and keep selector/relation repairs separate.

## Boundary
- Review-only packet; no technique source, generated, schema, frontmatter, status, path, or relation source change.
- No universal `Law / Local Form / Bridges` blocks.
- No empirical small-agent proof claim.

## Validation
- `git diff --check`
- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- public-safety grep over touched files
- bridge-block grep over touched files
- current-source ID parity and owner-boundary boundary-row checks
