### PR TITLE
Close owner-boundary long pass ledger

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -418,6 +418,11 @@ permission slip to remap techniques automatically.
   and Waves A through F, accounting for `28/28` shelves and `107/107`
   bundles, confirming `107` unique boundary rows, finding no hidden source or
   relation repair, and leaving the owner-boundary repair queue empty
+- owner-boundary bridge closeout: landed as durable review memory for the full
+  owner-boundary long pass, closing `28/28` shelves and `107/107` bundles with
+  no accepted source repairs, no accepted owner-boundary relation repairs, no
+  schema/frontmatter/generated changes, and the temporary rhythm plan marked
+  superseded rather than deleted
 
 ## Evidence Stack
 
@@ -562,6 +567,7 @@ permission slip to remap techniques automatically.
 | [Owner-Boundary Bridge Wave E Continuity Recovery Review](reviews/owner-boundary-bridge-wave-e-continuity-recovery-review.md) | confirms the fifth long-pass wave over continuity and recovery shelves: `22` leaves keep review, compaction, handoff, donor, diagnosis, checkpoint, degraded recovery, receipt analysis, service stop, and stress closeout authority bounded | source repair, memory truth, agent-role law, checkpoint doctrine, quest/progression authority, accepted skill behavior, routing policy, KAG substrate ownership, playbook choreography, runtime incident doctrine, service-operation ownership, eval verdict authority, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Wave F Knowledge Ingest History Tool Review](reviews/owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md) | confirms the sixth long-pass wave over knowledge-lift, ingest, history, and tool-use shelves: `20` leaves keep source-lift, media ingest, history artifact, and MCP gateway authority bounded | source repair, KAG graph truth, retrieval policy, media-platform doctrine, cleanup/deletion policy, auth/session doctrine, memory truth, transcript canon, hosted viewer product, repo analytics, MCP platform law, marketplace ownership, scanner/trust scoring, runtime deployment, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Owner-Boundary Bridge Residual Cross-Wave Scan](reviews/owner-boundary-bridge-residual-cross-wave-scan.md) | accounts for the two calibration pilots plus Waves A through F as `28/28` shelves, `107/107` bundles, `107` unique boundary rows, and an empty owner-boundary repair queue | source repair, direct relation repair, schema/frontmatter migration, generated-surface change, universal bridge blocks, sibling-owner acceptance, or empirical small-agent proof |
+| [Owner-Boundary Bridge Long-Pass Closeout Ledger](reviews/owner-boundary-bridge-long-pass-closeout-ledger.md) | closes the owner-boundary bridge long pass as durable review memory with full current-corpus coverage, empty repair queue, temporary-plan disposition, and next-lane guidance toward a small template modernization pilot | bundle authority, source rewrite, direct relation repair, schema/frontmatter migration, generated-surface change, sibling-owner acceptance, or empirical small-agent proof |
 | [Agon First-Narrowing Frontier](../agon-candidate-handoff/gates/frontier/first-narrowing-frontier-review.md) | why capability, substrate, execution, and risk axes matter before new kinds | readiness to add new required fields or promote Agon source status |
 | [Agon Handoff Generated Index](../agon-candidate-handoff/generated/agon_candidate_handoff.min.json) | current machine-readable frontier, pipeline counts, and topology cues | technique canon or Agon acceptance |
 
@@ -726,11 +732,17 @@ finds no missing or extra `AOA-T-*` IDs, accepts no source repair, accepts no
 owner-boundary relation repair, and leaves the owner-boundary repair queue
 empty.
 
-Next clean move: close the owner-boundary bridge long pass with a durable
-ledger, mark the temporary plan superseded, update the ingress evidence stack,
-and choose the next reform lane. Do not restart portability as a broad audit,
-do not add future relation names such as `follows`, do not promote scout axes
-into frontmatter without a separate decision and validator wave, and do not run
+Current latest owner-boundary bridge closeout: the long pass is closed as
+durable review memory. It records full current-corpus coverage, accepts no
+source repair, accepts no owner-boundary relation repair, marks the temporary
+plan superseded, and routes the next technique-reform lane toward a small
+template modernization pilot rather than another broad boundary audit.
+
+Next clean move: plan a small `Template Modernization Pilot` over one to three
+direct-read bundles where the source shape would become more executable for a
+small agent. Do not restart portability or owner-boundary as broad audits, do
+not add future relation names such as `follows`, do not promote scout axes into
+frontmatter without a separate decision and validator wave, and do not run
 local small-agent proof without an `aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md
@@ -2,13 +2,13 @@
 
 Source packet: [Technique Reform Ingress](README.md)
 
-Status: active temporary rhythm plan for the next owner-boundary bridge long
-pass.
+Status: superseded temporary rhythm plan. The durable closeout is
+[Owner-Boundary Bridge Long-Pass Closeout Ledger](reviews/owner-boundary-bridge-long-pass-closeout-ledger.md).
 
-This file is a working control surface. Keep it current while the long pass is
-active, then distill it into reviewed packets and remove it or mark its
-disposition in the closeout ledger. It is not bundle authority, not a roadmap,
-not a schema proposal, and not a generated catalog.
+This file was the working control surface for the long pass. It is now
+preserved as traceable rhythm provenance because the wave packets link to it.
+It is not current task authority, not bundle authority, not a roadmap, not a
+schema proposal, and not a generated catalog.
 
 ## Purpose
 
@@ -156,7 +156,7 @@ Use this exact loop for every wave:
 - [x] Phase 7: Wave F knowledge, ingest, history, and tool-use authority
   review.
 - [x] Phase 8: residual cross-wave scan and repair queue decision.
-- [ ] Phase 9: closeout ledger, temporary-plan disposition, and next lane.
+- [x] Phase 9: closeout ledger, temporary-plan disposition, and next lane.
 
 ## Calibration Pilots Accounted Set
 

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -123,5 +123,6 @@ Current reviews:
 - [owner-boundary-bridge-wave-e-continuity-recovery-review](owner-boundary-bridge-wave-e-continuity-recovery-review.md)
 - [owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review](owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md)
 - [owner-boundary-bridge-residual-cross-wave-scan](owner-boundary-bridge-residual-cross-wave-scan.md)
+- [owner-boundary-bridge-long-pass-closeout-ledger](owner-boundary-bridge-long-pass-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-long-pass-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/owner-boundary-bridge-long-pass-closeout-ledger.md
@@ -1,0 +1,171 @@
+# Owner-Boundary Bridge Long-Pass Closeout Ledger
+
+Source packet: [Technique Reform Ingress](../README.md)
+
+Residual scan:
+[Owner-Boundary Bridge Residual Cross-Wave Scan](owner-boundary-bridge-residual-cross-wave-scan.md)
+
+Superseded temporary plan:
+[Temporary Owner-Boundary Bridge Long-Pass Plan](../TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md)
+
+Status: long-pass closeout ledger, not bundle authority, not generated output,
+not schema migration, not frontmatter promotion, not relation repair, not
+empirical small-agent proof.
+
+## Verdict
+
+Close the owner-boundary bridge long pass as durable review memory.
+
+The pass covers all `28` active shelves and all `107` current technique
+bundles. It used two calibration pilots, six long-pass waves, and one residual
+cross-wave scan to test whether each technique remains a reusable, portable,
+atomic practice move while destination authority stays with the correct owner.
+
+Final disposition:
+
+- `28/28` active shelves covered.
+- `107/107` current bundles covered.
+- `107` unique boundary rows recorded.
+- `0` accepted source repairs.
+- `0` accepted owner-boundary relation repairs.
+- `0` generated, schema, frontmatter, status, maturity, path, `domain`, or
+  `kind` changes.
+- `0` universal bridge-law blocks introduced.
+- `0` sibling-owner acceptance claims.
+- `0` empirical small-agent proof claims.
+
+The strongest result is not that every technique is owner-neutral. The stronger
+result is that the current technique atoms can name AoA-shaped owners, proof
+surfaces, memory surfaces, KAG surfaces, runtime surfaces, skill surfaces,
+playbooks, and local project owners as bridge context without importing their
+authority into `aoa-techniques`.
+
+## Closeout Stack
+
+| packet | shelves | bundles | source repair | result |
+|---|---:|---:|---:|---|
+| [Owner-Boundary Bridge Promotion-Boundary Pilot](owner-boundary-bridge-promotion-boundary-pilot.md) | 1 | 3 | 0 | calibration held |
+| [Owner-Boundary Bridge Practice-Adoption-Lifecycle Pilot](owner-boundary-bridge-practice-adoption-lifecycle-pilot.md) | 1 | 3 | 0 | calibration held |
+| [Owner-Boundary Bridge Wave A Governance Owner Proof Review](owner-boundary-bridge-wave-a-governance-owner-proof-review.md) | 4 | 13 | 0 | governance and owner-proof held |
+| [Owner-Boundary Bridge Wave B Proof Publication Review](owner-boundary-bridge-wave-b-proof-publication-review.md) | 3 | 10 | 0 | proof and publication held |
+| [Owner-Boundary Bridge Wave C Skill Instruction Capability Review](owner-boundary-bridge-wave-c-skill-instruction-capability-review.md) | 6 | 22 | 0 | skill, instruction, and capability edges held |
+| [Owner-Boundary Bridge Wave D Execution Runtime Review](owner-boundary-bridge-wave-d-execution-runtime-review.md) | 4 | 14 | 0 | execution and runtime-adjacent edges held |
+| [Owner-Boundary Bridge Wave E Continuity Recovery Review](owner-boundary-bridge-wave-e-continuity-recovery-review.md) | 5 | 22 | 0 | continuity, donor, checkpoint, and recovery edges held |
+| [Owner-Boundary Bridge Wave F Knowledge Ingest History Tool Review](owner-boundary-bridge-wave-f-knowledge-ingest-history-tool-review.md) | 4 | 20 | 0 | knowledge, ingest, history, and tool-use edges held |
+| [Owner-Boundary Bridge Residual Cross-Wave Scan](owner-boundary-bridge-residual-cross-wave-scan.md) | 28 | 107 | 0 | full-corpus parity confirmed |
+
+The residual scan confirms that the row-level `AOA-T-*` account matches the
+current `107` `TECHNIQUE.md` files exactly, with no missing IDs, no extra IDs,
+and no duplicate boundary-row IDs.
+
+## What This Proves
+
+- Owner-boundary pressure was real review pressure, not an automatic repair
+  queue.
+- Bridge wording works when it is light, local, and tied to the technique's
+  natural contract, risks, examples, or adaptation notes.
+- `aoa-techniques` can stay reusable outside OS Abyss while still fitting the
+  wider AoA ecosystem.
+- Sibling owner names are useful as stop-lines and route hints; they do not
+  become imported policy, workflow, proof, memory, graph, runtime, or role law.
+- The current corpus can move to the next reform lane without first doing a
+  source-wide owner-boundary rewrite.
+
+## What This Does Not Prove
+
+- It does not prove execution success by 2-4B local models.
+- It does not replace `aoa-evals`.
+- It does not make any promoted bundle canonical.
+- It does not add new required frontmatter fields or scout-axis schema truth.
+- It does not add relation vocabulary or relation rationale schema.
+- It does not accept authority on behalf of `aoa-skills`, `aoa-evals`,
+  `aoa-routing`, `aoa-memo`, `aoa-kag`, `aoa-playbooks`, `aoa-agents`,
+  runtime owners, stats owners, local project owners, or the AoA center.
+
+## Held Owner-Boundary Pressure
+
+| pressure class | held outside the technique atom |
+|---|---|
+| AoA center and Method-growth | constitutional or growth doctrine stays outside reusable technique source |
+| skills | accepted skill workflow, activation, packaging, command behavior, and marketplace acceptance |
+| evals and proof | empirical verdicts, proof categories, eval harnesses, CI policy, and pass/fail authority |
+| routing and playbooks | route selection products, scenarios, campaigns, fallback choreography, and questline authority |
+| memo, KAG, and history | memory truth, recall ranking, graph semantics, transcript canon, and provenance substrate ownership |
+| runtime and local infrastructure | deployment, service lifecycle, host command law, local approval, rollback, and operator policy |
+| governance and approval | owner consent, policy enforcement, release governance, live automation, and durable job execution |
+
+These holds should stay as review memory. They should not be copied into every
+bundle as a universal section.
+
+## Relation Repair Boundary
+
+The selector/relation lane accepted exactly seven source relation repairs:
+
+- `AOA-T-0058 requires AOA-T-0057`
+- `AOA-T-0059 requires AOA-T-0057`
+- `AOA-T-0050 requires AOA-T-0049`
+- `AOA-T-0103 used_together_for AOA-T-0104`
+- `AOA-T-0082 requires AOA-T-0081`
+- `AOA-T-0064 requires AOA-T-0063`
+- `AOA-T-0071 requires AOA-T-0070`
+
+This owner-boundary pass did not accept, hide, or imply any additional relation
+source change. Relation pressure remains owned by the selector/relation lane
+until a future relation-contract decision and validator wave say otherwise.
+
+## Temporary Plan Disposition
+
+`TEMP_OWNER_BOUNDARY_BRIDGE_LONG_PASS_PLAN.md` is now superseded by this
+closeout ledger and the residual scan. It remains in the tree as traceable
+rhythm provenance because the wave packets and residual scan link to it during
+the pass.
+
+The temporary plan is not current task authority, not a roadmap, not schema
+truth, and not bundle authority. Future agents should resume from this closeout
+ledger and the residual scan, then read the temporary plan only when they need
+the historical rhythm.
+
+## Next Reform Lane
+
+The owner-boundary bridge long pass should stay closed unless the corpus or
+owner map materially changes.
+
+The next honest technique-reform lane is a small `Template Modernization Pilot`
+with direct bundle reading before any edits. It should choose one to three
+bundles only where the source shape would become more executable for a small
+agent, and it should avoid a broad old-template rewrite.
+
+Good candidate pressure to inspect first:
+
+- a compact promoted shelf with recent selector and owner-boundary evidence;
+- a bundle whose procedure, inputs, outputs, validation, example, or capsule
+  shape blocks `pick -> inspect -> execute`;
+- a relation-adjacent bundle only if the current source shape confuses the
+  local stop-line.
+
+Keep empirical local-agent execution proof routed to `aoa-evals` until that
+owner has a clean harness. `aoa-techniques` may prepare better templates,
+examples, fixtures, and compact cards, but static review should not claim model
+pass/fail evidence.
+
+## Unauthorized Changes Not Made
+
+- no `TECHNIQUE.md` source rewrite;
+- no generated hand edit;
+- no schema or validator migration;
+- no frontmatter, status, maturity, path, `domain`, or `kind` change;
+- no relation source change;
+- no universal `Law / Local Form / Bridges` block;
+- no sibling-owner acceptance claim;
+- no empirical small-agent proof claim.
+
+## Validation
+
+Final closeout validation should use the same bounded menu as the residual
+scan:
+
+1. `git diff --check`
+2. public-safety grep over touched public-share surfaces
+3. bridge-block grep over touched public-share surfaces
+4. `python -m unittest tests.test_distillation_mechanics_topology`
+5. `python scripts/validate_repo.py`


### PR DESCRIPTION
## Summary
- Add the owner-boundary bridge long-pass closeout ledger.
- Close full current-corpus coverage over `28/28` active shelves and `107/107` current bundles.
- Mark the temporary owner-boundary rhythm plan superseded and route the next lane toward a small template modernization pilot.

## Boundary
- Review and closeout only; no technique source, generated, schema, frontmatter, status, path, or relation source change.
- Owner-boundary repair queue remains empty.
- Existing selector/relation repairs remain separate and unchanged.
- No universal `Law / Local Form / Bridges` blocks and no empirical small-agent proof claim.

## Validation
- `git diff --check`
- `python -m unittest tests.test_distillation_mechanics_topology`
- `python scripts/validate_repo.py`
- public-safety grep over touched files
- bridge-block grep over touched files
