### PR TITLE
[codex] Install portable AoA skill foundation

### DIFF
--- a/.agents/skills/aoa-adr-write
+++ b/.agents/skills/aoa-adr-write
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-adr-write

--- a/.agents/skills/aoa-adr-write/SKILL.md
+++ b/.agents/skills/aoa-adr-write/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: aoa-adr-write
+description: Capture a meaningful architectural or workflow decision as an ADR or decision note, place it in the canonical decision surface, and verify the rationale stays discoverable. Use when structure, boundaries, tooling, or workflow expectations change and future contributors need to know why. Do not use for tiny self-evident edits or when the real problem is source-of-truth ambiguity rather than decision rationale.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-adr-write/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0033,AOA-T-0002
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-adr-write
+
+## Intent
+Use this skill to capture an architectural, structural, or workflow decision in a concise reviewable note, then place and verify that note in the canonical repo surface so the rationale stays findable.
+
+## Trigger boundary
+Use this skill when:
+- a decision changes structure, boundaries, tooling, or workflow expectations
+- future contributors will need to know why a path was chosen
+- several plausible options existed and the reasoning matters
+- the team or project risks repeating the same debate later
+- the note needs a clear canonical home, not just a one-off comment
+- the decision crosses ownership, layer, evidence, lifecycle, portability, runtime-facing, handoff, risk, or scale boundaries and needs a durable rationale
+- reviewed evidence, planning work, generated output, audit results, or operational receipts have revealed a decision that must stay separate from the evidence that revealed it
+
+Do not use this skill when:
+- the change is tiny and self-evident
+- the note would only restate an obvious diff with no real decision content
+- the main problem is unclear authoritative documentation rather than decision rationale; use `aoa-source-of-truth-check` first
+- the main problem is deciding whether logic belongs in the core or at the edge; use `aoa-core-logic-boundary` first
+- no decision exists yet and the next step is still discovery, option framing, or owner-route clarification
+- the boundary itself is still ambiguous; use `aoa-bounded-context-map` before recording the decision
+- the request is to record every possible lens, provisional hint, planning idea, or generated observation without one reviewed decision to preserve
+- the decision is an ordinary implementation choice whose rationale is already clear from the diff, tests, commit message, or review summary
+- the next honest move is a runbook, incident note, risk approval, or operational follow-up rather than durable decision rationale
+
+## Inputs
+- decision to record
+- context and problem statement
+- relevant options or alternatives
+- chosen path and rationale
+- known consequences or tradeoffs
+- owner, source, evidence, placement, or lifecycle boundaries that shape the decision
+
+## Outputs
+- concise decision note or ADR draft
+- statement of rationale
+- consequence notes
+- canonical placement or reference for the note
+- verification that the note landed in the expected decision surface
+- verification that the note matches the actual change
+- decision-boundary notes that say what the ADR records and what stays with stronger owners, evidence surfaces, generated or derived outputs, or follow-up routes
+
+## Procedure
+1. confirm a real decision exists and is meaningful enough to record; if not, route to discovery rather than writing an ADR
+2. when placement, owner, evidence, or lifecycle could blur the record, choose the smallest useful decision-lens set from `references/decision-boundary-lenses.md`
+3. state the context and the problem the decision addresses
+4. list the main options if they meaningfully shaped the choice
+5. record the chosen decision in clear language
+6. note why it was chosen and what tradeoffs it introduces
+7. place the note in the canonical decision surface or repo-local home that future reviewers should use
+8. connect the note to the actual change surface when relevant
+9. verify that the note explains the decision rather than narrating the diff only
+10. verify that the note is reachable from the intended canonical location
+
+## Contracts
+- the note should explain why, not just what changed
+- the decision should be bounded and understandable
+- tradeoffs should not be hidden behind certainty theater
+- the note should help future reviewers, not merely satisfy process
+- the note should have an explicit canonical placement, not a hidden or implied home
+- the note should distinguish the decision from the evidence, planning surface, generated output, audit result, workflow event, or runtime-facing event that motivated it
+- decision lenses should be selected only when they clarify the decision's authority, placement, or future effect
+- the skill should prefer no ADR when a lighter artifact preserves enough rationale for future work
+- verification should check both rationale quality and note placement
+
+## Risks and anti-patterns
+- writing an ADR for a trivial edit with no real decision
+- writing a decision record before a decision actually exists
+- using inflated language to mask weak reasoning
+- recording the chosen path without naming consequences
+- letting the ADR drift away from the actual change
+- treating placement as optional after the note is written
+- using the skill when the main work is still source-of-truth clarification
+- treating a provisional note, generated observation, planning wish, or workflow candidate as a reviewed decision without owner evidence
+- copying stronger owner law into a local ADR instead of naming the decision's handoff and authority limit
+- creating ADR clutter for ordinary implementation choices that need verification or review summary instead
+- applying decision lenses exhaustively until the ADR becomes a governance essay
+
+## Verification
+- confirm the decision was meaningful enough to record
+- confirm the rationale is explicit
+- confirm consequences or tradeoffs are named
+- confirm at least one rejected option or accepted tradeoff is visible when alternatives shaped the choice
+- confirm the note aligns with the real change surface
+- confirm the note is placed where future reviewers will look for it
+- confirm the canonical location or reference is part of the result, not an afterthought
+- confirm a lighter artifact would not preserve enough rationale before creating a durable ADR
+- confirm evidence, generated, planning, workflow, or runtime-facing surfaces are cited as context rather than promoted into decision authority
+- confirm any selected decision lenses are necessary and narrow enough for this one decision
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0033 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/decision-rationale-recording/TECHNIQUE.md` and sections: Intent, When to use, When not to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0002 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` and sections: Intent, When to use, When not to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local ADR templates
+- alternative decision-note homes outside formal `docs/adr/` layouts
+- a short decision-lens pass from `references/decision-boundary-lenses.md` when durable rationale crosses owner, layer, evidence, workflow, runtime-facing, or scale boundaries
+- a compact note skeleton from `references/decision-note.template.md` when no repo-local template exists
+- local placement rules
+- local template variants that still preserve context, options, decision, and consequences
+- architecture review expectations
+- cross-linking rules back to canonical authority docs without replacing them
+- repository-specific examples

--- a/.agents/skills/aoa-adr-write/agents/openai.yaml
+++ b/.agents/skills/aoa-adr-write/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA ADR Write
+  short_description: Record architecture decisions clearly
+  default_prompt: Use $aoa-adr-write to record a meaningful architectural or workflow decision, place it in the canonical decision surface, and verify the rationale is easy to find.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-adr-write/assets/large-logo.svg
+++ b/.agents/skills/aoa-adr-write/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-adr-write/assets/small-logo.svg
+++ b/.agents/skills/aoa-adr-write/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-adr-write/references/decision-boundary-lenses.md
+++ b/.agents/skills/aoa-adr-write/references/decision-boundary-lenses.md
@@ -1,0 +1,61 @@
+# Decision Boundary Lenses
+
+Use these lenses when a real decision exists, but its authority, evidence,
+placement, or future effect could be confused with nearby surfaces. They are not
+an ADR expansion checklist. Pick only the lenses that keep one decision
+reviewable.
+
+## How To Use
+
+1. Name the decision in one sentence.
+2. Select the few lenses that change where the note belongs or how future
+   readers should interpret the decision.
+3. For each selected lens, record the boundary: what the ADR decides, what it
+   does not decide, and which stronger owner or evidence surface remains
+   stronger than the note.
+4. Drop any lens that only restates the same decision in different words.
+
+## Lens Set
+
+| Lens | Use When | ADR Question | Failure To Avoid |
+|---|---|---|---|
+| Decision object | The record may mix several choices or object classes. | Is this one architecture, workflow, tooling, policy, placement, or release decision? | One ADR becomes a bundle of unrelated moves. |
+| Owner/source | The rationale touches more than one owner repository, layer, or canonical file. | Who owns the decision, and whose truth is only referenced? | A local ADR imports stronger owner law. |
+| Placement | Several decision homes, review notes, route cards, or changelogs could receive the note. | Where will future reviewers look first, and what links back here? | The note is correct but undiscoverable. |
+| Evidence state | The choice came from tests, evals, generated reports, receipts, or audit output. | What evidence informed the decision, and what claim does the evidence not prove? | Evidence is promoted into authority or verdict. |
+| Workflow/process | The choice came from a task session, checkpoint, closeout, scenario, campaign, or roadmap pass. | Is this a reviewed durable decision or only a process-local hint? | Temporary execution context becomes canon. |
+| Lifecycle/time | The note discusses current state, future direction, migration, deprecation, or release posture. | What is decided now, what is deferred, and what is only provenance? | A future trigger reads like an already-landed decision. |
+| Portability/overlay | Public reusable core and project-local overlay both shape the choice. | What is portable decision meaning, and what remains local adaptation? | Local paths or ecosystem assumptions leak into portable canon. |
+| Runtime/body | The decision affects docs, config, source code, deployment, service state, or observed runtime behavior. | Is the ADR authoring meaning, configuring behavior, or recording why a runtime-facing path was chosen? | Documentation pretends to operate the system. |
+| Handoff/fan-out | The decision affects downstream generated surfaces, exports, adapters, or sibling consumers. | Which surfaces must be refreshed or informed, and which remain derived? | Derived outputs become hidden decision records. |
+| Risk/approval | The choice affects destructive, public-share, privacy, security, or operational authority. | What approval, guardrail, dry run, or rollback expectation follows from the decision? | Risk is buried inside confident rationale. |
+| Scale | The choice could be local, package-level, repo-wide, workspace-wide, or federation-facing. | What is the smallest scope this ADR actually governs? | A local decision is written as universal project law. |
+| Lighter artifact | A commit message, PR summary, test, comment, runbook, incident note, or review note may be enough. | What would be lost if no ADR is written? | ADR clutter hides the decisions that matter. |
+
+## Compact Decision-Lens Pass
+
+Use this when a full ADR template would be too heavy but boundary clarity is
+still needed.
+
+| Field | Answer |
+|---|---|
+| Decision |  |
+| Selected lenses |  |
+| Owner of decision |  |
+| Evidence or context only |  |
+| Canonical placement |  |
+| Does not decide |  |
+| Handoff or refresh required |  |
+| Future reader should know |  |
+
+## Verification
+
+- exactly one decision is being preserved
+- selected lenses change authority, placement, interpretation, or follow-through
+- evidence and generated surfaces remain context unless they are the actual
+  owner-approved decision surface
+- session, checkpoint, roadmap, or scenario language is not stronger than
+  reviewed decision evidence
+- the note says what it does not decide when a stronger owner or future route
+  remains responsible
+- a lighter artifact is rejected only when it would lose important rationale

--- a/.agents/skills/aoa-adr-write/references/decision-note.template.md
+++ b/.agents/skills/aoa-adr-write/references/decision-note.template.md
@@ -1,0 +1,41 @@
+# Decision Note Template
+
+Use this compact shape only when the target repository has no local ADR or
+decision-note template. Keep one meaningful decision per note.
+
+## Context
+
+- problem:
+- relevant constraint:
+- evidence or context surface:
+
+## Decision Boundary
+
+- selected lenses:
+- owner of decision:
+- does not decide:
+
+## Options
+
+- option considered:
+- option rejected:
+
+## Decision
+
+- chosen path:
+
+## Rationale
+
+- why this path:
+
+## Consequences
+
+- accepted tradeoff:
+- follow-up or guardrail:
+
+## Placement Verification
+
+- canonical decision surface:
+- related change surface:
+- reachability check:
+- handoff or refresh required:

--- a/.agents/skills/aoa-approval-gate-check
+++ b/.agents/skills/aoa-approval-gate-check
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-approval-gate-check

--- a/.agents/skills/aoa-approval-gate-check/SKILL.md
+++ b/.agents/skills/aoa-approval-gate-check/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: aoa-approval-gate-check
+description: Classify whether a requested action is safe to proceed, requires explicit approval, or should not be executed. Use when a task may be destructive, security-sensitive, or operationally sensitive and the authority boundary is unclear. Do not use for clearly low-risk work or when the main need is previewing a mutation rather than deciding whether it may proceed.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: risk
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/risk/aoa-approval-gate-check/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0028
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-approval-gate-check
+
+## Intent
+Use this skill to classify whether a requested action crosses an approval boundary and to return a bounded next step that keeps authority explicit before any execution proceeds.
+
+## Trigger boundary
+Use this skill when:
+- a task may be destructive, operationally sensitive, or security-relevant
+- the current authority level is unclear
+- the agent needs to classify whether the next step is safe, explicit-only, or out of bounds
+- the task needs an operational gate decision rather than a broader workflow plan
+
+Do not use this skill when:
+- the task is clearly low-risk and already bounded by an ordinary workflow
+- no meaningful approval boundary exists in the current context
+- the authority is already clear and the main need is choosing a preview path before execution; use `aoa-dry-run-first`
+- the task is only about preparing a public-safe artifact for sharing; use `aoa-sanitized-share`
+
+## Inputs
+- requested action
+- touched surfaces
+- known approval state
+- risk signals
+- possible fallback or inspect-only path
+
+## Outputs
+- classification of the action: safe to proceed, explicit approval required, or do not execute
+- note on whether explicit approval is needed
+- bounded next-step recommendation
+- report of unresolved authority assumptions
+- a reviewable gate decision that can be passed to the next workflow step
+
+## Procedure
+1. identify the requested action and touched surfaces
+2. assess whether the action could be destructive, sensitive, or authority-gated
+3. classify the action as safe to proceed, explicit-approval required, or not appropriate to execute
+4. prefer inspect-only or bounded alternatives when authority is insufficient
+5. name the concrete next action or refusal in terms another agent can execute
+6. report the classification and the reason for it
+
+## Contracts
+- unclear authority should not be silently interpreted as permission
+- classification should be explicit and reviewable
+- safer bounded alternatives should be preferred when possible
+- the result should reduce accidental overreach
+- the gate decision should be concrete enough to hand to the next step without ambiguity
+- the skill remains a bounded operational package, not just a policy label
+
+## Risks and anti-patterns
+- assuming approval because a task sounds routine
+- collapsing several risk levels into a single vague warning
+- using approval logic to avoid useful bounded analysis
+- hiding destructive steps behind innocent labels
+- returning a generic caution instead of a real gate classification
+- widening into a general workflow planner instead of a gate checker
+
+## Verification
+- confirm the touched surfaces were identified
+- confirm the approval need was classified explicitly rather than as a vague warning
+- confirm the next step fits the stated authority level
+- confirm uncertainty was not masked as permission
+- confirm the gate decision is actionable and bounded
+- confirm the skill still reads as an approval-classification package
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0028 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/confirmation-gated-mutating-action/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local authority models
+- local risk categories
+- approval examples
+- repository-specific explicit-only rules

--- a/.agents/skills/aoa-approval-gate-check/agents/openai.yaml
+++ b/.agents/skills/aoa-approval-gate-check/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Approval Gate Check
+  short_description: Classify approval boundaries
+  default_prompt: Use $aoa-approval-gate-check to classify whether the requested action is safe, approval-gated, or out of bounds before any execution proceeds.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#B45309'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-approval-gate-check/assets/large-logo.svg
+++ b/.agents/skills/aoa-approval-gate-check/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-approval-gate-check/assets/small-logo.svg
+++ b/.agents/skills/aoa-approval-gate-check/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-automation-opportunity-scan
+++ b/.agents/skills/aoa-automation-opportunity-scan
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-automation-opportunity-scan

--- a/.agents/skills/aoa-automation-opportunity-scan/SKILL.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: aoa-automation-opportunity-scan
+description: Detect reviewed or repeated project processes that are candidates for automation, classify whether they are seed-ready, and route them to the right owner layer without granting schedule or mutation authority. Use when a reviewed session or repeated project slice reveals a recurring manual route and the honest question is whether it should stay manual, become a bounded skill, or become a playbook automation seed candidate. Do not use for one-off exploratory work, creative synthesis with no stable trigger or output, live scheduling requests, or hidden self-change.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-automation-opportunity-scan/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0086,AOA-T-0087,AOA-T-0088
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-automation-opportunity-scan
+
+## Intent
+Use this skill to detect where repeated project work is ripe for automation and
+to package that finding into a bounded `AUTOMATION_OPPORTUNITY_PACKET`.
+
+The goal is not to automate by reflex.
+The goal is to notice when a process has become repetitive, stable, legible,
+and evidence-backed enough that automation or semi-automation becomes an honest
+next move.
+
+## Trigger boundary
+Use this skill when:
+- a reviewed session or repeated project slice reveals a recurring manual route
+- the same audit, report, hygiene pass, or triage loop keeps coming back
+- a session-harvest packet includes an `automation_candidate`
+- an operator wants to know whether a recurring route should stay manual, become a bounded skill, or become a playbook automation seed
+- repeated friction suggests a good automation opportunity but authority and risk still need classification
+
+Do not use this skill when:
+- the work happened only once and still looks exploratory
+- the route is primarily creative synthesis with no stable trigger or output
+- the task is asking for live scheduling or hidden background execution authority
+- the route would mutate important system surfaces without checkpoint posture
+- the work still needs basic donor harvest or source-of-truth clarification first
+
+## Inputs
+- reviewed session artifact, harvest packet, or recurring project slice
+- evidence of repeated manual work
+- known current manual route
+- known triggers, inputs, outputs, or their current ambiguity
+- current risk, approval, rollback, and proof posture if known
+
+## Outputs
+- `AUTOMATION_OPPORTUNITY_PACKET`
+- one or more `AUTOMATION_CANDIDATE` cards
+- `seed_ready` or `not_now` verdict for each candidate
+- `checkpoint_required` flag when the route crosses self-change or approval-sensitive boundaries
+- next-artifact suggestion such as `skill`, `playbook_seed`, `technique_candidate`, `repair_quest`, `quest`, or `defer`
+- one `AUTOMATION_CANDIDATE_RECEIPT` using
+  `references/stats-event-envelope.md` and
+  `references/automation-candidate-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. start from reviewed evidence, not from vague enthusiasm
+2. isolate the current manual route as actually practiced
+3. classify repeat signal, friction, determinism, input clarity, output clarity, proof surface, reversibility, secret coupling, and approval sensitivity
+4. decide whether the first honest landing is a bounded skill, a playbook automation seed candidate, a technique candidate, a repair quest, or a defer verdict
+5. mark `checkpoint_required` when the route would cross into self-change, hidden authority, or important mutation
+6. emit `seed_ready` only when the process is stable enough to name inputs, outputs, bounded prompts or activation hints, and a likely owner surface
+7. state the nearest wrong target so promotion pressure stays honest
+8. when classification pressure is high, use `references/automation-fit-matrix.md`, `references/session-harvest-integration.md`, `references/playbook-seed-bridge.md`, `references/checkpoint-boundary.md`, and `references/automation-opportunity-packet-schema.yaml`
+9. emit one `AUTOMATION_CANDIDATE_RECEIPT` when the packet closes, keeping the
+   receipt detector-shaped rather than scheduler-shaped
+10. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+    that records the finished kernel-skill run, points back to the bounded
+    detail receipt, and stays separate from scheduler or mutation authority
+
+## Contracts
+- this skill detects and packages automation opportunities; it does not create live automation authority
+- schedule hints remain hints, not runtime truth
+- recurring scenario candidates belong in `aoa-playbooks` as seed candidates rather than hidden playbooks inside a skill
+- self-changing or approval-heavy candidates must surface checkpoint posture explicitly
+- unresolved candidates may become repair quests instead of fake-ready automations
+- handoffs to `aoa-session-self-diagnose`, `aoa-session-self-repair`, or
+  `aoa-quest-harvest` must stay explicit rather than being smuggled in as
+  silent policy
+- candidate receipts stay subordinate to the packet and never grant live
+  schedule, mutation, or approval authority
+- generic core receipts stay subordinate to the candidate receipt and never
+  replace automation classification meaning
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- treating one exciting session as proof of repeatability
+- automating unstable, under-specified, or secret-heavy work too early
+- confusing a bounded skill with a recurring scenario seed
+- using automation desire to bypass approval, rollback, or post-change health checks
+- writing authored meaning first into derived routing or KAG surfaces
+- inventing fake confidence about gains while hiding costs or risks
+- reading an automation-candidate receipt as if it were a scheduler verdict
+
+## Verification
+- confirm each candidate names the current manual route
+- confirm evidence refs justify the repeat signal
+- confirm stable input and output posture is assessed explicitly
+- confirm `seed_ready` or `not_now` is explicit for each candidate
+- confirm a first owner layer and next artifact are named
+- confirm the nearest wrong target is rejected when classification pressure exists
+- confirm checkpoint posture appears for self-changing or approval-heavy routes
+- confirm any emitted receipt stays detector-shaped, evidence-linked, and non-authoritative
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points back to the
+  detail receipt and does not claim more than one finished kernel-skill run
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0086 from `8Dionysus/aoa-techniques` at `7f17c22ddd96de4b63873eff4c8e9e4c94a6aee9` using path `techniques/governance/automation-readiness/automation-fit-matrix/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Core procedure, Risks, Validation
+- AOA-T-0087 from `8Dionysus/aoa-techniques` at `7f17c22ddd96de4b63873eff4c8e9e4c94a6aee9` using path `techniques/governance/automation-readiness/human-loop-to-first-landing/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Contracts, Validation
+- AOA-T-0088 from `8Dionysus/aoa-techniques` at `7f17c22ddd96de4b63873eff4c8e9e4c94a6aee9` using path `techniques/governance/automation-readiness/approval-sensitivity-check/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Contracts, Risks, Validation
+
+## Adaptation points
+- project overlays may add local execution modes, trigger classes, or schedule vocabularies
+- project overlays may add local approval classes or environment-risk labels
+- project overlays may add local candidate examples tied to recurring repo rituals

--- a/.agents/skills/aoa-automation-opportunity-scan/agents/openai.yaml
+++ b/.agents/skills/aoa-automation-opportunity-scan/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Automation Opportunity Scan
+  short_description: Classify automation-ready routes
+  default_prompt: Use $aoa-automation-opportunity-scan to turn reviewed recurring work into an automation opportunity packet with a seed-ready or not-now verdict, checkpoint posture, and the most honest next artifact.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-automation-opportunity-scan/assets/large-logo.svg
+++ b/.agents/skills/aoa-automation-opportunity-scan/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-automation-opportunity-scan/assets/small-logo.svg
+++ b/.agents/skills/aoa-automation-opportunity-scan/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-automation-opportunity-scan/references/automation-candidate-receipt-schema.yaml
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/automation-candidate-receipt-schema.yaml
@@ -1,0 +1,19 @@
+receipt_name: AUTOMATION_CANDIDATE_RECEIPT
+event_kind: automation_candidate_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - manual_route_ref
+  - repeat_signal_posture
+  - determinism_posture
+  - reversibility_posture
+  - checkpoint_required
+  - seed_ready
+  - next_artifact_hint
+optional_payload_fields:
+  - likely_owner_layer
+  - not_now_reason
+  - proof_surface_notes
+rules:
+  - keep the receipt detector-shaped rather than scheduler-shaped
+  - `seed_ready` does not grant live execution authority
+  - keep manual-route and evidence refs inspectable instead of duplicating the full packet

--- a/.agents/skills/aoa-automation-opportunity-scan/references/automation-fit-matrix.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/automation-fit-matrix.md
@@ -1,0 +1,38 @@
+# Automation Fit Matrix
+
+Use this matrix to decide whether a process is actually ready for automation or
+only desires automation.
+
+| signal | what strong looks like | what weak looks like | likely consequence |
+|---|---|---|---|
+| frequency | repeats across sessions or review windows | happened once | weak candidates should usually stay manual or become quests |
+| friction | repeated drag, context switching, checklist fatigue, or rote triage | negligible cost | low-friction work rarely justifies early automation |
+| determinism | route mostly follows stable rules | route still depends on changing human judgment | weak determinism often means `not_now` or technique extraction first |
+| input clarity | canonical sources and triggers are visible | hidden, unstable, or private inputs | unclear inputs block honest automation |
+| output clarity | the end state is checkable | success is aesthetic or vague | unclear outputs weaken proof and health checks |
+| proof surface | there is a bounded verification seam | results are hard to inspect | weak proof posture means higher false confidence |
+| dry run | preview or simulation is possible | only live mutation exists | lack of preview raises risk and approval burden |
+| reversibility | rollback marker is obvious | rollback is unclear or expensive | weak rollback pushes toward repair or checkpoint routes |
+| secret coupling | little or no secret handling | secret-heavy or environment-bound | high coupling often disqualifies public seed-ready paths |
+| approval sensitivity | authority is explicit | authority is hidden or shifting | unclear authority should force checkpoint or defer posture |
+
+## Good first candidates
+
+Good first candidates usually look like:
+
+- recurring audits
+- repeated hygiene checks
+- bounded report generation
+- repeated doc or drift reviews
+- repeated preflight or postflight rituals
+- repeated session closeout routes
+
+## Bad first candidates
+
+Bad first candidates usually look like:
+
+- one-off creative synthesis
+- unstable exploratory research loops
+- secret-heavy ops without explicit boundaries
+- routes with no rollback or no health check
+- routes that silently reshape important system surfaces

--- a/.agents/skills/aoa-automation-opportunity-scan/references/automation-opportunity-packet-schema.yaml
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/automation-opportunity-packet-schema.yaml
@@ -1,0 +1,24 @@
+packet_kind: AUTOMATION_OPPORTUNITY_PACKET
+required_fields:
+  - candidate_name
+  - current_manual_route
+  - repeat_signal
+  - friction_signal
+  - input_clarity
+  - output_clarity
+  - proof_surface
+  - reversibility
+  - approval_sensitivity
+  - verdict
+  - checkpoint_required
+  - owner_layer
+  - next_artifact
+optional_fields:
+  - schedule_hint
+  - nearest_wrong_target
+  - repair_reason
+  - evidence_refs
+rules:
+  - schedule_hint must remain advisory only
+  - checkpoint_required must be true for self-changing or approval-heavy routes
+  - verdict must be seed_ready or not_now

--- a/.agents/skills/aoa-automation-opportunity-scan/references/checkpoint-boundary.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/checkpoint-boundary.md
@@ -1,0 +1,33 @@
+# Checkpoint Boundary For Automation Opportunity Scanning
+
+Automation opportunity detection should stay cheap.
+Checkpoint posture should activate only when the candidate route would reshape
+important system surfaces, cross approval boundaries, or act in self-changing
+ways.
+
+## Strong checkpoint triggers
+
+Mark `checkpoint_required: true` when the candidate would:
+
+- mutate important system surfaces
+- operate with hidden or changing authority
+- require rollback discipline that is not already explicit
+- act as a self-repair or self-upgrade route
+- blur thinker and operator roles
+
+## Typical safe lower-risk candidates
+
+Usually lower-risk candidates look like:
+
+- report generation
+- repeated drift checks
+- repeatable session closeout packaging
+- bounded read-only audits
+- preview or dry-run orchestration
+
+## Resulting action
+
+When checkpoint posture is needed, the next artifact is usually not a ready
+automation seed.
+It is a checkpoint-aware repair route, playbook review packet, or bounded skill
+proposal with explicit approval seams.

--- a/.agents/skills/aoa-automation-opportunity-scan/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-automation-opportunity-scan
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-automation-opportunity-scan`
+  - `detail_event_kind` must equal `automation_candidate_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-automation-opportunity-scan/references/playbook-seed-bridge.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/playbook-seed-bridge.md
@@ -1,0 +1,32 @@
+# Bridge To Playbook Automation Seeds
+
+Use this bridge when `aoa-automation-opportunity-scan` detects something that
+should become a candidate automation seed.
+
+## First honest landing
+
+| shape | first landing |
+|---|---|
+| one bounded executable workflow | `aoa-skills` |
+| recurring multi-skill or scheduled scenario | `aoa-playbooks` automation seed candidate |
+| stable reusable practice behind multiple automations | `aoa-techniques` |
+| approval-heavy self-change route | `aoa-agents` checkpoint posture plus proof hooks |
+| not ready yet | repair quest, technique candidate, or defer |
+
+## Minimum seed-ready posture
+
+A candidate should usually be `seed_ready: true` only when it can name:
+
+- the current manual route
+- stable inputs and outputs
+- a likely owning playbook or skill handle
+- a bounded prompt or activation description
+- schedule hints as hints, not authority
+
+## What not to do
+
+Do not confuse:
+
+- an automation seed with a live scheduler
+- a playbook seed with a secret-bearing ops script
+- a skill with a recurring scenario composition surface

--- a/.agents/skills/aoa-automation-opportunity-scan/references/session-harvest-integration.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/session-harvest-integration.md
@@ -1,0 +1,42 @@
+# Session-Harvest Integration Notes
+
+This add-on should plug into the existing session-harvest family without
+swallowing it.
+
+## Donor-harvest
+
+Allow `automation_candidate` as one extract kind inside `HARVEST_PACKET`.
+
+Use donor-harvest to say "there may be automation value here."
+Use `aoa-automation-opportunity-scan` to say "here is the automation candidate
+packet and why it is or is not ready."
+
+## Route-forks
+
+Route-forks may compare:
+
+- keep manual for now
+- convert into a bounded skill
+- package as a playbook automation seed
+- defer until prerequisite repair lands
+
+## Self-diagnose
+
+Self-diagnose should be allowed to report blocked automation due to:
+
+- unstable inputs
+- unclear source of truth
+- missing approval gate
+- missing rollback marker
+- weak post-change health checks
+- secret or environment coupling
+
+## Self-repair
+
+Self-repair should be allowed to emit the smallest prerequisite packet needed
+before automation can become honest.
+
+## Progression-lift
+
+Progression-lift may include an optional automation-readiness hint.
+Do not turn that hint into an all-authority score.

--- a/.agents/skills/aoa-automation-opportunity-scan/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-bounded-context-map
+++ b/.agents/skills/aoa-bounded-context-map
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-bounded-context-map

--- a/.agents/skills/aoa-bounded-context-map/SKILL.md
+++ b/.agents/skills/aoa-bounded-context-map/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: aoa-bounded-context-map
+description: Clarify system or domain boundaries, name contexts, and surface interfaces so changes stay semantically scoped. Use when naming is overloaded, responsibilities are mixed, or a task needs a cleaner boundary before coding. Do not use for tiny local edits or when the boundary is already clear and the real task is contract validation.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-bounded-context-map/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0016,AOA-T-0002
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-bounded-context-map
+
+## Intent
+Use bounded-context thinking to reduce semantic drift, mixed responsibilities, and unclear interfaces.
+
+## Trigger boundary
+Use this skill when:
+- a project mixes several domains or subsystems
+- naming is drifting or overloaded
+- the task needs a clearer boundary before coding safely
+- an agent is likely to confuse nearby concepts without sharper separation
+- a repository has a dual posture, such as standalone public package and ecosystem component
+- practice patterns, execution workflows, evaluation artifacts, scenarios, generated/export surfaces, or owner-local implementations are easy to blur together
+- the same work changes shape across task, session, repository, layer, surface, or process context
+- several boundary types may matter at once, such as owner, layer, lifecycle, authority, surface-state, portability, proof, runtime, or handoff
+
+Do not use this skill when:
+- the change is tiny and fully local
+- the boundary is already clear and agreed on, and the real task is validating the interface contract; use `aoa-contract-test`
+- the main problem is deciding whether logic belongs in the core or at the edge; use `aoa-core-logic-boundary` first
+- the request is a broad architecture redesign, taxonomy program, or durable governance map rather than one bounded ambiguity-reduction pass
+- the request asks to apply every boundary lens exhaustively without one concrete ambiguity or next change to constrain
+
+## Inputs
+- target area or subsystem
+- current naming and responsibilities
+- known neighboring contexts
+- ambiguous or overloaded terms
+- owner layers, stronger source surfaces, or portability constraints that shape the boundary
+- active boundary lenses when the ambiguity spans several kinds of difference
+
+## Outputs
+- named contexts or subsystems
+- rough boundary map
+- interface notes between contexts
+- ambiguity notes and recommended vocabulary
+- owner split, stop-line, and portable-versus-integration vocabulary when those boundaries matter
+- selected lens notes that explain which kinds of boundary matter for this task and which ones are intentionally out of scope
+
+## Procedure
+1. confirm the task has one concrete ambiguity or scoping problem; if it asks for a broad architecture program, narrow or route away first
+2. when several kinds of boundary are mixed, choose the smallest useful lens set from `references/boundary-lenses.md`
+3. identify the target area and the terms people use for it
+4. separate responsibilities into bounded contexts, subsystems, layers, owner surfaces, or repositories
+5. name what belongs inside each context and what stays outside
+6. distinguish portable core meaning from ecosystem integration, local implementation, generated projection, or historical provenance when those surfaces coexist
+7. describe the interfaces, handoffs, stop-lines, or translations between contexts
+8. note ambiguous terms and propose clearer language
+9. report how the boundary should constrain the next change, including what should route away
+
+## Contracts
+- boundaries should reduce semantic confusion, not create ceremony for its own sake
+- neighboring contexts should be named explicitly when relevant
+- interface or translation points should be visible
+- boundary lenses should be selected because they reduce the current ambiguity, not because a checklist exists
+- a context map should not transfer authority from a stronger owner into the local repository
+- portable core wording should remain usable without hidden ecosystem dependencies when the target surface is public
+
+## Risks and anti-patterns
+- inventing too many contexts for a small problem
+- renaming concepts without reducing confusion
+- treating context maps as proof of good architecture when interfaces remain muddy
+- copying center or sibling-repo law into a local surface instead of naming a light handoff
+- turning a dual-posture repo into two unrelated identities rather than one bounded interface
+- using context labels as decoration while the next diff still crosses owner boundaries
+- letting one context map become an open-ended architecture taxonomy or governance program
+- treating `references/boundary-lenses.md` as an exhaustive checklist rather than a way to choose the right few distinctions
+- freezing one session, repository, layer, or surface's current shape as universal project law
+
+## Verification
+- confirm the main ambiguity was reduced
+- confirm interfaces or handoff points are named
+- confirm the output helps future scoped changes
+- confirm the map says what routes away when a stronger owner owns the truth
+- confirm portable and integration-only wording remain distinct when both are present
+- confirm a future change can tell what stays out of scope, not only what was renamed
+- confirm the selected lenses are necessary and enough for the next change, with unused lenses left out rather than padded in
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0016 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/bounded-context-map/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0002 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays should add:
+- local domain vocabulary
+- canonical docs that define terminology
+- local examples of context boundaries
+- a short lens pass from `references/boundary-lenses.md` when the same task spans session, repository, layer, lifecycle, authority, or runtime-facing differences
+- a compact map skeleton from `references/context-map.template.md` when no repo-local format exists
+- local owner-route maps, portability rules, and generated-surface handoffs

--- a/.agents/skills/aoa-bounded-context-map/agents/openai.yaml
+++ b/.agents/skills/aoa-bounded-context-map/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Bounded Context Map
+  short_description: Map contexts and interfaces
+  default_prompt: Use $aoa-bounded-context-map to name the relevant contexts, clarify what belongs inside each boundary, and note the interfaces between them.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-bounded-context-map/assets/large-logo.svg
+++ b/.agents/skills/aoa-bounded-context-map/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-bounded-context-map/assets/small-logo.svg
+++ b/.agents/skills/aoa-bounded-context-map/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-bounded-context-map/references/boundary-lenses.md
+++ b/.agents/skills/aoa-bounded-context-map/references/boundary-lenses.md
@@ -1,0 +1,84 @@
+# Boundary Lenses
+
+Use these lenses when one ambiguity crosses several kinds of context. They are
+not a checklist to exhaust. Pick the few that explain why the next change is
+currently hard to place, then collapse the rest.
+
+## How To Use
+
+1. Name the concrete ambiguity or next change.
+2. Select two to four lenses that change where the work belongs or what must
+   stay out of scope.
+3. For each selected lens, answer: what is being confused, who owns the
+   stronger truth, what handoff or stop-line matters, and what the next change
+   may safely touch.
+4. Drop any lens that only adds labels without changing the boundary.
+
+## Lens Set
+
+| Lens | Use When | Clarifying Question | Common Failure |
+|---|---|---|---|
+| Object-kind | Different object classes are being treated as one thing. | Is this a practice pattern, execution skill, evaluation artifact, scenario, route, memory object, role contract, generated view, runtime body, seed, or source node? | One object becomes a weak substitute for another. |
+| Owner | More than one repository, layer, team, or surface could claim the truth. | Which owner can change this meaning, and which surfaces only point to it? | A local note absorbs stronger owner law. |
+| Layer | The work crosses practice, execution, proof, routing, memory, role, scenario, derived, runtime, source, seed, or public-entry layers. | Which layer owns the meaning and which layer only composes, derives, runs, or routes it? | Layer labels become decoration while authority still drifts. |
+| Surface state | Authored source, generated output, export, adapter, legacy archive, staging note, receipt, and runtime mirror are mixed. | Is this surface authoritative, derived, transported, historical, provisional, or live operational evidence? | Generated or historical material starts acting like current source truth. |
+| Lifecycle | The same object has seed, candidate, scaffold, evaluated, canonical, released, deprecated, live, or future-roadmap posture. | What is true now, what is planned, and what is only provenance? | A future direction or old receipt is read as current status. |
+| Workflow/process | A task, session note, checkpoint, closeout, scenario, campaign, or roadmap is being used as if it had the same authority. | Is this temporary execution context, reviewed session evidence, durable obligation, or program direction? | Session-local hints become durable canon without review. |
+| Authority/proof | Claims, evidence, tests, evals, verdicts, assumptions, and trust language are blending. | What claim is being made, what proves it, and what remains unproven? | Proof language gets stronger than the evidence. |
+| Portability | Public reusable core and project-local overlay details both matter. | What must work without local paths, secrets, runtime state, or ecosystem-only assumptions? | A portable surface quietly depends on private or local context. |
+| Runtime/body | Docs, config, service state, deployment, storage, automation, and source code are easy to confuse. | Is the change authoring meaning, configuring behavior, running infrastructure, or describing evidence from a run? | Documentation starts pretending to operate the system. |
+| Interface/handoff | Two contexts touch through a seam, adapter, export, import, bridge, or review route. | What crosses the boundary, in what shape, and who receives it next? | The map names contexts but leaves the exchange implicit. |
+| Vocabulary | A word means different things in different contexts. | Which term should be narrowed, renamed, or qualified for this task? | Synonyms multiply while responsibilities stay unclear. |
+| Time/freshness | Current, historical, generated-at, released, stale, and planned surfaces are mixed. | Which facts are current enough for this change, and which need verification? | Stale generated data or old plans drive a current change. |
+| Risk/approval | A boundary crosses destructive, security, public-share, privacy, operational, or irreversible action. | What requires explicit approval, dry run, sanitization, or safer fallback? | Risk-heavy work hides behind ordinary wording. |
+| Role/agency | Actor, role, persona, skill, playbook, runtime agent, and autonomy language are blurring. | Who acts, under which role contract, and what authority is not granted? | Role language becomes hidden execution authority. |
+| Scale | Local file, package, repository, project component, workspace root, federation, and public profile scopes are mixed. | What is the smallest scope that can honestly solve the ambiguity? | A local ambiguity turns into federation-wide governance. |
+
+## Diverse Use Shapes
+
+Use a lens pass for many different task shapes:
+
+- a coding session where checkpoint notes, generated outputs, and the next
+  concrete diff point in different directions
+- a repository that acts both as a public library and as one component in a
+  larger federation
+- a generated or exported surface whose source document, builder, adapter, and
+  runtime consumer need separate authority lines
+- a project overlay that adds local commands without changing portable core
+  meaning
+- a proof or eval request that sounds like workflow guidance but really needs
+  a bounded claim and verdict limit
+- a scenario-shaped request that repeats across sessions and should not be
+  collapsed into one execution skill
+- a role or agent-profile request where persona, execution workflow, handoff,
+  and runtime autonomy need distinct boundaries
+- a seed or intake surface that is useful as provenance but not yet the owning
+  repository's truth
+- a runtime or infrastructure task where service behavior, source meaning,
+  operator command, and observed receipt must stay separate
+- a source-first knowledge task where authored meaning, downstream export, and
+  derived retrieval substrate should not become identical
+
+## Compact Lens Pass
+
+Use this shape when a full map would be too heavy:
+
+| Field | Answer |
+|---|---|
+| Concrete ambiguity |  |
+| Selected lenses |  |
+| Stronger owner or source |  |
+| Local surface may own |  |
+| Must route away |  |
+| Handoff or translation |  |
+| Next change constrained |  |
+
+## Verification
+
+- the selected lenses explain a real ambiguity in the current task
+- each selected lens changes a boundary, owner, handoff, or stop-line
+- the output names what the next change may touch and what it must leave alone
+- public portable meaning remains distinct from local overlay or runtime detail
+- generated, historical, provisional, or derived evidence remains weaker than
+  authored source truth
+- the lens pass is smaller than the ambiguity it resolves

--- a/.agents/skills/aoa-bounded-context-map/references/context-map.template.md
+++ b/.agents/skills/aoa-bounded-context-map/references/context-map.template.md
@@ -1,0 +1,43 @@
+# Context Map Template
+
+Use this compact shape only when the target repository has no local context-map
+format. Keep the map tied to one concrete ambiguity or scoping problem.
+
+## Target Ambiguity
+
+- overloaded term or mixed responsibility:
+- next change this map should constrain:
+
+## Active Boundary Lenses
+
+| Lens | Why It Matters Here |
+|---|---|
+|  |  |
+
+## Contexts
+
+| Context | Owns | Does Not Own |
+|---|---|---|
+|  |  |  |
+
+## Interfaces
+
+| From | To | Handoff or Translation |
+|---|---|---|
+|  |  |  |
+
+## Vocabulary
+
+- prefer:
+- avoid:
+
+## Route-Away Lines
+
+- stronger owner:
+- generated, historical, or integration-only surface:
+
+## Verification
+
+- ambiguity reduced:
+- out-of-scope line visible:
+- next change constrained:

--- a/.agents/skills/aoa-change-protocol
+++ b/.agents/skills/aoa-change-protocol
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-change-protocol

--- a/.agents/skills/aoa-change-protocol/SKILL.md
+++ b/.agents/skills/aoa-change-protocol/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: aoa-change-protocol
+description: Plan and execute a bounded, non-trivial repository change with explicit verification and reporting. Use when code, config, docs, or operational surfaces change in a meaningful way and the task benefits from an explicit plan. Do not use for trivial wording fixes or when a more specific risk skill fits better.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-change-protocol/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0001,AOA-T-0002
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-change-protocol
+
+## Intent
+Ground non-trivial changes in the owner route before editing, then keep the diff reviewable and explicitly verified without hidden scope expansion.
+
+## Trigger boundary
+Use this skill when:
+- the change affects code, config, docs, or operational surfaces in a meaningful way
+- the task benefits from an explicit plan and verification path
+- the task touches more than a trivial wording fix
+- the request references previous work, sibling repositories, root surfaces, mechanics, generated outputs, or owner boundaries that must be inspected before planning
+
+Do not use this skill when:
+- the edit is tiny and has no meaningful review or operational consequence
+- a more specific risk skill should be used instead
+
+## Inputs
+- target goal
+- owner repository or route surface
+- touched files or surfaces
+- source-of-truth or route-law surfaces that constrain the change
+- main risk
+- intended validation path
+- rollback idea
+
+## Outputs
+- explicit plan
+- scoped change
+- named verification result
+- post-change route review when source-of-truth, generated, decision, roadmap, changelog, quest, mechanic, or owner surfaces may have moved
+- concise final report
+
+## Procedure
+1. choose the owner repository and read the nearest route card, `AGENTS.md`, source-of-truth surfaces, and local validation path before planning
+2. state the goal, touched surfaces, and evidence already inspected; if the request depends on prior work, inspect the current repo state rather than relying on memory
+3. identify the main risk, owner boundary, and rollback or recovery shape before editing
+4. prepare the smallest reviewable change that follows the current source route
+5. avoid unrelated cleanup, opportunistic refactors, or importing a sibling owner's authority into the local surface
+6. apply the change inside the declared scope
+7. run or name explicit verification, including generated/export rebuilds when source surfaces feed derived outputs
+8. perform the narrow post-change route review only for surfaces whose meaning actually moved
+9. report what changed, what was verified, what was skipped, what remains risky, and where the next owner route is
+
+## Contracts
+- the change must remain reviewable
+- verification must be explicit, not implied
+- the change should stay inside the declared scope
+- rollback thinking should exist before apply
+- the plan should be grounded in inspected source surfaces, not only conversation memory or generic pattern recall
+- generated, exported, compact, or derived surfaces should be refreshed from source rather than hand-authored as truth
+- cross-repo or mechanics changes should name owner boundaries and stop-lines before moving content
+
+## Risks and anti-patterns
+- over-formalizing trivial edits
+- symbolic verification that creates false safety
+- using the report as a substitute for a readable diff
+- silently expanding the task during implementation
+- planning from stale memory when the repository already has route cards, mechanics, or source-of-truth docs that answer the question
+- treating legacy, provenance, generated, or sibling-owner surfaces as if they were the active local contract
+- inserting broad law blocks into local surfaces instead of shaping the change through the existing route
+
+## Verification
+- confirm the owner route and relevant source surfaces were inspected before apply
+- confirm the change stayed scoped
+- confirm at least one explicit verification step was run or intentionally skipped with explanation
+- confirm generated or export surfaces were rebuilt when canonical inputs changed
+- confirm the post-change route review touched only surfaces whose meaning moved
+- confirm the report includes outcome, rollback thinking, skipped checks, and remaining owner-route risk
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0001 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0002 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays should add:
+- local source-of-truth files
+- local validation commands
+- local risk tiers
+- approval or review rules
+- local post-change route review surfaces such as changelog, roadmap, decision records, generated indexes, questbooks, or mechanics ledgers

--- a/.agents/skills/aoa-change-protocol/agents/openai.yaml
+++ b/.agents/skills/aoa-change-protocol/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Change Protocol
+  short_description: Plan, scope, verify, report
+  default_prompt: Use $aoa-change-protocol to plan, apply, verify, and report a bounded non-trivial repository change.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-change-protocol/assets/large-logo.svg
+++ b/.agents/skills/aoa-change-protocol/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-change-protocol/assets/small-logo.svg
+++ b/.agents/skills/aoa-change-protocol/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-checkpoint-closeout-bridge
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-checkpoint-closeout-bridge

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/SKILL.md
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: aoa-checkpoint-closeout-bridge
+description: Bridge provisional checkpoint evidence into one explicit reviewed closeout execution chain without turning notes into final harvest, progression, or quest authority. Use when a reviewed session artifact exists, checkpoint notes or closeout handoffs already carry focus hints, and the next honest move is to reread the reviewed artifact while driving donor harvest, progression lift, and quest harvest in that fixed order. Do not use for mid-session collection only, for hidden execution inside `aoa closeout run`, or when the request tries to mint final verdicts from checkpoint notes without reviewed evidence.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/session-growth/aoa-checkpoint-closeout-bridge/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0075,AOA-T-0084,AOA-T-0089
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-checkpoint-closeout-bridge
+
+## Intent
+Use this skill to connect checkpoint-led session growth with explicit reviewed
+closeout execution.
+
+It does not replace the core session-growth skills.
+It keeps checkpoint capture provisional during the session and then drives the
+explicit reviewed-closeout chain in the fixed order:
+
+`aoa-session-donor-harvest -> aoa-session-progression-lift -> aoa-quest-harvest`
+
+## Trigger boundary
+Use this skill when:
+- checkpoint notes already carry harvest, progression, or upgrade candidates
+- reviewed closeout must use those candidates as focus hints without treating
+  them as final authority
+- the route needs one explicit bridge from local checkpoint evidence into the
+  reviewed session-harvest family
+- the honest next move is not raw recap, but a bounded session-end chain
+
+Do not use this skill when:
+- the session is still active and only mid-session collection is needed
+- there is no reviewed artifact yet
+- the task is to implement or patch the bridge itself rather than execute a
+  reviewed closeout chain
+- the task wants final harvest, progression, or quest verdicts from checkpoint
+  notes alone
+- the request tries to make `aoa closeout run` a hidden skill runner
+
+## Inputs
+- reviewed session artifact
+- optional local checkpoint note
+- optional reviewed surface closeout handoff
+- optional receipt refs from already published or staged session evidence
+- repo scope and touched owner hints
+- full session evidence available to the agent, such as the reviewed artifact,
+  Codex rollout trace, transcript excerpts, and relevant receipts
+
+## Outputs
+- in `checkpoint-collect` mode:
+  - updated local checkpoint note
+  - updated provisional progression-axis hints
+  - ordered session-end target list
+- in `reviewed-closeout-execute` mode:
+  - one explicit execution context bundle
+  - one explicit run of:
+    - `aoa-session-donor-harvest`
+    - `aoa-session-progression-lift`
+    - `aoa-quest-harvest`
+  - one execution report that records what ran, what was skipped, and which
+    artifacts or receipts were emitted
+  - one agent-authored closeout summary that says which conclusions came from
+    reread session evidence, which checkpoint hints were accepted, and which
+    hints were rejected as stale, cross-session, or contaminated
+
+## Procedure
+1. during checkpoint collection, keep the note append-only and provisional
+2. treat checkpoint candidates and progression-axis hints as shortlist inputs,
+   not verdict authority
+3. publish the reviewed-closeout target order explicitly:
+   - donor harvest first
+   - progression lift second
+   - quest harvest third
+4. before executing reviewed closeout, the Codex agent must reread the skill
+   instructions and the primary session evidence; checkpoint JSON, generated
+   packets, and closeout reports are only navigation aids
+5. when executing reviewed closeout, reread the full reviewed artifact before
+   every core skill stage
+6. let checkpoint note and reviewed handoff narrow attention, but never replace
+   the reviewed artifact or receipt evidence
+7. explicitly separate current-session evidence from stale, neighboring, or
+   diagnostic checkpoint contamination before naming final candidates
+8. run `aoa-session-donor-harvest` first so reusable units and owner routing
+   are bounded before any progression verdict
+9. run `aoa-session-progression-lift` second so final multi-axis movement is
+   gathered from reviewed evidence, donor outputs, and provisional checkpoint
+   axes together
+10. run `aoa-quest-harvest` third so final promotion triage happens only after
+   donor harvest and progression lift have finished
+11. keep stats refresh out of this bridge skill; that remains downstream after
+   explicit closeout receipts exist
+
+## Contracts
+- checkpoint note stays provisional and lower-authority than reviewed closeout
+- `checkpoint-collect` never emits final harvest, progression, or quest verdicts
+- `reviewed-closeout-execute` must reread the reviewed artifact and any receipt
+  evidence; it may not trust checkpoint notes alone
+- generated bridge artifacts are mechanical outputs, not proof that the agent
+  applied the skill protocol; the agent must still produce the final analytical
+  judgment from reread evidence
+- core skill order is fixed:
+  - `aoa-session-donor-harvest`
+  - `aoa-session-progression-lift`
+  - `aoa-quest-harvest`
+- this bridge skill coordinates core skills; it does not replace their meaning
+- `aoa closeout run` remains a separate receipt-first publisher path
+- stats refresh is not part of this skill
+
+## Risks and anti-patterns
+- treating checkpoint hints as if they were final donor harvest truth
+- treating `execute-closeout-chain` JSON as if it were the actual skill
+  application instead of an artifact bundle that still needs agent judgment
+- skipping donor harvest and jumping straight to progression or quest verdicts
+- using progression verdicts that were not reread against the reviewed artifact
+- letting quest harvest run before progression lift
+- turning the bridge into a hidden auto-runner inside `aoa closeout run`
+- refreshing stats before the explicit reviewed-closeout chain finishes
+
+## Verification
+- confirm `checkpoint-collect` only updates local ledger surfaces
+- confirm the bridge never emits final verdicts during mid-session capture
+- confirm reviewed closeout refuses to run without a reviewed artifact
+- confirm the core skill order is fixed and visible
+- confirm checkpoint note and reviewed handoff are treated as hints rather than
+  sole evidence
+- confirm the final answer distinguishes current-session evidence from
+  checkpoint hints and from stale or contaminated ledger entries
+- confirm the execution report's mechanical bridge outputs were not presented
+  as autonomous skill analysis
+- confirm stats refresh remains downstream of the bridge execution
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0075 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/session-donor-harvest/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Contracts, Validation
+- AOA-T-0084 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/progression-evidence-lift/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Contracts, Validation
+- AOA-T-0089 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/promotion-boundary/quest-unit-promotion-review/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Validation
+
+## Adaptation points
+Project overlays may add:
+- local reviewed artifact entrypoints
+- local receipt bundle locations
+- local stop conditions before quest triage
+- local owner-layer route maps for generated donor packets
+- project-local reviewed follow-through notes under `docs/session-harvests/`
+  when bridge upkeep becomes reusable but is still below promotion authority
+- project-local reminders that downstream `aoa-session-self-diagnose`, owner
+  follow-through, and stats refresh stay explicit next steps outside this skill
+- local post-closeout stats or owner follow-through commands that stay outside
+  this bridge skill

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/agents/openai.yaml
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Checkpoint Closeout Bridge
+  short_description: Bridge checkpoints into reviewed closeout
+  default_prompt: Use $aoa-checkpoint-closeout-bridge to build one closeout context from reviewed evidence, keep checkpoint hints provisional, and run donor harvest, progression lift, and quest harvest in order.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/assets/large-logo.svg
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/assets/small-logo.svg
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/references/checkpoint-closeout-execution-report-schema.yaml
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/references/checkpoint-closeout-execution-report-schema.yaml
@@ -1,0 +1,18 @@
+receipt_name: CHECKPOINT_CLOSEOUT_EXECUTION_REPORT
+event_kind: checkpoint_closeout_execution_report
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - context_ref
+  - executed_skills
+  - produced_receipt_refs
+  - final_stop_reason
+optional_payload_fields:
+  - checkpoint_note_ref
+  - surface_handoff_ref
+  - skipped_skills
+  - produced_artifact_refs
+rules:
+  - the report must reflect the fixed order `aoa-session-donor-harvest -> aoa-session-progression-lift -> aoa-quest-harvest`
+  - checkpoint notes and handoffs remain shortlist hints, not final authority
+  - at least one reviewed artifact ref must stay inspectable through the paired closeout context
+  - stats refresh remains downstream and must not be represented as an executed bridge stage

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-checkpoint-closeout-bridge
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-checkpoint-closeout-bridge`
+  - `detail_event_kind` must equal `checkpoint_closeout_execution_report`
+  - `detail_receipt_ref` must point to the bounded reviewed-closeout execution report for the same run
+  - include `route_ref` only when the orchestrator already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-contract-test
+++ b/.agents/skills/aoa-contract-test
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-contract-test

--- a/.agents/skills/aoa-contract-test/SKILL.md
+++ b/.agents/skills/aoa-contract-test/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: aoa-contract-test
+description: Design or extend contract-oriented validation at module, service, or workflow boundaries. Use when two components interact across a meaningful interface, downstream assumptions matter, or a smoke path needs an explicit contract. Do not use for purely local changes or when the real need is invariant or property testing instead of boundary validation.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-contract-test/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0003,AOA-T-0015
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-contract-test
+
+## Intent
+Strengthen boundary reliability by making stable producer-consumer expectations, validation surfaces, and claim limits explicit.
+
+## Trigger boundary
+Use this skill when:
+- two modules or services interact across a meaningful boundary
+- a smoke path or interface needs a stable validation contract
+- a module, service, CLI, schema, manifest, report, receipt, generated/export surface, workflow handoff, or repo-to-repo seam has consumers that rely on stable shape or behavior
+- a source-owned surface feeds generated, exported, adapter, or downstream consumer surfaces
+- a reusable practice, execution workflow, evaluation artifact, scenario, memory or recall object, role contract, router, SDK, metric, or generated/export surface exposes a stable object shape that other surfaces consume
+- a change risks breaking downstream assumptions
+
+Do not use this skill when:
+- the change is entirely local and does not affect a meaningful boundary
+- the boundary itself is still semantically unclear and naming is drifting; use `aoa-bounded-context-map`
+- the main problem is expressing a broad invariant rather than a boundary contract; use `aoa-property-invariants`
+- the main problem is auditing whether existing checks really cover a stable rule; use `aoa-invariant-coverage-audit`
+- the output is incidental logs, debug prose, or a one-off snapshot with no named consumer
+- the request would freeze internal implementation details or current incidental output as a public contract
+- a broad system rewrite is needed before the boundary itself is stable
+
+## Inputs
+- boundary under review
+- producer and named consumer
+- expected inputs and outputs
+- current verification surface
+- known downstream dependencies
+- contract limits and out-of-contract behavior
+
+## Outputs
+- explicit contract assumptions
+- tests, fixture checks, schema checks, smoke summaries, or structured validation notes
+- verification notes
+- downstream impact notes
+- contract limits that say what the check does not prove
+
+## Procedure
+1. identify the boundary and its consumers
+2. when the boundary is not a simple module or service interface, choose the smallest useful shape from `references/contract-shapes.md`
+3. state the expected input, output, behavior, report, receipt, schema, or handoff shape
+4. state what remains out of contract so the check does not become a whole-system proof
+5. express the contract in tests, fixture checks, schema checks, smoke summaries, or structured checks
+6. verify both the boundary behavior and the reporting shape
+7. report what became explicit, which consumers were protected, and what remains weak
+
+## Contracts
+- the contract should be visible to another human or agent
+- verification should be tied to the boundary, not only to internals
+- downstream assumptions should be named when relevant
+- out-of-contract behavior should stay explicit when it affects consumers
+- a contract test should protect the named seam, not claim the whole system is correct
+- generated, exported, adapter, and derived surfaces should remain subordinate to their source owners
+- consumer convenience should not become new source authority
+
+## Risks and anti-patterns
+- vague contracts that do not actually constrain behavior
+- treating a smoke summary as proof when it does not cover the real boundary
+- changing interface behavior without downstream impact notes
+- asserting internal implementation details as if they were public contract
+- freezing incidental output, debug logs, or transient runtime text as stable contract
+- turning a local boundary check into federation-wide law
+- widening the skill into generic test strategy instead of one named producer-consumer contract
+
+## Verification
+- confirm the contract is visible and reviewable
+- confirm validation is tied to the interface or boundary
+- confirm downstream impact was considered when relevant
+- confirm the report names any known contract limits or exclusions
+- confirm the named consumer and producer are both clear
+- confirm generated or exported surfaces are checked as derived consumers, not promoted into source truth
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0003 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/evaluation-chain/contract-first-smoke-summary/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Contracts, Validation
+- AOA-T-0015 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/contract-test-design/TECHNIQUE.md` and sections: Intent, Inputs, Core procedure, Risks
+
+## Adaptation points
+Project overlays should add:
+- local endpoints or module boundaries
+- local smoke or test commands
+- boundary-specific invariants
+- local schema, receipt, registry, report, export, or handoff contract examples
+- local source-owner and downstream-consumer names

--- a/.agents/skills/aoa-contract-test/agents/openai.yaml
+++ b/.agents/skills/aoa-contract-test/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Contract Test
+  short_description: Strengthen interface contracts
+  default_prompt: Use $aoa-contract-test to make a boundary contract explicit in tests or structured checks and report what the validation now proves.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-contract-test/assets/large-logo.svg
+++ b/.agents/skills/aoa-contract-test/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-contract-test/assets/small-logo.svg
+++ b/.agents/skills/aoa-contract-test/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-contract-test/references/contract-shapes.md
+++ b/.agents/skills/aoa-contract-test/references/contract-shapes.md
@@ -1,0 +1,51 @@
+# Contract Shapes
+
+Use this reference when the contract boundary is wider than a simple module or
+service interface. It is not a checklist. Pick the smallest shape that names
+one producer, one consumer, one stable expectation, and one honest validation
+surface.
+
+## How To Use
+
+1. Name the producer and consumer.
+2. Name the stable shape or behavior the consumer relies on.
+3. Choose the narrowest contract shape below.
+4. State what the contract does not prove.
+5. Validate the shape with the smallest reviewable check.
+
+## Shape Set
+
+| Shape | Producer | Consumer | Validate | Do Not Claim |
+|---|---|---|---|---|
+| Module, service, or API | Function, package, service, or endpoint. | Caller, client, downstream service, or workflow. | Input/output shape, errors, status, side effects, compatibility smoke. | Internal implementation details are public contract. |
+| CLI or tool report | Command, script, or local tool. | Automation, CI, another script, or operator workflow. | Flags, exit code, machine-readable output, report fields, failure mode. | Human log wording is stable unless explicitly documented. |
+| Schema, manifest, or registry | Authored schema, config, registry, or manifest builder. | Validator, router, SDK, generated reader, or release check. | Required fields, version, enum, reference resolution, invalid fixture failure. | Current incidental field order or formatting is semantic truth. |
+| Source to generated/export | Source-owned file, builder, or canonical bundle. | Generated catalog, export, adapter, or compact capsule consumer. | Source-to-output field mapping, freshness check, rebuild check, source ref. | Generated output owns the meaning it summarizes. |
+| Practice object or handoff | Practice atom, topology, capsule, or practice-to-skill bridge. | Execution skill, routing, eval, retrieval substrate, or downstream practice consumer. | Stable ID, atom shape, topology fields, selected sections, handoff payload. | A practice object is a skill, eval, role, memory object, or scenario. |
+| Skill bundle or export | Canonical skill bundle and export builder. | Runtime, SDK, router, pack profile, or installed skill surface. | Metadata, trigger boundary, support refs, export path, trigger eval. | Exported installed copy replaces authored bundle truth. |
+| Eval proof or report | Eval bundle, runner, scorer, or verdict emitter. | Review gate, release support, metric summary, or regression reader. | Claim limit, fixture shape, scoring logic, verdict schema, report fields. | One eval proves total quality or intelligence. |
+| Role contract or runtime seam | Profile, role contract, projection builder, runtime seam binding. | Scenario, SDK, runtime harness, or handoff consumer. | Role fields, authority limits, handoff payload, projection artifact. | Role text grants hidden runtime authority. |
+| Memory recall or writeback | Memory object, recall contract, writeback envelope, or retrieval export. | Router, retrieval substrate, eval, agent, or closeout workflow. | Inspect/capsule/expand shape, source refs, provenance, retention limit. | Recall output is fresh proof or live memory authority by itself. |
+| Scenario or reentry | Scenario route, review packet, stress lane, or reentry gate. | Agent, routing, metrics, runtime, or follow-through workflow. | Phase route, handoff, fallback, evidence expectation, reentry fields. | A recurring scenario is a single skill or live runtime ledger. |
+| Routing or SDK typed seam | Router hint, owner dispatch seam, SDK facade, CLI report, typed loader. | Agent, script, CI, notebook, or downstream adapter. | Typed fields, owner refs, dispatch result, compatibility result, error report. | Routing or SDK owns the source meaning it points to. |
+| Metrics receipt or summary ABI | Receipt publisher, shared envelope, event-kind registry, summary builder. | Metric summary, dashboard, closeout, routing, or review reader. | Envelope fields, event kind, supersession, active view, summary schema. | Summary counts are owner truth or final promotion verdict. |
+
+## Compact Contract Pass
+
+| Field | Answer |
+|---|---|
+| Producer |  |
+| Consumer |  |
+| Stable expectation |  |
+| Validation surface |  |
+| Out of contract |  |
+| Downstream impact if broken |  |
+| Source owner remains |  |
+
+## Verification
+
+- one producer and one consumer are named
+- the stable shape or behavior is observable by the consumer
+- the check fails reviewably when the contract is broken
+- incidental output and internal implementation details stay out of contract
+- derived, generated, or adapter surfaces remain weaker than source owners

--- a/.agents/skills/aoa-core-logic-boundary
+++ b/.agents/skills/aoa-core-logic-boundary
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-core-logic-boundary

--- a/.agents/skills/aoa-core-logic-boundary/SKILL.md
+++ b/.agents/skills/aoa-core-logic-boundary/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: aoa-core-logic-boundary
+description: Separate reusable core logic from glue, orchestration, and infrastructure detail. Use when stable rules are mixed with wiring, the same logic repeats in several places, or reviews are muddy because the responsibility center is unclear. Do not use for tiny isolated fixes or when the real task is introducing a port or adapter around a concrete dependency.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-core-logic-boundary/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0016,AOA-T-0015
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-core-logic-boundary
+
+## Intent
+Use this skill to separate a stable reusable center from surrounding glue, orchestration, projection, infrastructure, or presentation detail so future changes land in the right place.
+
+## Trigger boundary
+Use this skill when:
+- a module mixes stable rules with wiring or execution detail
+- an execution workflow, practice pattern, evaluation artifact, scenario, memory or recall object, role contract, router, SDK, metric, generated/export, or process surface mixes reusable meaning with projection, report, runtime, or local delivery detail
+- the same logic is starting to appear in several places
+- tests or reviews are muddy because the center of responsibility is unclear
+- you need to decide whether something belongs in the core or at the edges
+- generated, exported, adapter, report, or presentation surfaces are starting to look like they own the reusable rule they only carry
+
+Do not use this skill when:
+- the task is a tiny isolated fix with no meaningful boundary ambiguity
+- the code is already clearly partitioned
+- the result would only rename folders without improving understanding
+- the owner, context, or source-of-truth boundary is still unclear; use `aoa-bounded-context-map` first
+- the main problem is recording decision rationale rather than boundary placement; use `aoa-adr-write` first
+- the main problem is validating a consumer-visible contract after the boundary is clear; use `aoa-contract-test`
+- the boundary is already clear and the main task is introducing a port or adapter around a concrete dependency; use `aoa-port-adapter-refactor`
+
+## Inputs
+- target module, service, repository surface, layer surface, or slice
+- current responsibilities
+- repeated or reusable logic candidates
+- surrounding glue, projection, rendering, runtime, infrastructure, or orchestration context
+- source owner and edge consumers when the split crosses generated, exported, adapter, or downstream surfaces
+
+## Outputs
+- clarified boundary between core logic and surrounding glue
+- notes on what should stay reusable versus edge-specific
+- small refactor proposal or bounded implementation
+- source-owner and derived-surface stop-lines when relevant
+- verification summary
+
+## Procedure
+1. identify which rules or behaviors are stable enough to count as reusable core logic
+2. when the target is not a simple code module, choose the smallest useful shape from `references/core-boundary-shapes.md`
+3. identify which parts are mostly wiring, orchestration, I/O, projection, report rendering, local path handling, generated output, adapter behavior, or environment detail
+4. separate the concerns conceptually before moving code or rewriting docs
+5. move or propose moving only the bounded subset that clearly belongs in the reusable center
+6. avoid renaming or restructuring for ceremony alone
+7. verify that the new boundary improves changeability and review clarity
+
+## Contracts
+- reusable logic should not stay trapped in glue if that blocks testing or reuse
+- glue should not be over-promoted into domain logic without reason
+- the boundary should improve clarity, not just aesthetics
+- the change should remain reviewable and bounded
+- derived, generated, exported, adapter, and presentation surfaces should not become source authority just because they are convenient
+- reusable center can mean stable rule, mapping, scoring logic, role contract, recall rule, receipt envelope, route choice, or scenario phase, but it must stay named and bounded
+
+## Risks and anti-patterns
+- treating all logic as core logic and over-abstracting the system
+- moving orchestration detail into the core under the label of purity
+- renaming layers without reducing actual confusion
+- hiding a broad rewrite inside a boundary-cleanup task
+- treating generated output, report prose, runtime projection, or local adapter code as the reusable center
+- freezing one repository, layer, or surface's current implementation detail as universal project architecture
+- using this skill when the actual problem is owner-route ambiguity, contract validation, or a concrete dependency seam
+
+## Verification
+- confirm the core candidate is genuinely reusable or stability-shaped
+- confirm edge-specific code remains at the edge when appropriate
+- confirm the refactor improved clarity for future changes
+- confirm no unrelated structural churn was introduced
+- confirm source-owned meaning stays stronger than generated, exported, adapter, or presentation surfaces
+- confirm the split says what future changes should update together and what should remain independent
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0016 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/bounded-context-map/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Contracts, Validation
+- AOA-T-0015 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/contract-test-design/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local layering conventions
+- preferred directories or module boundaries
+- repository-specific examples of core versus glue
+- local project-specific examples from `references/core-boundary-shapes.md`
+- local verification commands

--- a/.agents/skills/aoa-core-logic-boundary/agents/openai.yaml
+++ b/.agents/skills/aoa-core-logic-boundary/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Core Logic Boundary
+  short_description: Separate core logic from glue
+  default_prompt: Use $aoa-core-logic-boundary to decide what belongs in reusable core logic versus glue or infrastructure detail, then keep the refactor bounded.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-core-logic-boundary/assets/large-logo.svg
+++ b/.agents/skills/aoa-core-logic-boundary/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-core-logic-boundary/assets/small-logo.svg
+++ b/.agents/skills/aoa-core-logic-boundary/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-core-logic-boundary/references/core-boundary-shapes.md
+++ b/.agents/skills/aoa-core-logic-boundary/references/core-boundary-shapes.md
@@ -1,0 +1,56 @@
+# Core Boundary Shapes
+
+Use this reference when the core-versus-glue question is wider than one code
+module. It is not a checklist. Pick the smallest shape that names one reusable
+center, one edge context, one stop-line, and one verification surface.
+
+## How To Use
+
+1. Name the already-understood context or owner surface.
+2. Name the reusable rule, mapping, decision, or behavior candidate.
+3. Name the glue, projection, rendering, adapter, runtime, or delivery detail.
+4. Choose the narrowest shape below.
+5. Verify that future changes can update the center without dragging edge
+   detail, and edge detail without silently changing the center.
+
+## Shape Set
+
+| Shape | Reusable Center | Edge Or Glue | Do Not Promote | Verify |
+|---|---|---|---|---|
+| Code module or service slice | Stable rule, calculation, policy, state transition, or selection logic. | Request parsing, retries, logging, persistence, transport, scheduling, environment paths. | Delivery mechanics as domain truth. | Core tests stay small; edge behavior remains covered separately. |
+| Skill bundle | Portable workflow, trigger boundary, contracts, risks, verification posture. | Installed export, profile metadata, pack selection, local overlay wording, runtime discovery. | Exported copy or router hint as authored skill truth. | Authored bundle remains source; generated/export refresh is deterministic. |
+| Practice object | Atomic move, invariant posture, reusable proof or execution pattern. | Origin notes, examples, promotion notes, topology metadata, skill bridge wording. | Practice pattern as skill, scenario, eval, role, or runtime law. | Core move is stable; support notes stay explanatory. |
+| Eval bundle | Scoring rule, proof contract, claim limit, verdict semantics. | Fixture loading, report layout, markdown rendering, runner plumbing. | Polished report text as proof logic. | A changed score rule is distinguishable from report rendering churn. |
+| Role contract | Role contract, authority limits, handoff posture, collaboration mode. | Prompt projection, model-tier routing, runtime binding, UI labels. | Runtime projection as hidden role authority. | Role source remains reviewable apart from projection glue. |
+| Memory, recall, or provenance surface | Recall rule, writeback envelope, provenance expectation, retention boundary. | Storage adapter, vector index, cache, search ranking, retrieval export plumbing. | Retrieved text or adapter cache as live memory authority. | Provenance and retention rules survive storage changes. |
+| Scenario or playbook | Recurring route shape, phase order, fallback rule, evidence expectation. | Real-run notes, execution logs, scheduler hooks, orchestration scripts. | Scenario recipe as hidden runtime engine. | Scenario can be reviewed without replaying local runtime behavior. |
+| Routing or SDK seam | Typed loader rule, owner dispatch decision, compatibility posture, facade contract. | CLI flags, report formatting, local path discovery, adapter wrappers. | Router or SDK as owner of the meaning it points to. | Typed behavior stays stable while presentation or local wrappers change. |
+| Metrics or receipt surface | Event envelope, receipt semantics, supersession rule, active-view contract. | Dashboard rendering, summary prose, aggregation display, export packaging. | Counts or charts as final owner verdict. | Envelope and verdict limits remain clear under report changes. |
+| Generated or export builder | Source-to-output mapping rule, freshness check, source reference preservation. | Generated artifact bytes, compact formatting, sort order, install path. | Generated output as source-owned meaning. | Rebuild proves mapping; source remains stronger than output. |
+| Mechanics or process docs | Local mechanic contract, part boundary, roadmap rule, landing/provenance relation. | Legacy notes, logs, status prose, migration staging, folder ceremony. | Roadmap or provenance notes as active mechanic contract. | Active contract points to nearby docs without dragging legacy language. |
+| Session or workflow surface | Stable phase order, stop condition, review gate, handoff requirement. | Checkpoint note, shell command, transcript detail, one-session local evidence. | A single session trace as universal workflow law. | The reusable phase survives while local evidence stays evidence. |
+
+## Compact Core Boundary Pass
+
+| Field | Answer |
+|---|---|
+| Context already understood |  |
+| Reusable center |  |
+| Edge or glue |  |
+| Source owner |  |
+| Derived or consumer surfaces |  |
+| Stop-line |  |
+| Verification surface |  |
+| Future update rule |  |
+
+## Verification
+
+- the center is stable enough to reuse, test, or review independently
+- edge detail is still allowed to vary without changing the center
+- source-owned meaning stays stronger than generated, exported, adapter, or
+  presentation surfaces
+- the split reduces future review confusion rather than only renaming folders
+- if the source owner or context is still unclear, stop and use
+  `aoa-bounded-context-map` first
+- if the concrete dependency seam is already clear, stop and use
+  `aoa-port-adapter-refactor`

--- a/.agents/skills/aoa-dry-run-first
+++ b/.agents/skills/aoa-dry-run-first
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-dry-run-first

--- a/.agents/skills/aoa-dry-run-first/SKILL.md
+++ b/.agents/skills/aoa-dry-run-first/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: aoa-dry-run-first
+description: Prefer simulation, preview, or inspect-only paths before any real mutation, then require one explicit confirmation for the concrete mutating step. Use when the action can be previewed and mistakes would be costly, such as delete, restore, migrate, or reconfigure operations. Do not use for purely analytical tasks or when the primary question is whether execution is authorized at all.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: risk
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/risk/aoa-dry-run-first/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0004,AOA-T-0028
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-dry-run-first
+
+## Intent
+Use this skill to run a preview-first workflow that stops at inspection until one concrete mutation is ready, then asks for a visible confirmation before the real action proceeds.
+
+## Trigger boundary
+Use this skill when:
+- the task can be simulated, previewed, or inspected before real execution
+- the action may delete, restore, migrate, reconfigure, or otherwise alter a live surface
+- the cost of a mistaken execution is meaningfully higher than the cost of a preview step
+- the task needs a clear seam between dry-run evidence and the one confirmed mutating action
+
+Do not use this skill when:
+- no meaningful dry-run or preview path exists and the task is already clearly bounded and harmless
+- the task is purely analytical and does not approach execution at all
+- the central question is whether execution is authorized at all rather than how to preview it; use `aoa-approval-gate-check`
+- the task is only about preparing a sanitized artifact for sharing; use `aoa-sanitized-share`
+
+## Inputs
+- requested action
+- available preview or dry-run mechanisms
+- touched surfaces
+- known limits of the preview path
+
+## Outputs
+- dry-run or preview recommendation
+- bounded preview result or plan
+- note on what the preview does and does not prove
+- explicit confirmation request for the mutating step when the preview is complete
+- recommendation for next step
+
+## Procedure
+1. identify whether a preview, simulation, inspect-only, or dry-run path exists
+2. prefer the safest bounded preview path before real execution
+3. make explicit what the preview covers and what it cannot guarantee
+4. stop at inspection until the mutating step is concrete enough to name
+5. require one explicit confirmation before any state-changing action runs
+6. avoid treating dry-run output as proof of total safety
+7. recommend the next step only after the preview and confirmation seam have both been interpreted
+
+## Contracts
+- dry-run should reduce uncertainty before execution
+- preview results should not be overstated
+- lack of a dry-run path should be named as a risk, not hidden
+- real execution should not be smuggled into a preview step
+- confirmation must name the concrete mutation, not just generic permission
+- the mutating step stays singular and bounded after the gate
+
+## Risks and anti-patterns
+- treating a preview as complete validation
+- skipping preview because the real change looks small
+- using a fake or weak preview path that does not touch the real risk surface
+- blurring inspect-only and execute behavior
+- turning the confirmation seam into a vague caution prompt
+- chaining extra mutations after the confirmed step without a fresh gate
+
+## Verification
+- confirm a preview or dry-run path was considered first
+- confirm the preview scope was named honestly
+- confirm unresolved risk after preview was not hidden
+- confirm the preview step did not silently perform the real action
+- confirm the explicit confirmation names the exact mutating step
+- confirm the recommended next step matches the preview confidence
+- confirm the workflow stops after the confirmed mutation instead of widening into a loop
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0004 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/intent-chain/intent-plan-dry-run-contract-chain/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Validation
+- AOA-T-0028 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/confirmation-gated-mutating-action/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local preview commands
+- dry-run limitations
+- restore or recovery expectations
+- project-specific inspect-only patterns

--- a/.agents/skills/aoa-dry-run-first/agents/openai.yaml
+++ b/.agents/skills/aoa-dry-run-first/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Dry Run First
+  short_description: Preview before real mutation
+  default_prompt: Use $aoa-dry-run-first to find the safest preview path, interpret what it proves, and stop for explicit confirmation before the real mutation.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#B45309'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-dry-run-first/assets/dry_run_contract.template.json
+++ b/.agents/skills/aoa-dry-run-first/assets/dry_run_contract.template.json
@@ -1,0 +1,29 @@
+{
+  "requested_action": "Switch application symlink from current to previous release",
+  "preview_steps": [
+    {
+      "label": "inspect current symlink target",
+      "command": "readlink current",
+      "touches_state": false
+    },
+    {
+      "label": "show candidate target",
+      "command": "readlink previous",
+      "touches_state": false
+    }
+  ],
+  "apply_step": {
+    "label": "switch symlink",
+    "command": "ln -sfn previous current",
+    "touches_state": true
+  },
+  "touched_surfaces": [
+    "application symlink",
+    "release pointer"
+  ],
+  "limitations": [
+    "preview does not prove runtime health after the switch",
+    "preview does not validate permissions for the final write"
+  ],
+  "confirmation_required": true
+}

--- a/.agents/skills/aoa-dry-run-first/assets/dry_run_report.schema.json
+++ b/.agents/skills/aoa-dry-run-first/assets/dry_run_report.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DryRunFirstReport",
+  "type": "object",
+  "required": [
+    "skill",
+    "requested_action",
+    "preview_verdict",
+    "workflow_state",
+    "preview_steps",
+    "apply_step",
+    "honest_boundaries",
+    "warnings",
+    "errors",
+    "next_step"
+  ],
+  "properties": {
+    "skill": {
+      "const": "aoa-dry-run-first"
+    },
+    "requested_action": {
+      "type": "string"
+    },
+    "preview_verdict": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "warn",
+        "fail"
+      ]
+    },
+    "workflow_state": {
+      "type": "string"
+    },
+    "preview_steps": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "apply_step": {
+      "type": "object"
+    },
+    "touched_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "honest_boundaries": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "confirmation_prompt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "next_step": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/.agents/skills/aoa-dry-run-first/assets/large-logo.svg
+++ b/.agents/skills/aoa-dry-run-first/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-dry-run-first/assets/small-logo.svg
+++ b/.agents/skills/aoa-dry-run-first/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-dry-run-first/references/confirmation_seam.md
+++ b/.agents/skills/aoa-dry-run-first/references/confirmation_seam.md
@@ -1,0 +1,19 @@
+# Confirmation seam
+
+The confirmation step should name the exact mutating action.
+
+## Good confirmation shape
+
+- command or operation name
+- touched surface
+- one-sentence risk note
+
+## Example
+
+Confirm the exact mutating step: switch symlink -> `ln -sfn previous current`
+
+## Anti-patterns
+
+- "Proceed?" with no mutation named
+- reusing the dry-run command as the confirmation target
+- confirming a batch of extra mutations that were not previewed

--- a/.agents/skills/aoa-dry-run-first/references/dry_run_limitations.md
+++ b/.agents/skills/aoa-dry-run-first/references/dry_run_limitations.md
@@ -1,0 +1,16 @@
+# Dry-run limitations
+
+Use this file when the preview exists but does not prove the whole change is safe.
+
+## Record at least these boundaries
+
+- what the preview exercised
+- what the preview did not exercise
+- which real mutation still remains
+- what could still fail after a clean preview
+
+## Good language
+
+- "This preview confirms the render shape but not post-apply runtime health."
+- "This inspection shows the target files, not whether the write will succeed."
+- "This plan reduces uncertainty but does not prove rollback safety."

--- a/.agents/skills/aoa-dry-run-first/scripts/dry_run_contract.py
+++ b/.agents/skills/aoa-dry-run-first/scripts/dry_run_contract.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+TEMPLATE = {
+    "requested_action": "Switch application symlink from current to previous release",
+    "preview_steps": [
+        {
+            "label": "inspect current symlink target",
+            "command": "readlink current",
+            "touches_state": False,
+        },
+        {
+            "label": "show candidate target",
+            "command": "readlink previous",
+            "touches_state": False,
+        },
+    ],
+    "apply_step": {
+        "label": "switch symlink",
+        "command": "ln -sfn previous current",
+        "touches_state": True,
+    },
+    "touched_surfaces": ["application symlink", "release pointer"],
+    "limitations": [
+        "preview does not prove runtime health after the switch",
+        "preview does not validate permissions for the final write",
+    ],
+    "confirmation_required": True,
+}
+
+
+def _load_payload(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON input on stdin or via a file path.")
+    return json.loads(raw)
+
+
+def _command(step: dict[str, Any]) -> str:
+    return str(step.get("command", "")).strip()
+
+
+def build_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    raw_preview_steps = payload.get("preview_steps") or []
+    preview_steps = raw_preview_steps if isinstance(raw_preview_steps, list) else []
+    raw_apply_step = payload.get("apply_step") or {}
+    apply_step = raw_apply_step if isinstance(raw_apply_step, Mapping) else {}
+    limitations = payload.get("limitations") or []
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    if not isinstance(raw_preview_steps, list):
+        errors.append("preview_steps must be a list.")
+    if raw_apply_step and not isinstance(raw_apply_step, Mapping):
+        errors.append("apply_step must be an object.")
+    if not preview_steps:
+        errors.append("No preview_steps were provided.")
+    if not apply_step:
+        errors.append("No apply_step was provided.")
+
+    preview_commands = []
+    for idx, step in enumerate(preview_steps, start=1):
+        if not isinstance(step, Mapping):
+            errors.append(f"preview step {idx} must be an object.")
+            continue
+        preview_commands.append(_command(step))
+        if step.get("touches_state") is True:
+            errors.append(f"preview step {idx} is marked as mutating.")
+        if not _command(step):
+            errors.append(f"preview step {idx} is missing a command.")
+
+    apply_command = _command(apply_step)
+    if not apply_command:
+        errors.append("apply_step.command is missing.")
+    if apply_step.get("touches_state") is False:
+        warnings.append("apply_step is marked as non-mutating; confirm that this is intentional.")
+
+    if apply_command and apply_command in preview_commands:
+        errors.append("The apply command matches one of the preview commands.")
+
+    if not limitations:
+        warnings.append("No limitations were recorded. The preview boundary is probably underspecified.")
+
+    confirmation_required = bool(payload.get("confirmation_required", True))
+    if not confirmation_required:
+        warnings.append("confirmation_required is false. This weakens the explicit seam the skill expects.")
+
+    if errors:
+        workflow_state = "hold"
+        preview_verdict = "fail"
+        next_step = "repair-the-preview-contract-before-mutation"
+        confirmation_prompt = None
+    elif warnings:
+        workflow_state = "ready_for_confirmation" if confirmation_required else "preview-complete"
+        preview_verdict = "warn"
+        next_step = "ask-for-confirmation" if confirmation_required else "review-warnings-before-apply"
+        confirmation_prompt = (
+            f"Confirm the exact mutating step: {apply_step.get('label', 'apply')} -> {apply_command}"
+            if confirmation_required
+            else None
+        )
+    else:
+        workflow_state = "ready_for_confirmation"
+        preview_verdict = "ok"
+        next_step = "ask-for-confirmation"
+        confirmation_prompt = f"Confirm the exact mutating step: {apply_step.get('label', 'apply')} -> {apply_command}"
+
+    return {
+        "skill": "aoa-dry-run-first",
+        "requested_action": payload.get("requested_action", ""),
+        "preview_verdict": preview_verdict,
+        "workflow_state": workflow_state,
+        "preview_steps": preview_steps,
+        "apply_step": apply_step,
+        "touched_surfaces": payload.get("touched_surfaces") or [],
+        "honest_boundaries": limitations,
+        "warnings": warnings,
+        "errors": errors,
+        "confirmation_prompt": confirmation_prompt,
+        "next_step": next_step,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a deterministic dry-run contract.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--template", action="store_true", help="Print a starter JSON payload and exit.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print the output JSON.")
+    args = parser.parse_args()
+
+    if args.template:
+        print(json.dumps(TEMPLATE, indent=2))
+        return 0
+
+    payload = _load_payload(args.input_json)
+    result = build_contract(payload)
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0 if not result["errors"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-dry-run-first/scripts/preview_gap_check.py
+++ b/.agents/skills/aoa-dry-run-first/scripts/preview_gap_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_payload(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON input on stdin or via a file path.")
+    return json.loads(raw)
+
+
+def check_gaps(payload: dict[str, Any]) -> dict[str, Any]:
+    preview_steps = payload.get("preview_steps") or []
+    apply_step = payload.get("apply_step") or {}
+    limitations = payload.get("limitations") or payload.get("honest_boundaries") or []
+
+    gaps: list[str] = []
+    notes: list[str] = []
+
+    apply_command = str(apply_step.get("command", "")).strip()
+    if not preview_steps:
+        gaps.append("missing-preview-step")
+    if not apply_command:
+        gaps.append("missing-apply-command")
+
+    preview_commands = [str(step.get("command", "")).strip() for step in preview_steps]
+    if apply_command and apply_command in preview_commands:
+        gaps.append("preview-and-apply-are-the-same-command")
+
+    if not limitations:
+        gaps.append("missing-limitations")
+    elif len(limitations) == 1:
+        notes.append("only-one-limitation-recorded")
+
+    mutating_preview_steps = [
+        str(step.get("label", "preview")).strip()
+        for step in preview_steps
+        if step.get("touches_state") is True
+    ]
+    if mutating_preview_steps:
+        gaps.append("preview-step-marked-mutating")
+        notes.append(f"mutating preview labels: {', '.join(mutating_preview_steps)}")
+
+    confirmation_required = payload.get("confirmation_required")
+    if confirmation_required is False:
+        notes.append("confirmation seam has been weakened")
+
+    if gaps:
+        status = "fail"
+    elif notes:
+        status = "warn"
+    else:
+        status = "ok"
+
+    return {
+        "skill": "aoa-dry-run-first",
+        "status": status,
+        "gaps": gaps,
+        "notes": notes,
+        "checked_preview_steps": len(preview_steps),
+        "checked_limitations": len(limitations),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check preview-vs-apply separation.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON.")
+    args = parser.parse_args()
+
+    result = check_gaps(_load_payload(args.input_json))
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0 if result["status"] != "fail" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-invariant-coverage-audit
+++ b/.agents/skills/aoa-invariant-coverage-audit
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-invariant-coverage-audit

--- a/.agents/skills/aoa-invariant-coverage-audit/SKILL.md
+++ b/.agents/skills/aoa-invariant-coverage-audit/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: aoa-invariant-coverage-audit
+description: Audit whether existing tests and checks actually constrain the stable invariants that matter. Use when you need to judge if current coverage proves a rule or only repeats examples, and you want the smallest bounded follow-up gaps. Do not use when the invariant itself is still undefined or when the real task is to author new invariants rather than audit coverage.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-invariant-coverage-audit/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0017
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-invariant-coverage-audit
+
+## Intent
+Use invariant-oriented coverage to judge whether an existing validation or proof surface really constrains the stable truth, and turn that judgment into a bounded audit package instead of a loose example review.
+
+## Trigger boundary
+Use this skill when:
+- an existing test, check, schema, fixture, generated/export parity check, report, receipt, or proof surface needs a review for invariant strength
+- the question is whether current checks really constrain the stable rule
+- you need to turn a loose example set into a bounded coverage audit
+- you want an audit result that names the gap, not just the invariant
+- a validation surface may look broad, but its claim limits and blind spots need review
+
+Do not use this skill when:
+- the main problem is defining the invariant itself rather than auditing coverage; use `aoa-property-invariants` first
+- the invariant itself is still unknown and you need discovery work first
+- the task is mostly about presentation details or a narrow snapshot
+- you need a full boundary contract review rather than a coverage audit
+
+## Inputs
+- target rule or stable truth
+- current tests, checks, schemas, fixtures, reports, generated parity checks, proof reports, or examples
+- known edge cases and stress cases
+- the input space or states that matter most
+- known claim limits or downstream surfaces that rely on the invariant
+
+## Outputs
+- invariant coverage map
+- gap list for weak or missing checks
+- bounded follow-up checks or revisions
+- concise verification summary
+- audit verdict on whether coverage is strong enough for the current stable truth
+- claim-limit notes that say what the current validation surface does not prove
+
+## Procedure
+1. name the stable truth in plain language
+2. map each existing check to the invariant it constrains
+3. when the validation surface is not an ordinary test suite, choose the smallest useful shape from `references/coverage-audit-shapes.md`
+4. mark weak, redundant, or missing coverage
+5. add only bounded cases that strengthen the weakest invariant first
+6. separate the audit result from any invariant-authoring work that should happen elsewhere
+7. report what the suite or validation surface now proves and what it still does not
+
+## Contracts
+- every claimed invariant must be traceable to at least one check
+- the audit should distinguish real constraint from mere example repetition
+- schema, report, generated, fixture, and proof surfaces should be audited by the stable claim they constrain, not by how complete they look
+- the result should stay reviewable without sprawling into a full test strategy
+- the skill should stay an audit package rather than a general testing doctrine
+- the output should make the next coverage move obvious
+- claim limits should remain visible when downstream readers may over-trust the surface
+
+## Risks and anti-patterns
+- counting examples as if they were invariants
+- letting random data hide thin coverage
+- treating schema validity, report completeness, or generated freshness as proof of the underlying invariant
+- widening into generic test design or full suite architecture
+- making the audit so abstract that no one can act on it
+- drifting into invariant authoring when the task is really coverage review
+- turning the audit into a generic quality sermon instead of a bounded package
+
+## Verification
+- confirm each core invariant is named and mapped to a check
+- confirm the coverage gap list is specific and bounded
+- confirm non-test validation surfaces are judged by their constrained claim and claim limit
+- confirm another human can follow why the existing surface is or is not sufficient
+- confirm the result names the next bounded follow-up, if one is needed
+- confirm the skill reads like an operational audit rather than a plain technique lift
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0017 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/property-invariants/TECHNIQUE.md` and sections: Intent, When to use, When not to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays should add:
+- local test or check commands
+- domain-specific invariants and edge cases
+- local schemas, generated parity checks, proof reports, receipts, or fixture families that should be audited through `references/coverage-audit-shapes.md`
+- notes on where coverage gaps are recorded
+- rules for when a coverage audit should escalate into a deeper review

--- a/.agents/skills/aoa-invariant-coverage-audit/agents/openai.yaml
+++ b/.agents/skills/aoa-invariant-coverage-audit/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Invariant Coverage Audit
+  short_description: Audit invariant coverage
+  default_prompt: Use $aoa-invariant-coverage-audit to map checks to invariants, identify the thinnest coverage gaps, and report what the current suite does and does not prove.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-invariant-coverage-audit/assets/large-logo.svg
+++ b/.agents/skills/aoa-invariant-coverage-audit/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-invariant-coverage-audit/assets/small-logo.svg
+++ b/.agents/skills/aoa-invariant-coverage-audit/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-invariant-coverage-audit/references/coverage-audit-shapes.md
+++ b/.agents/skills/aoa-invariant-coverage-audit/references/coverage-audit-shapes.md
@@ -1,0 +1,52 @@
+# Coverage Audit Shapes
+
+Use this reference when the validation surface is wider than an ordinary unit
+test suite. It is not a checklist. Pick the smallest shape that names one
+stable invariant, one existing evidence surface, one claim limit, and one
+bounded next check.
+
+## How To Use
+
+1. Name the stable truth being claimed.
+2. Name the validation or proof surface that appears to support it.
+3. Choose the narrowest audit shape below.
+4. Map evidence to the invariant, then state what the evidence does not prove.
+5. Add only the smallest follow-up check that closes the most important gap.
+
+## Shape Set
+
+| Shape | Existing Surface | Invariant Question | Gap To Look For | Useful Follow-Up |
+|---|---|---|---|---|
+| Code test suite | Unit, integration, smoke, or regression tests. | Does behavior hold across the important input or state space? | Examples cover happy paths but not the stable rule. | Boundary, negative, property, or regression case. |
+| Schema or manifest | JSON schema, YAML manifest, registry, config, or typed model. | Does structural validity protect the rule consumers rely on? | Required fields pass while semantic relationships are unchecked. | Invalid fixture, enum drift check, or cross-field validation. |
+| Fixture family | Golden files, snapshots, canned inputs, or sample repos. | Do examples represent the meaningful variation? | Many fixtures repeat the same shape. | One fixture per missing state, role, boundary, or failure mode. |
+| Generated/export parity | Builder output, compact index, installed copy, adapter export, or capsule. | Does generated material stay derived from source truth? | Freshness passes while source-to-output meaning is not checked. | Rebuild check plus source-ref, field-map, or stale-output failure. |
+| Report or receipt | Markdown report, JSON receipt, run summary, status surface, or dashboard feed. | Does the report constrain the claim readers infer from it? | Complete-looking reports overstate verdicts or hide exclusions. | Claim-limit assertion, required exclusion field, or malformed receipt case. |
+| Eval or proof result | Eval bundle, scorer output, verdict, benchmark result, or review gate. | Does the proof surface justify exactly the claim being made? | One score is treated as total quality or broad intelligence. | Claim-scope fixture, scorer edge case, or verdict-schema failure. |
+| Router, SDK, or adapter compatibility | Dispatch hints, typed loader, SDK facade, CLI compatibility report, adapter bridge. | Does compatibility preserve stable consumer assumptions? | Consumer paths work only for the common route. | Unsupported-shape fixture, error contract, or version compatibility case. |
+| Workflow or role scenario | Playbook phase, handoff, role contract, session route, approval gate, or operator step. | Does the workflow guard the invariant under realistic route changes? | Scenario prose states a rule but no check catches skipped gates. | Minimal route trial, handoff receipt, stop-condition, or negative path check. |
+| Memory, recall, or provenance surface | Recall object, writeback envelope, source reference, retention rule, retrieval capsule. | Does retrieved or stored evidence keep provenance and freshness limits clear? | Recall output looks authoritative without source or freshness bounds. | Source-ref check, stale-recall case, retention invariant, or writeback envelope check. |
+| Metrics or source coverage | Coverage report, metric summary, source-count report, adoption audit, or quality dashboard. | Does the metric actually constrain the stable claim it is used to support? | Counts are treated as proof of quality, adoption, or completeness. | Denominator check, source coverage gap, active-view rule, or metric exclusion case. |
+
+## Compact Audit Pass
+
+| Field | Answer |
+|---|---|
+| Stable invariant |  |
+| Existing surface |  |
+| Shape selected |  |
+| Evidence that constrains it |  |
+| Evidence that only repeats examples |  |
+| Claim limit |  |
+| Smallest useful follow-up |  |
+| Downstream reader risk |  |
+
+## Verification
+
+- one invariant is named in plain language
+- the existing validation surface is mapped to that invariant, not praised in
+  general
+- the claim limit is explicit enough to stop over-trust
+- the follow-up check is smaller than a full test strategy
+- generated, reported, scored, or retrieved evidence remains weaker than the
+  source truth it describes

--- a/.agents/skills/aoa-local-stack-bringup
+++ b/.agents/skills/aoa-local-stack-bringup
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-local-stack-bringup

--- a/.agents/skills/aoa-local-stack-bringup/SKILL.md
+++ b/.agents/skills/aoa-local-stack-bringup/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: aoa-local-stack-bringup
+description: Bring up a bounded local multi-service stack by rendering runtime truth, checking selector-aware host readiness, and launching through one explicit lifecycle entrypoint with a visible stop path. Use when profiles, presets, or overlays can change what starts and host readiness must be reviewed before launch. Do not use for remote deployment, pure diagnostics without launch intent, or generic infra-change work.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: risk
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/risk/aoa-local-stack-bringup/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0036,AOA-T-0037,AOA-T-0028,AOA-T-0038
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-local-stack-bringup
+
+## Intent
+Use this skill to turn local multi-service startup into a reviewable bring-up workflow with a visible pre-start seam and one explicit launch path.
+
+## Trigger boundary
+Use this skill when:
+- a local stack has more than one meaningful service or runtime layer
+- the selected profile, preset, or overlay can change what will actually start
+- startup depends on host readiness signals that should be checked before launch
+- the operator needs one explicit launch path and stop path after pre-start review
+- a plain infrastructure change workflow would miss the local runtime selection, preflight, or lifecycle seam
+
+Do not use this skill when:
+- the main task is remote deployment, continuous monitoring, or fleet orchestration
+- the task is only to inspect rendered runtime truth without any launch decision
+- the task is only to diagnose readiness without planning a bounded local bring-up
+- the main question is whether authority exists at all; use `aoa-approval-gate-check`
+- the task is a broader operational or configuration change with no bounded local stack bring-up; use `aoa-safe-infra-change`
+
+## Inputs
+- selected local runtime, profile, or preset
+- available render-truth surface for the chosen runtime
+- available readiness or doctor surface for the chosen runtime
+- one explicit local lifecycle entrypoint
+- intended stop path or cleanup path
+
+## Outputs
+- rendered runtime truth summary for what would actually start
+- selector-aware readiness verdict with named blockers or warnings
+- explicit go, hold, or confirm-before-launch recommendation
+- started bounded local stack with visible stop path, or a deferred-start report
+- concise runtime report with unresolved warnings, blockers, or cleanup notes
+
+## Procedure
+1. name the selected runtime, the expected service set, and the explicit launch surface before starting anything
+2. render the effective service list or composed runtime truth before startup, and keep any full rendered config local and controlled
+3. run the selector-aware doctor or readiness surface for the same selected runtime and note `ok`, `warn`, or `fail` items
+4. stop and report if the render or readiness step exposes a blocker or unresolved ambiguity that should be fixed before launch
+5. require explicit operator confirmation before launch when startup would materially mutate the local runtime or when warnings remain
+6. launch the bounded stack through one operator-facing lifecycle entrypoint and keep the stop path visible
+7. report what was rendered, what the readiness verdict said, what started, and what remains risky, deferred, or cleanup-sensitive
+
+## Contracts
+- render review happens before startup
+- readiness checks stay tied to the selected runtime rather than acting like one global score
+- startup remains explicit and reviewable rather than hiding behind ambient background state
+- the skill uses one bounded lifecycle entrypoint and one visible stop path
+- rendered truth, readiness, confirmation, and lifecycle remain distinct steps even when one script wraps parts of them together
+- the workflow stays local-stack oriented and does not widen into generic bootstrap, deployment, or monitoring doctrine
+
+## Risks and anti-patterns
+- treating rendered truth as proof that the host is ready or that startup will succeed
+- treating a passing doctor result as proof of post-start health
+- skipping the pre-start review seam because the launch command feels convenient
+- leaking full rendered config or other sensitive local runtime material
+- hiding startup in background helpers that obscure what started or how to stop it
+- widening the bundle into generic install, bootstrap, or platform-management doctrine
+
+## Verification
+- confirm the rendered output answered what would actually start before launch
+- confirm the readiness verdict was selector-aware and itemized with visible severity
+- confirm blockers stopped the launch path or were explicitly deferred with explanation
+- confirm explicit operator intent or confirmation existed before the mutating launch step
+- confirm startup status named what started and how to stop it
+- confirm unresolved warnings, sensitive rendered material handling, and cleanup notes were reported clearly
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0036 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/runtime-truth-lifecycle/render-truth-before-startup/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0037 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/runtime-truth-lifecycle/contextual-host-doctor/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0028 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/confirmation-gated-mutating-action/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0038 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/runtime-truth-lifecycle/one-command-service-lifecycle/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays should add:
+- local render commands and safe storage rules for rendered config
+- local runtime selectors, profiles, or presets
+- local readiness checks and strictness policy
+- local lifecycle entrypoints, stop commands, and cleanup expectations

--- a/.agents/skills/aoa-local-stack-bringup/agents/openai.yaml
+++ b/.agents/skills/aoa-local-stack-bringup/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Local Stack Bringup
+  short_description: Bring up local stacks safely
+  default_prompt: Use $aoa-local-stack-bringup to review what would start, run readiness checks for the selected runtime, and launch the local stack through one explicit entrypoint.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#B45309'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-local-stack-bringup/assets/large-logo.svg
+++ b/.agents/skills/aoa-local-stack-bringup/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-local-stack-bringup/assets/local_stack_bringup.template.json
+++ b/.agents/skills/aoa-local-stack-bringup/assets/local_stack_bringup.template.json
@@ -1,0 +1,27 @@
+{
+  "runtime_name": "compose",
+  "selector": "dev",
+  "rendered_services": [
+    "api",
+    "worker",
+    "postgres",
+    "redis"
+  ],
+  "readiness_items": [
+    {
+      "severity": "ok",
+      "label": "docker daemon reachable"
+    },
+    {
+      "severity": "ok",
+      "label": "dev profile render completed"
+    },
+    {
+      "severity": "warn",
+      "label": "postgres volume will be reused"
+    }
+  ],
+  "launch_command": "docker compose --profile dev up -d",
+  "stop_command": "docker compose --profile dev down",
+  "confirmation_required": true
+}

--- a/.agents/skills/aoa-local-stack-bringup/assets/local_stack_report.schema.json
+++ b/.agents/skills/aoa-local-stack-bringup/assets/local_stack_report.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LocalStackBringupReport",
+  "type": "object",
+  "required": [
+    "skill",
+    "runtime_name",
+    "selector",
+    "rendered_services",
+    "readiness_items",
+    "blocker_count",
+    "warning_count",
+    "launch_command",
+    "stop_command",
+    "verdict",
+    "next_step",
+    "warnings",
+    "errors"
+  ],
+  "properties": {
+    "skill": {
+      "const": "aoa-local-stack-bringup"
+    },
+    "runtime_name": {
+      "type": "string"
+    },
+    "selector": {
+      "type": "string"
+    },
+    "rendered_services": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "readiness_items": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "blocker_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "warning_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "launch_command": {
+      "type": "string"
+    },
+    "stop_command": {
+      "type": "string"
+    },
+    "verdict": {
+      "type": "string"
+    },
+    "next_step": {
+      "type": "string"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/.agents/skills/aoa-local-stack-bringup/assets/small-logo.svg
+++ b/.agents/skills/aoa-local-stack-bringup/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-local-stack-bringup/references/bounded_lifecycle_visibility.md
+++ b/.agents/skills/aoa-local-stack-bringup/references/bounded_lifecycle_visibility.md
@@ -1,0 +1,16 @@
+# Bounded lifecycle visibility
+
+Local bring-up stays legible when the launch and stop surfaces are obvious.
+
+## Keep visible
+
+- one explicit launch command
+- one explicit stop command
+- unresolved warnings
+- any cleanup-sensitive surfaces such as volumes or caches
+
+## Anti-patterns
+
+- hiding start in background helpers with no visible stop path
+- launching multiple selectors without naming the chosen one
+- treating a doctor pass as proof of post-start health

--- a/.agents/skills/aoa-local-stack-bringup/references/render_truth_before_start.md
+++ b/.agents/skills/aoa-local-stack-bringup/references/render_truth_before_start.md
@@ -1,0 +1,15 @@
+# Render truth before start
+
+Before launch, answer one question clearly:
+
+What would actually start for the selected runtime and selector?
+
+## Minimum visible facts
+
+- runtime name
+- selector or profile
+- rendered service set
+- lifecycle entrypoint
+- stop path
+
+Do not treat rendered truth as proof that the host is ready.

--- a/.agents/skills/aoa-local-stack-bringup/scripts/bringup_contract.py
+++ b/.agents/skills/aoa-local-stack-bringup/scripts/bringup_contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+TEMPLATE = {
+    "runtime_name": "compose",
+    "selector": "dev",
+    "rendered_services": ["api", "worker", "postgres", "redis"],
+    "readiness_items": [
+        {"severity": "ok", "label": "docker daemon reachable"},
+        {"severity": "ok", "label": "dev profile render completed"},
+        {"severity": "warn", "label": "postgres volume will be reused"},
+    ],
+    "launch_command": "docker compose --profile dev up -d",
+    "stop_command": "docker compose --profile dev down",
+    "confirmation_required": True,
+}
+
+
+def _load_payload(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON input on stdin or via a file path.")
+    return json.loads(raw)
+
+
+def build_report(payload: dict[str, Any]) -> dict[str, Any]:
+    services = [str(x) for x in payload.get("rendered_services") or []]
+    readiness_items = payload.get("readiness_items") or []
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    if not payload.get("runtime_name"):
+        errors.append("runtime_name is missing.")
+    if not payload.get("selector"):
+        warnings.append("selector is missing; selected runtime truth may be ambiguous.")
+    if not services:
+        errors.append("rendered_services is empty.")
+    if not payload.get("launch_command"):
+        errors.append("launch_command is missing.")
+    if not payload.get("stop_command"):
+        warnings.append("stop_command is missing.")
+
+    fail_items: list[Mapping[str, Any]] = []
+    warn_items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(readiness_items, start=1):
+        if not isinstance(item, Mapping):
+            errors.append(f"readiness_items[{index}] must be an object.")
+            continue
+        severity = str(item.get("severity", "")).lower()
+        if severity == "fail":
+            fail_items.append(item)
+        elif severity == "warn":
+            warn_items.append(item)
+        elif severity in {"", "ok"}:
+            continue
+        else:
+            fail_items.append(item)
+            warnings.append(
+                f"Unknown readiness severity {severity!r} at item {index}; treated as a blocker."
+            )
+
+    if fail_items:
+        verdict = "hold"
+        next_step = "fix-blockers-before-launch"
+    elif payload.get("confirmation_required", True):
+        verdict = "ready_for_confirmation"
+        next_step = "ask-for-launch-confirmation"
+    else:
+        verdict = "go"
+        next_step = "launch"
+
+    if warn_items:
+        warnings.append(f"{len(warn_items)} readiness warning(s) remain visible.")
+
+    return {
+        "skill": "aoa-local-stack-bringup",
+        "runtime_name": payload.get("runtime_name", ""),
+        "selector": payload.get("selector", ""),
+        "rendered_services": services,
+        "readiness_items": readiness_items,
+        "blocker_count": len(fail_items),
+        "warning_count": len(warn_items),
+        "launch_command": payload.get("launch_command", ""),
+        "stop_command": payload.get("stop_command", ""),
+        "verdict": verdict if not errors else "hold",
+        "next_step": next_step if not errors else "repair-contract-before-launch",
+        "warnings": warnings,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a deterministic local-stack bringup contract.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--template", action="store_true", help="Print a starter JSON payload and exit.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON.")
+    args = parser.parse_args()
+
+    if args.template:
+        print(json.dumps(TEMPLATE, indent=2))
+        return 0
+
+    result = build_report(_load_payload(args.input_json))
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0 if not result["errors"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-local-stack-bringup/scripts/readiness_summary.py
+++ b/.agents/skills/aoa-local-stack-bringup/scripts/readiness_summary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_payload(path: str | None) -> Any:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON or text input on stdin or via a file path.")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.splitlines()
+
+
+def _normalize_line(line: str) -> dict[str, str]:
+    stripped = line.strip()
+    lower = stripped.lower()
+    if lower.startswith("ok:"):
+        return {"severity": "ok", "label": stripped[3:].strip()}
+    if lower.startswith("warn:"):
+        return {"severity": "warn", "label": stripped[5:].strip()}
+    if lower.startswith("fail:"):
+        return {"severity": "fail", "label": stripped[5:].strip()}
+    return {"severity": "warn", "label": stripped}
+
+
+def summarize(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, dict) and "readiness_items" in payload:
+        items = payload.get("readiness_items") or []
+    elif isinstance(payload, list):
+        if payload and isinstance(payload[0], dict):
+            items = payload
+        else:
+            items = [_normalize_line(str(line)) for line in payload if str(line).strip()]
+    else:
+        items = [_normalize_line(str(payload))]
+
+    normalized = []
+    counts = {"ok": 0, "warn": 0, "fail": 0}
+    for item in items:
+        severity = str(item.get("severity", "warn")).lower()
+        if severity not in counts:
+            severity = "warn"
+        counts[severity] += 1
+        normalized.append({"severity": severity, "label": str(item.get("label", "")).strip()})
+
+    overall = "fail" if counts["fail"] else ("warn" if counts["warn"] else "ok")
+    return {
+        "skill": "aoa-local-stack-bringup",
+        "overall": overall,
+        "counts": counts,
+        "items": normalized,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize selector-aware readiness items.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON.")
+    args = parser.parse_args()
+
+    result = summarize(_load_payload(args.input_json))
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0 if result["overall"] != "fail" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-port-adapter-refactor
+++ b/.agents/skills/aoa-port-adapter-refactor
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-port-adapter-refactor

--- a/.agents/skills/aoa-port-adapter-refactor/SKILL.md
+++ b/.agents/skills/aoa-port-adapter-refactor/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: aoa-port-adapter-refactor
+description: Refactor code toward clearer ports and adapters so domain or application logic is less entangled with infrastructure details. Use when concrete dependencies leak into core logic, tests are hard because external concerns bleed inward, or a module needs a clearer seam before further change. Do not use for tiny local fixes or when there is no meaningful boundary to clarify.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-port-adapter-refactor/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0016,AOA-T-0015
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-port-adapter-refactor
+
+## Intent
+Use this skill to separate reusable domain, application, builder, or workflow logic from concrete dependencies and runtime details by introducing or clarifying ports and adapters.
+
+## Trigger boundary
+Use this skill when:
+- business or domain logic is tightly coupled to a concrete dependency
+- tests are hard to write because external concerns leak into the core logic
+- the same dependency pattern is beginning to repeat across modules
+- a module needs a clearer seam before further change
+- a builder, CLI, SDK facade, generated/export writer, storage layer, filesystem path, environment lookup, clock, network client, subprocess, or provider API leaks into reusable logic
+- the boundary is already named, and the next honest move is a narrow dependency seam rather than another context map
+
+Do not use this skill when:
+- the task is a tiny local fix with no architectural pressure
+- there is no meaningful boundary to clarify yet
+- the code would become more ceremonial than useful after extraction
+- the main problem is deciding whether logic belongs in the core or at the edge; use `aoa-core-logic-boundary` first
+- the main problem is clarifying repository docs or source-of-truth ownership; use `aoa-source-of-truth-check` first
+- the main problem is validating a stable consumer-visible interface after the seam is clear; use `aoa-contract-test`
+- the dependency is only incidental setup or test fixture detail, not a real source of coupling
+
+## Inputs
+- target module, builder, tool, workflow, or slice
+- concrete dependency or runtime concern that currently leaks into reusable logic
+- desired scope of refactor
+- validation expectations
+- behavior the reusable center actually needs from the dependency
+- callers, consumers, or generated/export surfaces affected by the seam
+
+## Outputs
+- clearer boundary between logic and infrastructure
+- proposed or implemented port shape
+- proposed or implemented adapter shape
+- notes on what remains inside the reusable center and what the adapter owns
+- verification summary
+
+## Procedure
+1. identify the concrete dependency that is making change or testing harder
+2. confirm the broader context and core-versus-edge boundary are already clear enough to make a seam; otherwise route to `aoa-bounded-context-map` or `aoa-core-logic-boundary`
+3. when the dependency is not a simple service client, choose the smallest useful shape from `references/adapter-seam-shapes.md`
+4. isolate the reusable logic from the infrastructure-specific behavior
+5. define a narrow port around what the reusable center actually needs
+6. move infrastructure-specific behavior behind an adapter or equivalent seam
+7. keep the refactor bounded and avoid unrelated cleanup
+8. verify that the new boundary improves clarity and does not silently change behavior
+
+## Contracts
+- the extracted boundary should reduce coupling, not add decorative abstraction
+- the port should stay narrow and purpose-shaped
+- the port should describe the reusable center's need, not mirror the provider API
+- adapters should own translation, retries, transport, local paths, credentials, process calls, or runtime discovery when those details are the dependency pressure
+- the refactor should not widen into a hidden rewrite
+- the final result should remain understandable to another human or agent
+- generated, exported, or runtime-facing consumers should keep their explicit contract checks separate from the adapter refactor
+
+## Risks and anti-patterns
+- introducing empty abstractions with no real boundary value
+- extracting a port that mirrors an overgrown concrete dependency instead of narrowing it
+- using the refactor as a pretext for unrelated architectural churn
+- making tests more indirect without improving clarity
+- wrapping every helper in an interface because ports are fashionable
+- hiding source-of-truth or core-logic ambiguity under a new adapter name
+- treating adapter introduction as proof that downstream contracts are validated
+
+## Verification
+- confirm the concrete dependency pressure was real
+- confirm the new boundary is narrower and clearer than before
+- confirm behavior did not drift silently
+- confirm the refactor stayed inside the declared scope
+- confirm the adapter owns the concrete dependency details and the reusable center depends only on the narrow port
+- confirm any generated/export or consumer-visible behavior still has its own contract validation when needed
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0016 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/bounded-context-map/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Contracts, Validation
+- AOA-T-0015 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/contract-test-design/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local architecture conventions
+- preferred adapter locations
+- local test commands
+- local adapter seam examples from `references/adapter-seam-shapes.md`
+- repository-specific review rules

--- a/.agents/skills/aoa-port-adapter-refactor/agents/openai.yaml
+++ b/.agents/skills/aoa-port-adapter-refactor/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Port Adapter Refactor
+  short_description: Refactor toward ports/adapters
+  default_prompt: Use $aoa-port-adapter-refactor to isolate a concrete dependency behind a narrow port and adapter without turning the change into a hidden rewrite.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-port-adapter-refactor/assets/large-logo.svg
+++ b/.agents/skills/aoa-port-adapter-refactor/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-port-adapter-refactor/assets/small-logo.svg
+++ b/.agents/skills/aoa-port-adapter-refactor/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-port-adapter-refactor/references/adapter-seam-shapes.md
+++ b/.agents/skills/aoa-port-adapter-refactor/references/adapter-seam-shapes.md
@@ -1,0 +1,51 @@
+# Adapter Seam Shapes
+
+Use this reference when the dependency seam is wider than a simple service
+client. It is not a checklist. Pick the smallest shape that names one concrete
+dependency, one narrow port, one adapter responsibility, and one behavior check.
+
+## How To Use
+
+1. Name the reusable logic that should stop knowing concrete dependency detail.
+2. Name the concrete dependency pressure.
+3. Choose the narrowest seam shape below.
+4. Define the port by what the reusable center needs, not by the provider API.
+5. Move translation and environment detail behind the adapter, then verify no
+   behavior drift.
+
+## Shape Set
+
+| Shape | Dependency Pressure | Port Should Expose | Adapter Owns | Avoid | Verify |
+|---|---|---|---|---|---|
+| External service or API client | Vendor client, HTTP library, auth flow, retry policy, remote error shape. | The one operation or query the reusable logic needs. | Transport, credentials, retries, provider errors, response mapping. | Mirroring the whole vendor SDK as the port. | Fake adapter or contract smoke around success, failure, and timeout shape. |
+| Storage or database | SQL driver, ORM, collection API, transaction detail, migration state. | Purpose-shaped read/write operations or repository queries. | Connection, transaction, serialization, storage-specific errors. | Hiding query logic so far away that rules become unreviewable. | Core tests with fake store plus one storage adapter integration check. |
+| Filesystem, path, or environment | Local paths, workspace layout, env vars, profile discovery, permissions. | Logical read/write/discovery needs. | Path resolution, env lookup, permission errors, platform differences. | Treating local workspace shape as domain truth. | Temp-directory tests and missing-path/error cases. |
+| Clock, randomness, or ID source | Current time, timers, UUIDs, random selection, generated IDs. | Time, ID, or entropy in the smallest useful form. | Real clock, random source, monotonic behavior, deterministic test substitutes. | Letting nondeterminism leak into core tests. | Deterministic fake plus edge checks for ordering, uniqueness, or expiry. |
+| CLI, subprocess, or tool runner | Shell command, executable availability, exit codes, stdout/stderr format. | Command outcome shape the core actually uses. | Invocation, arguments, cwd, environment, timeouts, output parsing. | Freezing incidental human log text as the port. | Fake runner, malformed output case, and one real smoke when available. |
+| Generated/export writer | Install path, compact artifact format, export profile, copy/write mechanics. | Source-to-output intent and target artifact identity. | Formatting, filesystem writes, profile paths, install layout, freshness markers. | Generated output becoming source authority. | Rebuild check, source-ref preservation, stale-output failure, and no-drift check. |
+| Runtime discovery or configuration | Runtime inventory, local config, feature flags, service discovery, plugin lookup. | The stable capability or setting the reusable logic needs. | Discovery mechanics, defaults, missing capability behavior, config parsing. | Runtime presence becoming hidden compile-time truth. | Missing-capability case, default behavior, and compatibility smoke. |
+| SDK or typed facade | SDK loader, typed model, compatibility layer, versioned API. | Stable typed operation or compatibility result. | Version handling, adapter translation, deprecation behavior, error mapping. | Letting SDK convenience own source meaning. | Fixture for old/new version, invalid input, and compatibility result. |
+| Queue, event, or scheduler | Event bus, queue client, cron, background worker, callback runner. | Enqueue, schedule, publish, or consume intent. | Delivery mechanics, retries, ordering guarantees, dead-letter behavior. | Pretending asynchronous delivery is immediate core behavior. | Fake queue plus adapter smoke for ordering and failure semantics. |
+
+## Compact Seam Pass
+
+| Field | Answer |
+|---|---|
+| Reusable center |  |
+| Concrete dependency |  |
+| Shape selected |  |
+| Port operation |  |
+| Adapter owns |  |
+| Out of scope |  |
+| Behavior check |  |
+| Contract check needed separately |  |
+
+## Verification
+
+- the port is narrower than the concrete dependency API
+- the reusable center can be tested without the concrete dependency
+- adapter behavior is covered at least by a focused smoke or integration check
+- source-owned meaning stays outside generated, runtime, or provider-specific
+  convenience
+- contract validation is kept separate when external consumers rely on a stable
+  shape

--- a/.agents/skills/aoa-property-invariants
+++ b/.agents/skills/aoa-property-invariants
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-property-invariants

--- a/.agents/skills/aoa-property-invariants/SKILL.md
+++ b/.agents/skills/aoa-property-invariants/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: aoa-property-invariants
+description: Express stable system or domain truths as invariant-oriented tests or checks rather than only fixed examples. Use when correctness depends on behavior that should hold across many inputs or states, such as monotonicity, idempotency, conservation, or structural rules. Do not use when no meaningful invariant is known yet or when the real task is auditing existing coverage instead of writing the properties.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-property-invariants/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0017,AOA-T-0007
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-property-invariants
+
+## Intent
+Use invariant-oriented thinking to test broad behavior and stable artifact relationships through properties rather than only through a short list of fixed examples.
+
+## Trigger boundary
+Use this skill when:
+- a rule should hold across many inputs or states
+- examples alone feel too narrow
+- the system has conservation, monotonicity, idempotency, or structural invariants
+- safety or correctness depends on broad input coverage
+- a stable relationship should hold across artifacts, transformations, generated/export outputs, workflow phases, route choices, or provenance chains
+- correctness depends on repeatability, round-trip behavior, source-ref preservation, lifecycle ordering, uniqueness, freshness bounds, or authorization limits
+
+Do not use this skill when:
+- the behavior is mostly about presentation details or narrow snapshots
+- the main problem is checking whether existing checks really cover the invariant; use `aoa-invariant-coverage-audit` first
+- the main problem is a boundary contract rather than a stable invariant; use `aoa-contract-test`
+- no meaningful invariant is yet understood
+- the proposed property would only restate one example with random inputs around it
+- the input generator or artifact family cannot be bounded enough for review
+
+## Inputs
+- target rule or domain truth
+- current examples or tests
+- input space or generators
+- known edge cases
+- artifact families, transformations, lifecycle states, or generated/export surfaces when the invariant is not simple data behavior
+- invalid cases, exclusion rules, and claim limits for the property
+
+## Outputs
+- explicit invariants
+- property-oriented tests or checks
+- notes on generator assumptions
+- verification summary
+- notes on what the property proves and what remains outside its claim
+
+## Procedure
+1. identify what must remain true across many cases
+2. separate strong invariants from weak hopes or vague expectations
+3. when the invariant is not a simple input/output behavior rule, choose the smallest useful shape from `references/invariant-shapes.md`
+4. define the valid input space, artifact family, lifecycle range, or transformation surface, including exclusions
+5. express those invariants as property-oriented tests or repeated checks
+6. keep the generators or inputs bounded and reviewable
+7. keep a few concrete examples when they explain failures better than generated data alone
+8. run the checks and report what properties now constrain behavior and what they do not prove
+
+## Contracts
+- each property should express a real invariant, not a wish
+- the test should broaden coverage beyond a small handpicked set
+- generator assumptions should remain understandable
+- failures should point back to the protected rule rather than only to generated data
+- generated/export, workflow, provenance, lifecycle, and structural invariants should stay tied to the source truth they protect
+- a property should name its claim limit so broad input coverage does not pretend to prove total quality
+
+## Risks and anti-patterns
+- writing weak properties that prove almost nothing
+- confusing random data with meaningful coverage
+- letting overly broad generators or harness complexity hide the protected domain truth
+- using polished invariant language while the actual stable truth remains underspecified
+- using property checks where a small set of concrete examples would be clearer
+- using invariant language to avoid naming the actual rule or boundary that matters
+- turning every stable example into a property when the variation space is not meaningful
+- treating generated data volume as evidence when the generator misses the important states
+- letting project-specific artifact names dominate the portable invariant shape
+
+## Verification
+- confirm the property expresses a meaningful invariant
+- confirm the invariant broadens coverage beyond fixed examples
+- confirm the report names which stable truth was violated or protected, not only that generated inputs failed
+- confirm the result is understandable to another human or agent
+- confirm the input generator or artifact set is bounded and reviewable
+- confirm the claim limit is visible when the property does not cover all states, artifacts, or consumers
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0017 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/skill-support/property-invariants/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0007 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/proof/evaluation-chain/signal-first-gate-promotion/TECHNIQUE.md` and sections: summary, Validation
+
+## Adaptation points
+Project overlays should add:
+- local generator tools
+- domain-specific invariants
+- local artifact, generated/export, lifecycle, workflow, or provenance invariant examples from `references/invariant-shapes.md`
+- rules for when property-based checks are mandatory, optional, or out of scope

--- a/.agents/skills/aoa-property-invariants/agents/openai.yaml
+++ b/.agents/skills/aoa-property-invariants/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Property Invariants
+  short_description: Write property-based invariants
+  default_prompt: Use $aoa-property-invariants to identify the stable truth that must hold across many cases and express it as bounded property-oriented checks.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-property-invariants/assets/large-logo.svg
+++ b/.agents/skills/aoa-property-invariants/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-property-invariants/assets/small-logo.svg
+++ b/.agents/skills/aoa-property-invariants/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-property-invariants/references/invariant-shapes.md
+++ b/.agents/skills/aoa-property-invariants/references/invariant-shapes.md
@@ -1,0 +1,50 @@
+# Invariant Shapes
+
+Use this reference when the invariant is wider than one ordinary data rule. It
+is not a checklist. Pick the smallest shape that names one stable truth, one
+variation space, one property check, and one claim limit.
+
+## How To Use
+
+1. Name the stable truth in plain language.
+2. Name the input space, artifact family, state transition, or transformation.
+3. Choose the narrowest invariant shape below.
+4. State valid inputs and exclusions before writing the property.
+5. Keep a few concrete examples when they make failures easier to understand.
+
+## Shape Set
+
+| Shape | Protected Truth | Variation Space | Property | Avoid | Useful Check |
+|---|---|---|---|---|---|
+| Conservation or accounting | Totals, balances, references, or counts remain conserved. | Operation sequences, grouped artifacts, filtered subsets. | Sum, count, or reference relation stays equal under valid operations. | Counting examples while missing state sequences. | Stateful property plus boundary examples. |
+| Monotonicity or ordering | Progress, version, priority, timestamp, or maturity only moves in allowed directions. | Status transitions, append-only logs, sorted lists, version bumps. | Movement never reverses or violates ordering rules. | Assuming all newer data is better or authoritative. | Random transition sequence with invalid-reversal cases. |
+| Idempotency or repeatability | Repeating a safe operation does not change meaning after the first run. | Rebuilds, imports, normalization, refreshes, retries. | Same source and options produce equivalent result. | Ignoring timestamps, nondeterministic IDs, or environment effects. | Repeated-run property with stable fields and explicit exclusions. |
+| Round trip or normalization | Parse, serialize, import, export, or normalize preserves intended meaning. | Encodings, field order, optional values, aliases. | `decode(encode(x))` or normalized variants preserve semantic fields. | Treating formatting bytes as meaning unless required. | Round-trip fixtures plus generated cases for optional fields. |
+| Structural or schema relationship | Required relationships between fields or nodes stay valid. | Manifests, trees, graphs, references, nested objects. | IDs are unique, refs resolve, parent/child or source/output links hold. | Schema validity without relationship checks. | Generated graph/manifest variants with invalid-ref negative cases. |
+| Lifecycle or state machine | Objects move only through allowed states. | Candidate/evaluated/canonical, pending/active/closed, draft/released/deprecated. | Every transition is allowed and required evidence appears at gates. | Treating roadmap or provenance as current state. | Transition generator plus forbidden-transition examples. |
+| Source to generated/export | Derived surfaces preserve source identity and stay subordinate. | Builders, compact indexes, installed copies, exports, reports. | Eligible sources appear once, refs are preserved, excluded sources stay out. | Generated freshness as proof of source meaning. | Rebuild/idempotency property plus source-ref and exclusion checks. |
+| Routing or selection | Selection stays stable under irrelevant variation and changes under relevant signals. | Dispatch hints, filters, priority rules, compatibility choices. | Equivalent inputs route the same; changed decisive signal changes result. | Encoding today's incidental ordering as law. | Permutation/irrelevant-field property plus tie-break examples. |
+| Authorization or risk boundary | Unsafe actions require explicit authority or safer fallback. | Mutation surfaces, share targets, infra actions, risk tiers. | Risky route cannot proceed without required approval or gate output. | Using property language to bypass human approval. | Generated risk cases with required denial and allow cases. |
+| Provenance or memory/recall | Retrieved, stored, or derived evidence keeps source and freshness limits clear. | Recall objects, writebacks, capsules, summaries, retention windows. | Source refs, timestamps, retention bounds, and claim limits survive transformations. | Treating recall output as live proof. | Transformation property plus stale/missing-source negative case. |
+
+## Compact Invariant Pass
+
+| Field | Answer |
+|---|---|
+| Stable truth |  |
+| Shape selected |  |
+| Variation space |  |
+| Valid inputs |  |
+| Exclusions |  |
+| Property statement |  |
+| Generator or repeated-check plan |  |
+| Concrete examples kept |  |
+| Claim limit |  |
+
+## Verification
+
+- the property protects a named stable truth
+- generated or repeated cases vary the meaningful dimension
+- exclusions are explicit enough for review
+- failure output points back to the invariant, not only generated data
+- broad coverage does not claim total quality beyond the named property

--- a/.agents/skills/aoa-quest-harvest
+++ b/.agents/skills/aoa-quest-harvest
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-quest-harvest

--- a/.agents/skills/aoa-quest-harvest/SKILL.md
+++ b/.agents/skills/aoa-quest-harvest/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: aoa-quest-harvest
+description: Give the final promotion verdict on one repeated reviewed quest-shaped unit without collapsing skills, playbooks, orchestrator classes, proof, or memory into one layer. Use when a bounded quest-shaped work pattern has repeated, reviewed evidence exists, and you need the final honest verdict on whether it should stay a quest or move into the next owner surface. Do not use when the route is still active, only one anecdotal occurrence exists, the task is to invent net-new doctrine, or a broader reviewed session artifact still needs donor harvest, route forks, diagnosis, repair, or progression reflection first.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-quest-harvest/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0089,AOA-T-0090
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-quest-harvest
+
+## Intent
+Use this skill to decide whether a repeated, reviewed quest-shaped pattern should remain a quest or be promoted into the next honest owner surface.
+
+## Trigger boundary
+Use this skill when:
+- a bounded work pattern has repeated and now needs an explicit promotion decision
+- reviewed evidence exists, but the correct destination is still unclear
+- the decision must distinguish between skill, playbook, orchestrator surface, proof surface, memo surface, or staying a quest
+- the route needs a compact final promotion triage rather than another free-form discussion
+
+Do not use this skill when:
+- the route is still active and the evidence has not been reviewed yet
+- there is only one anecdotal occurrence with no honest repeat signal
+- the task is to invent net-new doctrine rather than classify a repeated pattern
+- the route is already clearly scenario-shaped and only needs playbook authoring
+- the source is a reviewed session artifact with multiple candidate donor units that still need owner-layer routing first; use `aoa-session-donor-harvest`
+- the source still needs explicit automation-readiness classification for a
+  repeated manual route; use `aoa-automation-opportunity-scan`
+- the source still needs explicit route forks, diagnosis, repair, or progression reflection from the wider session-harvest family before final promotion triage
+
+## Inputs
+- source quest or quest family
+- reviewed run summary or harvest pack
+- repeat count and repeat shape
+- owner layer and touched surfaces
+- difficulty, risk, and control posture
+- residual ambiguity or reasons to defer promotion
+
+## Outputs
+- promotion verdict
+- owner repo and follow-up surface
+- explicit reason for promotion or non-promotion
+- named next artifact or next quest action
+- concise note on what boundary must remain intact
+- one `QUEST_PROMOTION_RECEIPT` using `references/stats-event-envelope.md`
+  and `references/quest-promotion-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. collect a bounded reviewed harvest pack rather than raw runtime state
+2. name what actually repeated: leaf workflow, route, proof pattern, recall pattern, or boundary law
+3. reject theme-only repetition; only repeatable work or repeatable law counts
+4. if the repeated unit is a bounded leaf workflow, consider promotion to a skill
+5. if the repeated unit is a multi-step scenario route, consider promotion to a playbook
+6. if the repeated unit is orchestrator boundary law, read order, or allowed outputs, promote toward orchestrator class surfaces in `aoa-agents`
+7. if the repeated unit is proof posture, promote toward `aoa-evals`
+8. if the repeated unit is recall, writeback, or recurrence posture, promote toward `aoa-memo`
+9. if repetition is still weak, owner is unclear, or boundary risk is high, keep or open a quest instead of forcing promotion
+10. record the verdict with one clear reason for promotion and one clear reason against the nearest wrong target
+11. emit one `QUEST_PROMOTION_RECEIPT` when the triage closes, keeping the
+    receipt smaller than the promotion packet itself
+12. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+    that points back to the bounded promotion receipt and records one finished
+    kernel-skill application
+
+## Contracts
+- invocation must remain explicit and post-session
+- orchestrator class identity must not be promoted into a skill
+- a skill promotion must stay leaf-workflow-shaped
+- a playbook promotion must stay route-shaped
+- proof and memory promotions must stay in their owner layers
+- one good run is not enough to justify promotion by itself
+- active quest state must not be copied into memo canon as if it were settled truth
+- `QUEST_PROMOTION_RECEIPT` is verdict telemetry, not promotion authority
+- `CORE_SKILL_APPLICATION_RECEIPT` is generic kernel telemetry, not promotion
+  authority and not a replacement for the verdict receipt
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- promoting a theme instead of a repeatable workflow
+- collapsing orchestrator class law into the skill layer
+- collapsing recurring route method into a single skill
+- treating proof debt as skill meaning
+- treating memo writeback as active quest ownership
+- forcing promotion just because the repeated work feels important
+
+## Verification
+- confirm the harvest pack is reviewed and bounded
+- confirm the repeated unit is named explicitly
+- confirm the chosen promotion target matches the owner layer
+- confirm the nearest wrong target is explicitly rejected
+- confirm class identity is not being defined by quest metadata
+- confirm the result is one of the allowed outcomes: keep or open quest, skill, playbook, orchestrator surface, proof surface, or memo surface
+- confirm any emitted receipt stays evidence-linked and subordinate to the closed triage
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the
+  promotion detail receipt and stays finish-only
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0089 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/promotion-boundary/quest-unit-promotion-review/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Validation
+- AOA-T-0090 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/promotion-boundary/nearest-wrong-target-rejection/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Risks, Validation
+
+## Adaptation points
+Project overlays may add:
+- local quest IDs and harvest entrypoints
+- local owner-repo route maps
+- local review packet or acceptance surfaces
+- local memo and eval references
+- local stop conditions for when promotion must remain deferred

--- a/.agents/skills/aoa-quest-harvest/agents/openai.yaml
+++ b/.agents/skills/aoa-quest-harvest/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Quest Harvest
+  short_description: Triage quest promotion honestly
+  default_prompt: Use $aoa-quest-harvest to decide whether repeated reviewed quest evidence should stay a quest or be promoted into the next honest owner surface.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-quest-harvest/assets/large-logo.svg
+++ b/.agents/skills/aoa-quest-harvest/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-quest-harvest/assets/small-logo.svg
+++ b/.agents/skills/aoa-quest-harvest/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-quest-harvest/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-quest-harvest/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-quest-harvest
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-quest-harvest`
+  - `detail_event_kind` must equal `quest_promotion_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-quest-harvest/references/promotion-outcomes.md
+++ b/.agents/skills/aoa-quest-harvest/references/promotion-outcomes.md
@@ -1,0 +1,31 @@
+# Promotion outcomes
+
+This reference names the allowed outcomes for `aoa-quest-harvest`.
+
+## Allowed outcomes
+
+1. `keep_or_open_quest`
+   Use when repetition is still weak, ownership is unclear, or the evidence is not yet honest enough for promotion.
+
+2. `promote_to_skill`
+   Use when the repeated unit is a bounded leaf workflow with a stable trigger boundary, explicit inputs and outputs, and a reviewable verification path.
+
+3. `promote_to_playbook`
+   Use when the repeated unit is a multi-step route with handoffs, artifacts, and stop or re-entry logic.
+
+4. `promote_to_orchestrator_surface`
+   Use when the repeated unit is class law such as read order, boundary note, allowed surfaces, forbidden surfaces, or expected outputs.
+
+5. `promote_to_proof_surface`
+   Use when the repeated unit is specifically a proof pattern, verdict posture, rubric law, or another bounded evaluation surface owned by `aoa-evals`.
+
+6. `promote_to_memo_surface`
+   Use when the repeated unit is specifically a recurrence, recall, or writeback pattern owned by `aoa-memo`.
+
+## Guardrail
+
+Do not promote an orchestrator class into a skill just because an orchestrator repeatedly performs some work.
+
+Promote only the repeatable leaf workflow, not the class itself.
+
+Do not collapse proof and memo promotions into one shared outcome. They route to different owner layers for different reasons.

--- a/.agents/skills/aoa-quest-harvest/references/quest-promotion-receipt-schema.yaml
+++ b/.agents/skills/aoa-quest-harvest/references/quest-promotion-receipt-schema.yaml
@@ -1,0 +1,16 @@
+receipt_name: QUEST_PROMOTION_RECEIPT
+event_kind: quest_promotion_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - promotion_verdict
+  - owner_repo
+  - next_surface
+  - nearest_wrong_target
+optional_payload_fields:
+  - defer_reason
+  - repeat_shape
+  - bounded_unit_ref
+rules:
+  - keep the receipt verdict-shaped rather than canon-shaped
+  - rejected nearest-wrong target must remain visible when promotion pressure exists
+  - the receipt summarizes the closed triage rather than replacing the quest promotion packet

--- a/.agents/skills/aoa-quest-harvest/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-quest-harvest/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or verdict object.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-safe-infra-change
+++ b/.agents/skills/aoa-safe-infra-change
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-safe-infra-change

--- a/.agents/skills/aoa-safe-infra-change/SKILL.md
+++ b/.agents/skills/aoa-safe-infra-change/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: aoa-safe-infra-change
+description: Make bounded infrastructure, configuration, service, or operational changes with explicit risk framing, proportional verification, and rollback thinking. Use when a change has runtime or deployment implications and needs stronger discipline than a normal code edit. Do not use for purely local code changes, or when the main need is approval classification or preview-first execution.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: risk
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/risk/aoa-safe-infra-change/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0028,AOA-T-0001
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-safe-infra-change
+
+## Intent
+Use this skill to shape infrastructure, service, configuration, or operational changes into a safer bounded workflow.
+
+## Trigger boundary
+Use this skill when:
+- the task changes infrastructure, services, configuration, orchestration, or operational surfaces
+- the change has runtime, safety, or deployment implications
+- the task needs stronger verification and rollback thinking than a normal code edit
+
+Do not use this skill when:
+- the task is a purely local code change with no operational implications
+- a more specific risk skill should be used instead
+- the operator has not provided enough authority for the requested action
+- the main question is whether authority exists at all; use `aoa-approval-gate-check`
+- the main need is to prefer or interpret a preview path before execution; use `aoa-dry-run-first`
+
+## Inputs
+- target change
+- touched operational surfaces
+- stated authority or approval state
+- validation path
+- rollback idea
+
+## Outputs
+- explicit risk-aware plan
+- bounded infrastructure or config change, or bounded execution recommendation
+- verification result
+- report with remaining risk notes
+
+## Procedure
+1. identify the operational surface and main risk
+2. confirm whether the change belongs to a high-risk or explicit-only category
+3. keep the change small and reviewable
+4. avoid unrelated cleanup or hidden expansion of scope
+5. verify the result using the strongest practical bounded checks available
+6. report what changed, what was verified, and what remains risky or deferred
+
+## Contracts
+- infrastructure changes should stay explicit and reviewable
+- risk should be named before apply, not after failure
+- verification should be stronger than symbolic confidence
+- rollback thinking should exist before execution
+
+## Risks and anti-patterns
+- treating infra edits like ordinary code edits
+- making broad config or orchestration changes under a narrow task label
+- relying on weak verification for changes with real runtime impact
+- skipping explicit risk framing because the diff looks small
+
+## Verification
+- confirm the operational surface was named clearly
+- confirm the change stayed bounded
+- confirm verification was explicit and proportional to the risk
+- confirm rollback or recovery thinking was present before execution or recommendation
+- confirm the report includes unresolved risk or recovery notes
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0028 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/confirmation-gated-mutating-action/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0001 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md` and sections: Intent, Outputs, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local risk classifications
+- approval rules
+- preferred validation commands
+- rollback or recovery expectations

--- a/.agents/skills/aoa-safe-infra-change/agents/openai.yaml
+++ b/.agents/skills/aoa-safe-infra-change/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Safe Infra Change
+  short_description: Make bounded infra changes safely
+  default_prompt: Use $aoa-safe-infra-change to plan and verify a bounded infrastructure or configuration change with explicit risk and rollback thinking.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#B45309'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-safe-infra-change/assets/infra_change_contract.template.json
+++ b/.agents/skills/aoa-safe-infra-change/assets/infra_change_contract.template.json
@@ -1,0 +1,21 @@
+{
+  "change_summary": "Adjust Terraform variables and service deployment configuration for the API tier",
+  "touched_surfaces": [
+    "infra/terraform/api.tfvars",
+    "deploy/kubernetes/api-deployment.yaml"
+  ],
+  "mutating_commands": [
+    "terraform apply -target=module.api",
+    "kubectl apply -f deploy/kubernetes/api-deployment.yaml"
+  ],
+  "verification_steps": [
+    "terraform plan -target=module.api",
+    "kubectl rollout status deployment/api",
+    "curl -fsS http://localhost:8080/healthz"
+  ],
+  "rollback_steps": [
+    "terraform apply -target=module.api -var-file=previous.tfvars",
+    "kubectl rollout undo deployment/api"
+  ],
+  "authority_state": "approved"
+}

--- a/.agents/skills/aoa-safe-infra-change/assets/infra_change_report.schema.json
+++ b/.agents/skills/aoa-safe-infra-change/assets/infra_change_report.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SafeInfraChangeReport",
+  "type": "object",
+  "required": [
+    "skill",
+    "change_summary",
+    "detected_surfaces",
+    "risk_band",
+    "report_state",
+    "authority_state",
+    "verification_strength",
+    "rollback_ready",
+    "warnings",
+    "errors"
+  ],
+  "properties": {
+    "skill": {
+      "const": "aoa-safe-infra-change"
+    },
+    "change_summary": {
+      "type": "string"
+    },
+    "detected_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risk_band": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "report_state": {
+      "type": "string"
+    },
+    "authority_state": {
+      "type": "string"
+    },
+    "verification_strength": {
+      "type": "string",
+      "enum": [
+        "missing",
+        "weak",
+        "moderate",
+        "strong"
+      ]
+    },
+    "rollback_ready": {
+      "type": "boolean"
+    },
+    "touched_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "mutating_commands": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "verification_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "rollback_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/.agents/skills/aoa-safe-infra-change/assets/large-logo.svg
+++ b/.agents/skills/aoa-safe-infra-change/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-safe-infra-change/assets/small-logo.svg
+++ b/.agents/skills/aoa-safe-infra-change/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-safe-infra-change/references/risk_surface_matrix.md
+++ b/.agents/skills/aoa-safe-infra-change/references/risk_surface_matrix.md
@@ -1,0 +1,17 @@
+# Risk surface matrix
+
+This reference helps the agent name the operational surface before mutation.
+
+## Common surfaces
+
+- infra as code
+- container or deployment orchestration
+- identity / secret flow
+- traffic routing
+- stateful data / migration
+- network boundary
+
+## Practical rule
+
+Name the surface before apply. Small diffs can still be high-risk when they
+touch routing, identity, or stateful data.

--- a/.agents/skills/aoa-safe-infra-change/references/verification_and_rollback_ladder.md
+++ b/.agents/skills/aoa-safe-infra-change/references/verification_and_rollback_ladder.md
@@ -1,0 +1,19 @@
+# Verification and rollback ladder
+
+Use stronger checks for stronger operational risk.
+
+## Verification ladder
+
+1. syntax / lint / render
+2. dry-run / plan / diff
+3. bounded rollout or startup status
+4. health or smoke check on the changed surface
+
+## Rollback rule
+
+Have one concrete recovery idea before the mutation:
+
+- undo command
+- previous config reference
+- previous release identifier
+- restore or revert path

--- a/.agents/skills/aoa-safe-infra-change/scripts/infra_change_contract.py
+++ b/.agents/skills/aoa-safe-infra-change/scripts/infra_change_contract.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TEMPLATE = {
+    "change_summary": "Adjust Terraform variables and service deployment configuration for the API tier",
+    "touched_surfaces": [
+        "infra/terraform/api.tfvars",
+        "deploy/kubernetes/api-deployment.yaml",
+    ],
+    "mutating_commands": [
+        "terraform apply -target=module.api",
+        "kubectl apply -f deploy/kubernetes/api-deployment.yaml",
+    ],
+    "verification_steps": [
+        "terraform plan -target=module.api",
+        "kubectl rollout status deployment/api",
+        "curl -fsS http://localhost:8080/healthz",
+    ],
+    "rollback_steps": [
+        "terraform apply -target=module.api -var-file=previous.tfvars",
+        "kubectl rollout undo deployment/api",
+    ],
+    "authority_state": "approved",
+}
+
+SURFACE_RULES: list[tuple[str, str, int]] = [
+    (r"terraform|tfvars|iac|terragrunt", "infra_as_code", 3),
+    (r"kubernetes|helm|docker-compose|compose|deployment\.ya?ml", "orchestration", 3),
+    (r"nginx|haproxy|envoy|ingress|gateway|lb|load[-_ ]balancer", "traffic_routing", 3),
+    (r"secret|vault|token|oauth|oidc|iam|identity|credential", "identity_or_secret", 4),
+    (r"migration|sql|database|schema|postgres|mysql|redis", "stateful_data", 4),
+    (r"systemd|service|unit|process manager", "runtime_service", 2),
+    (r"firewall|security group|network policy|iptables|dns", "network_boundary", 4),
+]
+
+
+def _load_payload(path: str | None) -> dict[str, Any]:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON input on stdin or via a file path.")
+    return json.loads(raw)
+
+
+def _iter_strings(values: list[Any]) -> list[str]:
+    out: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            out.append(value)
+        else:
+            out.append(json.dumps(value, ensure_ascii=False))
+    return out
+
+
+def classify_surfaces(texts: list[str]) -> tuple[list[str], int]:
+    detected: list[str] = []
+    score = 0
+    blob = " \n ".join(texts).lower()
+    for pattern, label, weight in SURFACE_RULES:
+        if re.search(pattern, blob):
+            detected.append(label)
+            score += weight
+    return detected, score
+
+
+def verification_strength(steps: list[str]) -> str:
+    joined = " ".join(steps).lower()
+    strength = 0
+    if any(token in joined for token in ("plan", "diff", "preview", "lint", "validate")):
+        strength += 1
+    if any(token in joined for token in ("test", "health", "status", "rollout", "smoke")):
+        strength += 1
+    if len(steps) >= 3:
+        strength += 1
+    if strength >= 3:
+        return "strong"
+    if strength == 2:
+        return "moderate"
+    if strength == 1:
+        return "weak"
+    return "missing"
+
+
+def build_report(payload: dict[str, Any]) -> dict[str, Any]:
+    touched_surfaces = _iter_strings(payload.get("touched_surfaces") or [])
+    commands = _iter_strings(payload.get("mutating_commands") or [])
+    verification_steps = _iter_strings(payload.get("verification_steps") or [])
+    rollback_steps = _iter_strings(payload.get("rollback_steps") or [])
+    detected_surfaces, score = classify_surfaces(touched_surfaces + commands)
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    if not touched_surfaces:
+        errors.append("No touched_surfaces were provided.")
+    if not commands:
+        errors.append("No mutating_commands were provided.")
+    if not verification_steps:
+        warnings.append("No verification_steps were provided.")
+    if not rollback_steps:
+        warnings.append("No rollback_steps were provided.")
+
+    authority_state = str(payload.get("authority_state", "unspecified")).strip().lower()
+    if authority_state not in {"approved", "planned", "unspecified"}:
+        warnings.append(f"Unrecognized authority_state value: {authority_state}")
+
+    risk_band = "low"
+    if score >= 9:
+        risk_band = "high"
+    elif score >= 5:
+        risk_band = "medium"
+
+    if "identity_or_secret" in detected_surfaces or "stateful_data" in detected_surfaces:
+        risk_band = "high"
+
+    if not detected_surfaces:
+        warnings.append("No operational surface patterns were detected. Confirm that the scope is described concretely.")
+
+    report_state = "hold" if errors else "ready"
+    if risk_band == "high" and authority_state != "approved":
+        warnings.append("High-risk change is not marked approved.")
+        report_state = "confirm-or-hold"
+
+    if verification_strength(verification_steps) == "missing":
+        warnings.append("Verification posture is missing or too thin.")
+
+    if not rollback_steps:
+        report_state = "confirm-or-hold"
+
+    return {
+        "skill": "aoa-safe-infra-change",
+        "change_summary": payload.get("change_summary", ""),
+        "detected_surfaces": detected_surfaces,
+        "risk_band": risk_band,
+        "report_state": report_state,
+        "authority_state": authority_state,
+        "verification_strength": verification_strength(verification_steps),
+        "rollback_ready": bool(rollback_steps),
+        "touched_surfaces": touched_surfaces,
+        "mutating_commands": commands,
+        "verification_steps": verification_steps,
+        "rollback_steps": rollback_steps,
+        "warnings": warnings,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a deterministic infrastructure-change contract.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--template", action="store_true", help="Print a starter JSON payload and exit.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON.")
+    args = parser.parse_args()
+
+    if args.template:
+        print(json.dumps(TEMPLATE, indent=2))
+        return 0
+
+    result = build_report(_load_payload(args.input_json))
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0 if not result["errors"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-safe-infra-change/scripts/risk_surface_scan.py
+++ b/.agents/skills/aoa-safe-infra-change/scripts/risk_surface_scan.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+RULES: list[tuple[str, str, str, str]] = [
+    (r"terraform|tfvars|terragrunt", "infra_as_code", "run plan before apply", "keep previous variable set or state-safe rollback path"),
+    (r"kubernetes|helm|docker-compose|compose|deployment\.ya?ml", "orchestration", "render effective config and inspect rollout status", "keep undo or stop command visible"),
+    (r"migration|schema|database|postgres|mysql|redis", "stateful_data", "capture dry-run or migration preview plus health check", "name restore or rollback before mutation"),
+    (r"secret|vault|token|oauth|oidc|iam|credential", "identity_or_secret", "verify access posture and secret source before apply", "prepare revoke or rotate path"),
+    (r"nginx|haproxy|envoy|ingress|gateway|load[-_ ]balancer", "traffic_routing", "verify config syntax and bounded health check", "keep previous config or undo route change ready"),
+    (r"firewall|security group|dns|network policy|iptables", "network_boundary", "stage bounded connectivity checks", "prepare precise revert command"),
+]
+
+
+def _load_payload(path: str | None) -> Any:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    raw = sys.stdin.read().strip()
+    if not raw:
+        raise SystemExit("Expected JSON or newline text on stdin or via a file path.")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.splitlines()
+
+
+def _flatten(payload: Any) -> list[str]:
+    if isinstance(payload, dict):
+        parts: list[str] = []
+        for value in payload.values():
+            parts.extend(_flatten(value))
+        return parts
+    if isinstance(payload, list):
+        parts: list[str] = []
+        for value in payload:
+            parts.extend(_flatten(value))
+        return parts
+    return [str(payload)]
+
+
+def scan(payload: Any) -> dict[str, Any]:
+    texts = _flatten(payload)
+    blob = " \n ".join(texts).lower()
+    detections = []
+    for pattern, label, verification_hint, rollback_hint in RULES:
+        if re.search(pattern, blob):
+            detections.append(
+                {
+                    "surface": label,
+                    "verification_hint": verification_hint,
+                    "rollback_hint": rollback_hint,
+                }
+            )
+    return {
+        "skill": "aoa-safe-infra-change",
+        "status": "ok" if detections else "warn",
+        "detected": detections,
+        "input_items": texts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scan paths, commands, or notes for risky infra surfaces.")
+    parser.add_argument("input_json", nargs="?", help="JSON file path. Reads stdin when omitted.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print output JSON.")
+    args = parser.parse_args()
+
+    result = scan(_load_payload(args.input_json))
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/aoa-sanitized-share
+++ b/.agents/skills/aoa-sanitized-share
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-sanitized-share

--- a/.agents/skills/aoa-sanitized-share/SKILL.md
+++ b/.agents/skills/aoa-sanitized-share/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: aoa-sanitized-share
+description: Turn raw technical material into a shareable public-safe artifact while keeping the raw source separate, placing the sanitized result in the canonical sharing surface, and preserving the lesson after redaction. Use when logs, configs, diagnostics, or reports may contain secrets, topology, or internal identifiers. Do not use when the material is already clearly public-safe or when the task is to perform the underlying operational change.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: risk
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/risk/aoa-sanitized-share/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0034,AOA-T-0002
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-sanitized-share
+
+## Intent
+Use this skill to turn potentially sensitive technical material into a shareable, reviewable, public-safe form, keeping the raw source distinct from the final public-safe output and placing that output where reviewers expect it.
+
+## Trigger boundary
+Use this skill when:
+- logs, configs, diagnostics, reports, or examples may contain sensitive details
+- a result needs to be shared publicly or with a broader audience
+- raw material may reveal secrets, topology, internal identifiers, or unsafe context
+- the output needs a canonical public-safe home rather than an ad hoc pasted summary
+
+Do not use this skill when:
+- the material is already clearly public-safe and minimal
+- the task is to perform the underlying operational change rather than prepare a shareable surface
+- the main task is deciding whether the underlying action should be allowed; use `aoa-approval-gate-check`
+- the task is to preview or execute the operational change itself; use `aoa-dry-run-first` or `aoa-safe-infra-change`
+
+## Inputs
+- material to be shared
+- sharing audience or context
+- known sensitive surfaces
+- acceptable level of abstraction
+
+## Outputs
+- sanitized shareable artifact, abstract summary, or recommendation not to share the raw material directly
+- note on what was generalized or removed
+- warning about any remaining ambiguity or sensitive edge
+- canonical public-safe output location or reference
+
+## Procedure
+1. inspect the material for secrets, tokens, private paths, topology, internal identifiers, or unsafe operational detail
+2. separate raw source material from the shareable surface before rewriting anything
+3. remove, redact, or generalize sensitive details
+4. preserve the technical lesson or signal without preserving the sensitive surface
+5. place the sanitized output in the canonical public-safe location or repo surface
+6. note what kind of sanitization was applied when that matters for interpretation
+7. verify that the shared result remains useful without revealing what should stay private
+
+## Contracts
+- shareable output should not leak secrets or private infrastructure detail
+- sanitization should preserve meaning where possible
+- generalization should not silently change the core lesson beyond recognition
+- uncertainty about sensitivity should lean toward caution
+- raw material and shareable output should remain clearly separated
+- the sanitized artifact should be discoverable from the expected public-safe surface
+
+## Risks and anti-patterns
+### Failure modes
+
+- over-sanitizing until the artifact becomes meaningless
+- under-sanitizing because a value looks harmless in isolation
+- collapsing raw and shareable surfaces into one note or transcript
+
+### Negative effects
+
+- the shared artifact becomes hard to reuse or verify
+- sensitivity leaks through topology, naming, or surrounding context even when tokens are removed
+- reviewers cannot tell where the canonical public-safe version lives
+
+### Misuse patterns
+
+- sharing raw excerpts when a bounded summary would be safer
+- treating a small harmless-looking field as proof that the full material is safe
+- using the shareable surface as a substitute for the raw source or vice versa
+
+### Detection signals
+
+- the sanitized output still points too directly to private topology or naming
+- a reviewer cannot tell what was generalized or removed
+- the artifact no longer communicates the lesson it was meant to preserve
+- the output has no clear canonical place for future reuse
+
+### Mitigations
+
+- generalize paths, hostnames, and private identifiers when needed
+- name the sanitization level and the remaining uncertainty
+- verify the shared result remains useful without preserving the sensitive surface
+- keep a visible boundary between raw input, sanitized output, and published placement
+
+## Verification
+- confirm obvious sensitive surfaces were checked
+- confirm the resulting artifact is still understandable
+- confirm the sanitization level matches the intended audience
+- confirm raw sensitive detail was not preserved by accident
+- confirm remaining uncertainty is named rather than ignored
+- confirm the sanitized output lives in the expected public-safe location or reference
+- confirm the raw/shareable split is still obvious after editing
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0034 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/public-safe-artifact-sanitization/TECHNIQUE.md` and sections: Intent, When to use, When not to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0002 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` and sections: Intent, When to use, When not to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local sanitization rules
+- examples of sensitive surfaces
+- public versus private sharing thresholds
+- project-specific reporting conventions

--- a/.agents/skills/aoa-sanitized-share/agents/openai.yaml
+++ b/.agents/skills/aoa-sanitized-share/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Sanitized Share
+  short_description: Sanitize tech artifacts for sharing
+  default_prompt: Use $aoa-sanitized-share to separate raw technical material from a public-safe artifact and verify the sanitized version still preserves the lesson.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#B45309'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-sanitized-share/assets/large-logo.svg
+++ b/.agents/skills/aoa-sanitized-share/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-sanitized-share/assets/small-logo.svg
+++ b/.agents/skills/aoa-sanitized-share/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="risk skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#B45309"/>
+<path d="M32 14 L50 46 H14 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M32 24 V35" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="42" r="2.8" fill="white"/>
+</svg>

--- a/.agents/skills/aoa-session-donor-harvest
+++ b/.agents/skills/aoa-session-donor-harvest
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-session-donor-harvest

--- a/.agents/skills/aoa-session-donor-harvest/SKILL.md
+++ b/.agents/skills/aoa-session-donor-harvest/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: aoa-session-donor-harvest
+description: Turn a reviewed session artifact into a bounded HARVEST_PACKET, route each reusable unit to the right AoA owner layer, and hand off to the next honest post-session skill when needed. Use when the source is a reviewed session transcript, compaction note, or recap and the real question is what should survive this session rather than merely what happened. Do not use for active or unreviewed sessions, raw session capture or indexing work, or when the only remaining object is already one repeated quest unit that just needs `aoa-quest-harvest` for the final promotion verdict.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-session-donor-harvest/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0075,AOA-T-0076,AOA-T-0077
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-session-donor-harvest
+
+## Intent
+Use this skill to metabolize a reviewed session artifact into a bounded
+`HARVEST_PACKET` that names reusable units, routes each one to the right AoA
+owner layer, and drafts the next honest artifact without forcing promotion.
+
+## Trigger boundary
+Use this skill when:
+- a session transcript, compaction note, review packet, or bounded recap exists and must be distilled into reusable donor units
+- the work is post-session and reviewable rather than live execution
+- candidate outputs may belong in technique canon, `aoa-skills`, `aoa-playbooks`, `aoa-evals`, `aoa-memo`, `aoa-agents`, or a hold/quest lane
+- a repeated manual route may also need an explicit automation-readiness seam instead of staying vague donor residue
+- the session may also have produced decision forks, diagnosis clues, repair candidates, progression evidence, or quest residue that should be made explicit rather than buried in recap prose
+- the question is not merely "what happened?" but "what reusable object, if any, emerged here?"
+
+Do not use this skill when:
+- the session is still active or unreviewed
+- the task is raw session capture, transcript export, or local indexing; those are history techniques, not this skill
+- the result is clearly one bounded repeated quest unit that only needs the narrower final promotion verdict from `aoa-quest-harvest`
+- the material is only a progress log, emotional recap, or theme cloud with no bounded reusable unit
+- the intended first destination is `aoa-routing` or `aoa-kag`; those are derivative layers and should not receive source-owned meaning first
+
+## Inputs
+- reviewed session artifact
+- session goal and closure state
+- candidate repeat signals or reuse signals
+- touched repos or AoA layers
+- explicit uncertainty and boundary risks
+- desired output posture: classify-only, draft-stub, or patch-ready proposal
+
+## Outputs
+- one bounded `HARVEST_PACKET`
+- named candidates, each with:
+  - candidate ref minted only after reviewed harvest
+  - source cluster ref when the reviewed input carried one
+  - reusable unit name
+  - unit kind: pattern, mechanic, utility, law, proof, recall, or route
+  - owner shape: technique, skill, playbook, eval, memo, agent, or hold
+  - owner hypothesis and owner repo recommendation
+  - one chosen next artifact
+  - one rejected nearest-wrong target
+  - status posture plus any supersedes, merged-into, or drop-reason carry
+  - evidence anchors from the session artifact
+- one short list of items to defer, drop, or keep as quest residue
+- one optional `automation_candidate` extract when a repeated manual route is
+  stable enough to deserve explicit automation-readiness classification
+- one optional handoff list to `aoa-automation-opportunity-scan`,
+  `aoa-session-route-forks`,
+  `aoa-session-self-diagnose`, `aoa-session-self-repair`,
+  `aoa-session-progression-lift`, or `aoa-quest-harvest`
+- one `HARVEST_PACKET_RECEIPT` using `references/stats-event-envelope.md` and
+  `references/harvest-packet-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. start from a reviewed session artifact rather than transient chat memory
+2. extract candidate reusable units, not topics; prefer explicit moves, laws, checklists, structures, routes, or proof patterns
+3. split merged candidates until each unit has one honest owner shape
+4. classify each kept candidate twice:
+   - by reuse kind: pattern, mechanic, utility, law, proof, recall, or route
+   - by owner shape: technique, skill, playbook, eval, memo, agent, or hold
+5. mint `candidate_ref` only after the reviewed unit is bounded and the owner
+   hypothesis plus nearest-wrong target are explicit
+6. mark `automation_candidate` only when a repeated manual route is stable
+   enough to name the current inputs, outputs, and risk posture, but the
+   surviving question is still automation readiness rather than owner canon
+7. reject theme-only repetition, aesthetic resonance, and broad "good idea" residue unless a bounded reusable unit exists
+8. route reusable practice meaning to technique canon first
+9. route bounded executable leaf workflows to `aoa-skills`
+10. route multi-step recurring scenario methods to `aoa-playbooks`
+11. route rubrics, verdict postures, and proof surfaces to `aoa-evals`
+12. route recall, writeback, recurrence, and memory-support patterns to `aoa-memo`
+13. route role law, orchestrator class law, handoff law, and actor-boundary rules to `aoa-agents`
+14. keep `aoa-routing` and `aoa-kag` out of first-authoring unless the source-owned object already exists elsewhere and the session only discovered a derivative bridge update
+15. preserve quest residue without forcing promotion when the reviewed session
+    is still mixed, early, or weakly repeated
+16. hand off to `aoa-automation-opportunity-scan` when the main surviving
+    question is whether a repeated manual route is honestly automation-ready
+17. hand off to `aoa-session-route-forks` when the main post-session need is
+    explicit next-route choice rather than donor extraction itself
+18. hand off to `aoa-session-self-diagnose` when the dominant surviving object
+    is drift, contradiction, proof gap, or ownership confusion
+19. hand off to `aoa-session-progression-lift` when the main surviving object is
+    evidence-backed progression reflection rather than owner placement
+20. when the candidate is a repeated reviewed quest unit and the remaining
+    ambiguity is specifically the final promotion target among quest, skill,
+    playbook, agent, eval, or memo, hand off to `aoa-quest-harvest`
+21. draft the smallest next artifact for each accepted candidate, such as
+    `TECHNIQUE.md`, `SKILL.md`, `PLAYBOOK.md`, `EVAL.md`, memory object seed,
+    or agent/orchestrator surface note
+22. keep `cluster_ref`, `owner_hypothesis`, `owner_shape`,
+    `nearest_wrong_target`, `status_posture`, `evidence_refs`, `supersedes`,
+    `merged_into`, and `drop_reason` on each accepted candidate when that carry
+    exists or becomes explicit during reviewed harvest
+23. emit one `HARVEST_PACKET_RECEIPT` when the packet is complete, using the
+    shared event envelope and a bounded receipt payload instead of duplicating
+    the full donor packet
+24. when the finish path is complete, emit one
+    `CORE_SKILL_APPLICATION_RECEIPT` that points back to the bounded detail
+    receipt, keeps `application_stage=finish`, and stays generic enough to act
+    as project-core kernel telemetry rather than a second donor packet
+25. record one clear reason for the chosen owner and one clear reason against
+    the nearest wrong owner
+
+## Contracts
+- invocation must remain explicit and post-session
+- the skill harvests donor units; it does not treat session history as memory canon or instruction authority
+- one candidate must map to one primary owner layer
+- `candidate_ref` appears only after reviewed donor harvest
+- `usefulness` is a reuse signal, not an owner layer by itself
+- derivative layers do not become first authoring targets for source-owned meaning
+- weak evidence may end in `hold` or `keep_or_open_quest`
+- the `HARVEST_PACKET` may carry handoff hints, but it does not become hidden
+  routing authority
+- `automation_candidate` is only a detector hint; it is not schedule or
+  mutation authority
+- `HARVEST_PACKET_RECEIPT` stays subordinate to the packet and never replaces
+  owner-layer or proof meaning
+- `CORE_SKILL_APPLICATION_RECEIPT` stays subordinate to the packet and the
+  detail receipt; it records one finished kernel-skill application and nothing
+  more
+- receipt corrections use `supersedes` rather than silent mutation
+- drafting a next artifact is allowed; forcing promotion is not
+
+## Risks and anti-patterns
+- collapsing technique, skill, and playbook into one generic "good reuse" bucket
+- mistaking session themes for reusable units
+- routing authored meaning into `aoa-routing` or `aoa-kag` first
+- turning agent class law into a skill just because an agent repeatedly used a workflow
+- promoting memory residue as if it were proof or source meaning
+- over-harvesting one session into too many thin objects
+- treating a transcript package or session index as the same thing as donor harvest
+- stuffing route-forks, diagnosis, repair, or progression meaning into vague
+  donor notes instead of naming the next family seam explicitly
+- turning donor harvest into a generic automation detector for every recurring
+  annoyance instead of keeping automation readiness as its own seam
+- letting receipt counts masquerade as proof, progression, or routing law
+
+## Verification
+- confirm the source artifact is reviewed and bounded
+- confirm each kept candidate names one reusable unit rather than a topic
+- confirm each accepted candidate has one primary owner layer
+- confirm the nearest wrong target is rejected explicitly
+- confirm `candidate_ref` was minted only for reviewed bounded units
+- confirm any surviving checkpoint `cluster_ref` stayed linked when available
+- confirm no candidate routes source-owned meaning first into derivative layers
+- confirm hold and defer outcomes remain available
+- confirm the output names the next artifact rather than only abstract categories
+- confirm any family handoff hint is explicit rather than smuggled into the
+  packet as hidden policy
+- confirm any `automation_candidate` names the current manual route and still
+  stops short of automation authority
+- confirm any emitted receipt stays append-only, evidence-linked, and smaller
+  than the packet it summarizes
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the matching
+  detail receipt and does not widen beyond one finished kernel-skill run
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0075 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/session-donor-harvest/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Validation
+- AOA-T-0076 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/decision-routing/owner-layer-triage/TECHNIQUE.md` and sections: Intent, When to use, Outputs, Core procedure, Risks, Validation
+- AOA-T-0077 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/harvest-packet-contract/TECHNIQUE.md` and sections: Inputs, Outputs, Contracts, Validation
+
+## Adaptation points
+Project overlays may add:
+- local session artifact entrypoints
+- local review packet templates
+- repo-relative destination paths for drafted artifacts
+- local stop conditions for when the result must stay `hold`
+- local naming rules for donor packs and quest IDs
+- local family handoff preferences when automation scan, route-forks,
+  diagnosis, repair, or progression surfaces exist
+
+This skill assumes the session artifact already exists. Adjacent history techniques such as session capture, transcript packaging, and local indexing remain separate neighbors rather than being reopened here.

--- a/.agents/skills/aoa-session-donor-harvest/agents/openai.yaml
+++ b/.agents/skills/aoa-session-donor-harvest/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Session Donor Harvest
+  short_description: Harvest reusable units from sessions
+  default_prompt: Use $aoa-session-donor-harvest to turn a reviewed session artifact into a HARVEST_PACKET, route each reusable unit to the right AoA owner layer, and name any explicit handoff to the next honest post-session skill.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-donor-harvest/assets/large-logo.svg
+++ b/.agents/skills/aoa-session-donor-harvest/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-donor-harvest/assets/small-logo.svg
+++ b/.agents/skills/aoa-session-donor-harvest/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-donor-harvest/references/candidate-lineage-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-donor-harvest/references/candidate-lineage-receipt-schema.yaml
@@ -1,0 +1,59 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Candidate Lineage Receipt
+type: object
+required:
+  - schema_version
+  - receipt_kind
+  - cluster_ref
+  - candidate_ref
+  - owner_hypothesis
+  - owner_shape
+  - nearest_wrong_target
+  - status_posture
+  - evidence_refs
+  - supersedes
+  - merged_into
+  - drop_reason
+properties:
+  schema_version:
+    const: aoa_candidate_lineage_receipt_v1
+  receipt_kind:
+    const: candidate_lineage_receipt
+  cluster_ref:
+    type:
+      - string
+      - "null"
+  candidate_ref:
+    type: string
+  owner_hypothesis:
+    type: string
+  owner_shape:
+    type: string
+  nearest_wrong_target:
+    type:
+      - string
+      - "null"
+  status_posture:
+    type: string
+    enum:
+      - early
+      - reanchor
+      - thin-evidence
+      - stable
+  evidence_refs:
+    type: array
+    items:
+      type: string
+  supersedes:
+    type: array
+    items:
+      type: string
+  merged_into:
+    type:
+      - string
+      - "null"
+  drop_reason:
+    type:
+      - string
+      - "null"
+additionalProperties: false

--- a/.agents/skills/aoa-session-donor-harvest/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-donor-harvest/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-session-donor-harvest
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-session-donor-harvest`
+  - `detail_event_kind` must equal `harvest_packet_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-session-donor-harvest/references/family-shape.md
+++ b/.agents/skills/aoa-session-donor-harvest/references/family-shape.md
@@ -1,0 +1,22 @@
+# Family Shape Around `aoa-session-donor-harvest`
+
+Recommended relation graph:
+
+- `aoa-session-donor-harvest`
+  - authors a bounded `HARVEST_PACKET`
+  - may hand off to:
+    - `aoa-automation-opportunity-scan`
+    - `aoa-session-route-forks`
+    - `aoa-session-self-diagnose`
+    - `aoa-session-self-repair`
+    - `aoa-session-progression-lift`
+    - `aoa-quest-harvest`
+
+- `aoa-session-self-diagnose`
+  - may hand off to `aoa-session-self-repair`
+
+- `aoa-session-self-repair`
+  - may emit repair quests or owner-repo deltas
+
+This keeps the donor-harvest nucleus strong while avoiding one giant
+bag-of-everything skill.

--- a/.agents/skills/aoa-session-donor-harvest/references/harvest-packet-contract.md
+++ b/.agents/skills/aoa-session-donor-harvest/references/harvest-packet-contract.md
@@ -1,0 +1,51 @@
+# Harvest Packet Contract
+
+Use this reference when `aoa-session-donor-harvest` needs a small but explicit
+shape for the post-session packet it emits.
+
+## Required fields
+
+- `packet_version`
+- `source_session_ref`
+- `reviewed_artifacts`
+- `candidates`
+- `deferred_or_dropped`
+
+## Common optional fields
+
+- `closure_state`
+- `wins`
+- `frictions`
+- `deferrals`
+- `quest_hooks`
+- `chronicle_stub`
+- `fork_cards`
+- `diagnosis`
+- `repair_candidates`
+- `progression`
+
+## Extract record expectations
+
+Each accepted candidate should keep:
+
+- `candidate_ref`
+- optional `cluster_ref`
+- `title`
+- `kind`
+- `summary`
+- `owner_hypothesis`
+- `owner_shape`
+- `evidence_refs`
+- `repeat_signal`
+- `owner_repo`
+- `chosen_next_surface`
+- `nearest_wrong_target`
+- `status_posture`
+- optional `supersedes`, `merged_into`, and `drop_reason`
+- optional `difficulty`, `risk`, `control_mode`, and `notes`
+
+## Contract rule
+
+The `HARVEST_PACKET` is a bounded post-session packet.
+It may point at route forks, diagnosis, repair, progression, or quest follow-up,
+but it must not silently replace those family seams.

--- a/.agents/skills/aoa-session-donor-harvest/references/harvest-packet-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-donor-harvest/references/harvest-packet-receipt-schema.yaml
@@ -1,0 +1,21 @@
+receipt_name: HARVEST_PACKET_RECEIPT
+event_kind: harvest_packet_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - extract_kind_counts
+  - owner_layer_distribution
+  - accepted_candidate_refs
+  - deferred_or_dropped_refs
+  - evidence_density_summary
+optional_payload_fields:
+  - candidate_lineage_refs
+  - candidate_lineage_entries
+  - automation_candidate_present
+  - handoff_targets
+  - chosen_next_artifact_refs
+rules:
+  - summarize the completed HARVEST_PACKET instead of duplicating its full body
+  - keep counts descriptive and evidence-linked rather than proof-shaped
+  - record only bounded candidate, lineage, or deferral refs, not raw session history
+  - candidate_lineage_entries may carry candidate_ref, cluster_ref, owner_hypothesis, owner_shape, nearest_wrong_target, status_posture, evidence_refs, supersedes, merged_into, and drop_reason
+  - candidate_lineage_entries must not carry seed_ref or object_ref; Dionysus and the final owner repo own those identities

--- a/.agents/skills/aoa-session-donor-harvest/references/owner-layer-map.md
+++ b/.agents/skills/aoa-session-donor-harvest/references/owner-layer-map.md
@@ -1,0 +1,66 @@
+# Owner Layer Map
+
+Use this map when `aoa-session-donor-harvest` needs a first owner recommendation.
+
+## First-authoring targets
+
+1. `aoa-techniques`
+   - reusable practice meaning
+   - patterns, mechanics, structures, and laws that travel across projects
+
+2. `aoa-skills`
+   - bounded executable leaf workflows for agents
+   - explicit trigger boundary, inputs, outputs, and verification path
+
+3. `aoa-playbooks`
+   - recurring multi-step scenario routes
+   - handoffs, fallbacks, artifacts, and re-entry logic
+
+4. `aoa-evals`
+   - proof posture, verdict logic, scoring rubrics, and bounded test/evidence surfaces
+
+5. `aoa-memo`
+   - recall, recurrence, writeback, chronicle, and memory-support patterns
+
+6. `aoa-agents`
+   - role law, orchestrator class law, handoff posture, actor boundaries
+
+## Family-aware routes
+
+- repeated reviewed quest residue
+  - keep the object in the session-harvest family until the remaining question
+    is only the final promotion verdict
+  - then hand off to `aoa-quest-harvest`
+
+- route-fork, diagnosis, repair, or progression follow-through
+  - keep the donor packet as the nucleus
+  - hand off explicitly to the next session-harvest family skill instead of
+    pretending the donor packet already closed the route
+
+## Rare or non-first routes
+
+- `aoa-routing`
+  - only after a source-owned object already exists elsewhere and the session
+    found a derivative dispatch or entry-surface update
+
+- `aoa-kag`
+  - not a first authoring target for source meaning; route authored meaning
+    first, then let substrate lifts happen later
+
+## Hold routes
+
+- `hold`
+  - evidence is too weak, merged, theme-only, or not yet honestly reusable
+
+- `keep_or_open_quest`
+  - the work is still exploratory or the final promotion ambiguity belongs in
+    `aoa-quest-harvest`
+
+## Wrong-first targets to reject
+
+- writing authored source meaning first into `aoa-routing`
+- writing authored source meaning first into `aoa-kag`
+- hiding role law inside a skill
+- hiding scenario method inside one skill
+- hiding eval doctrine inside memo
+- treating one session theme as a technique

--- a/.agents/skills/aoa-session-donor-harvest/references/rpg-reflection-posture.md
+++ b/.agents/skills/aoa-session-donor-harvest/references/rpg-reflection-posture.md
@@ -1,0 +1,28 @@
+# RPG Reflection Posture
+
+Session-harvest skills may emit RPG-shaped reading surfaces, but those are
+reflections rather than owner-layer truth.
+
+## Good uses
+
+- quest residue
+- quest hooks
+- questline or campaign hint
+- progression overlay
+- ability unlock hint for skills
+- feat hint for techniques
+- chronicle stub for memo
+- fork cards that read like quest-board choices
+
+## Bad uses
+
+- replacing owner-layer truth with RPG terminology
+- turning every session into a campaign
+- treating progression as one universal power score
+- treating quest hooks as runtime state
+- letting quest language overwrite proof, memory, or role contracts
+
+## Session-harvest rule
+
+A session may speak in quest and RPG language as a way of making the route
+legible, but the underlying owner layer still decides what artifact is real.

--- a/.agents/skills/aoa-session-donor-harvest/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-session-donor-harvest/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-session-progression-lift
+++ b/.agents/skills/aoa-session-progression-lift
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-session-progression-lift

--- a/.agents/skills/aoa-session-progression-lift/SKILL.md
+++ b/.agents/skills/aoa-session-progression-lift/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: aoa-session-progression-lift
+description: Lift reviewed session evidence into a bounded multi-axis progression delta with explicit unlock hints, quest reflection cues, and no fake single-score authority. Use when a reviewed session produced meaningful mastery evidence and you need progression legibility without mutating source role profiles or routing authority. Do not use when there is no reviewed evidence, when the request wants one universal power number, or when progression language is being used as hidden policy.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-session-progression-lift/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0084,AOA-T-0085
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-session-progression-lift
+
+## Intent
+Use this skill to author a `PROGRESSION_DELTA` from reviewed evidence.
+
+This is not score inflation.
+It is an evidence-backed overlay that says what mastery axes moved, what should
+hold or reanchor, and what small unlock hints are now safer.
+
+## Trigger boundary
+Use this skill when:
+- a reviewed session generated meaningful mastery evidence
+- the route needs progression legibility without mutating source role profiles
+- quest or RPG reflection would help continuation
+- the output needs to stay small, evidence-backed, and multi-axis
+
+Do not use this skill when:
+- there is no reviewed evidence
+- the request wants one global power number
+- progression is being used as hidden routing policy
+- the route is trying to mint authority rights without evidence
+
+## Inputs
+- reviewed session artifact or harvest packet
+- named evidence refs
+- relevant role or cohort context if known
+- existing progression baseline if available
+
+## Outputs
+- `PROGRESSION_DELTA` with axis movement, verdict, and optional unlock hints
+- optional automation-readiness hint when reviewed evidence supports it
+- optional rank reflection note if evidence is strong enough
+- quest hooks or chronicle stub when useful
+- negative or cautionary evidence when a hold, reanchor, or downgrade is more honest than advance
+- one `PROGRESSION_DELTA_RECEIPT` using `references/stats-event-envelope.md`
+  and `references/progression-delta-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. collect reviewed evidence refs
+2. assess movement qualitatively across `boundary_integrity`,
+   `execution_reliability`, `change_legibility`, `review_sharpness`,
+   `proof_discipline`, `provenance_hygiene`, and `deep_readiness`
+3. emit a verdict: advance, hold, reanchor, or downgrade
+4. name small unlock hints only when evidence supports them
+5. keep any automation-readiness hint small, descriptive, and non-authoritative
+6. allow negative, zero, and cautionary movement
+7. map ability or feat hints only as reflection, not as ownership transfer
+8. emit one `PROGRESSION_DELTA_RECEIPT` when the delta closes, keeping the
+   receipt descriptive, evidence-linked, and smaller than the progression packet
+9. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+   that points back to the bounded progression receipt and records one
+   finished kernel-skill application
+
+## Contracts
+- progression remains evidence-backed
+- multi-axis only; no authoritative universal score
+- rank labels are descriptive, not sovereign
+- unlock hints must stay reviewable and small
+- progression does not replace owner-layer truth or routing authority
+- progression does not greenlight automation by itself
+- progression receipts stay descriptive and append-only
+- generic core receipts stay subordinate to the progression receipt and do not
+  become progression authority
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- inventing progress from mood
+- using progression as policy
+- granting authority without cited evidence
+- flattening multi-axis growth into one number
+- confusing quest flavor with durable proof
+- treating progression hints as if they were approval or schedule rights
+- treating a progression receipt as if receipt emission itself proved growth
+
+## Verification
+- confirm all meaningful axis claims cite reviewed evidence
+- confirm the verdict matches the evidence
+- confirm zero or negative movement remains allowed
+- confirm unlock hints are small and explicit
+- confirm no universal score is introduced
+- confirm any emitted receipt stays multi-axis, evidence-linked, and non-sovereign
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the
+  progression detail receipt and stays finish-only
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0084 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/progression-evidence-lift/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Contracts, Validation
+- AOA-T-0085 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/continuity/donor-harvest/multi-axis-quest-overlay/TECHNIQUE.md` and sections: Outputs, Risks, Validation
+
+## Adaptation points
+Project overlays may add:
+- local axis notes
+- role-affinity hints
+- local unlock classes

--- a/.agents/skills/aoa-session-progression-lift/agents/openai.yaml
+++ b/.agents/skills/aoa-session-progression-lift/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Session Progression Lift
+  short_description: Lift reviewed progression signals
+  default_prompt: Use $aoa-session-progression-lift to turn reviewed session evidence into a bounded multi-axis progression delta with explicit verdicts and small unlock hints.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-progression-lift/assets/large-logo.svg
+++ b/.agents/skills/aoa-session-progression-lift/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-progression-lift/assets/small-logo.svg
+++ b/.agents/skills/aoa-session-progression-lift/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-progression-lift/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-progression-lift/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-session-progression-lift
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-session-progression-lift`
+  - `detail_event_kind` must equal `progression_delta_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-session-progression-lift/references/progression-axes.md
+++ b/.agents/skills/aoa-session-progression-lift/references/progression-axes.md
@@ -1,0 +1,14 @@
+# Progression Axes
+
+Use qualitative movement and named evidence across these axes:
+
+- `boundary_integrity`
+- `execution_reliability`
+- `change_legibility`
+- `review_sharpness`
+- `proof_discipline`
+- `provenance_hygiene`
+- `deep_readiness`
+
+Avoid one universal score.
+Keep movement reviewable, evidence-backed, and small.

--- a/.agents/skills/aoa-session-progression-lift/references/progression-delta-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-progression-lift/references/progression-delta-receipt-schema.yaml
@@ -1,0 +1,15 @@
+receipt_name: PROGRESSION_DELTA_RECEIPT
+event_kind: progression_delta_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - scope_ref
+  - axis_delta_summary
+  - verdict
+optional_payload_fields:
+  - caution_refs
+  - unlock_hint_refs
+  - automation_readiness_hint
+rules:
+  - keep the receipt multi-axis and descriptive rather than score-shaped
+  - allow hold, reanchor, or downgrade without treating receipt emission as progress by itself
+  - keep automation hints advisory and non-authoritative

--- a/.agents/skills/aoa-session-progression-lift/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-session-progression-lift/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-session-route-forks
+++ b/.agents/skills/aoa-session-route-forks
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-session-route-forks

--- a/.agents/skills/aoa-session-route-forks/SKILL.md
+++ b/.agents/skills/aoa-session-route-forks/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: aoa-session-route-forks
+description: Turn reviewed session evidence into explicit next-route forks with likely gains, costs, risks, owner targets, and stop conditions so continuation stays legible instead of buried in chat memory. Use when a reviewed session ended with several plausible next moves and you need visible branch choices rather than a hidden recommendation. Do not use when there is only one obvious next move, when donor harvest still has not happened, or when the real question is final promotion of one repeated quest unit.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-session-route-forks/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0078,AOA-T-0079
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-session-route-forks
+
+## Intent
+Use this skill to author `FORK_CARDS` from a reviewed session.
+
+The goal is not prediction theater.
+The goal is legible choice architecture: what routes exist, why each route
+matters, what each one likely costs, and where each route probably lands first.
+
+## Trigger boundary
+Use this skill when:
+- a reviewed session ended with multiple plausible next moves
+- the operator or Codex needs explicit branch choices instead of a buried recommendation
+- the next route may change owner repo, risk posture, or difficulty posture
+- the choice may include staying manual, becoming a bounded skill, becoming a playbook automation seed candidate, or waiting for prerequisite repair
+- the session needs quest-board legibility without pretending to be runtime state
+
+Do not use this skill when:
+- there is only one obvious next bounded move
+- the session still needs first-pass donor harvest
+- the question is final promotion of a repeated quest unit
+- the route needs scenario canon immediately rather than branch analysis
+
+## Inputs
+- reviewed session artifact or harvest packet
+- candidate next routes
+- known risks, dependencies, and blockers
+- desired control mode or approval posture
+- operator preference if already named
+
+## Outputs
+- `FORK_CARDS` with likely gain, cost, risk, owner repo, and stop conditions
+- one suggested default route if evidence is strong enough
+- one explicit hold or defer option when honest uncertainty remains
+- optional automation and non-automation branches side by side when that choice
+  is real
+- optional quest hooks or campaign hints without runtime authority
+- one `DECISION_FORK_RECEIPT` using `references/stats-event-envelope.md` and
+  `references/decision-fork-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. start from reviewed evidence rather than free speculation
+2. separate materially different branches instead of cosmetic variants
+3. name the likely first owner repo for each branch
+4. state likely gains, likely costs, likely risks, and stop conditions
+5. attach a small route passport with difficulty, risk, control mode, and delegate tier
+6. allow automation and non-automation branches to appear side by side when the reviewed evidence supports a real choice between them
+7. preserve a hold or reanchor path where uncertainty or risk remains meaningful
+8. emit quest-board-readable language only as adjunct reflection
+9. emit one `DECISION_FORK_RECEIPT` when the fork set closes, keeping the
+   receipt smaller than the branch cards themselves
+10. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+    that points back to the bounded fork receipt and records one finished
+    kernel-skill application only
+
+## Contracts
+- branch cards do not become routing authority
+- fork analysis must stay evidence-backed
+- confidence should be named when weak
+- stop conditions are first-class, not footnotes
+- a fork card may recommend but must not hide alternatives
+- automation-shaped branches must not be read as schedule authority
+- `DECISION_FORK_RECEIPT` is descriptive branch telemetry, not routing policy
+- `CORE_SKILL_APPLICATION_RECEIPT` is generic kernel telemetry, not branch
+  policy or route choice authority
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- fake certainty about future routes
+- using fork cards as hidden routing policy
+- collapsing all branches into one generic recommendation
+- confusing playbook outline with branch analysis
+- confusing an automation seed candidate with a live scheduler or background job
+- treating quest-board cards as runtime state
+- treating branch receipts as if they already chose the route
+
+## Verification
+- confirm each branch differs materially
+- confirm likely owner repo is named
+- confirm at least one cost or risk is explicit
+- confirm stop conditions exist for risky branches
+- confirm hold or defer remains possible when uncertainty is real
+- confirm any emitted receipt stays evidence-linked and subordinate to the fork cards
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the fork
+  detail receipt and stays finish-only
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0078 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/decision-routing/decision-fork-cards/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Core procedure, Validation
+- AOA-T-0079 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/governance/decision-routing/risk-passport-lift/TECHNIQUE.md` and sections: Outputs, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays may add:
+- local control-mode labels
+- local delegate tiers or approval classes
+- repo-specific route passports

--- a/.agents/skills/aoa-session-route-forks/agents/openai.yaml
+++ b/.agents/skills/aoa-session-route-forks/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Session Route Forks
+  short_description: Make next-route forks explicit
+  default_prompt: Use $aoa-session-route-forks to turn a reviewed session or harvest packet into explicit fork cards with likely gains, costs, risks, owner targets, and stop conditions.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-route-forks/assets/large-logo.svg
+++ b/.agents/skills/aoa-session-route-forks/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-route-forks/assets/small-logo.svg
+++ b/.agents/skills/aoa-session-route-forks/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-route-forks/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-route-forks/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-session-route-forks
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-session-route-forks`
+  - `detail_event_kind` must equal `decision_fork_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-session-route-forks/references/decision-fork-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-route-forks/references/decision-fork-receipt-schema.yaml
@@ -1,0 +1,18 @@
+receipt_name: DECISION_FORK_RECEIPT
+event_kind: decision_fork_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - branch_ids
+  - suggested_default_branch
+  - predicted_gain_posture
+  - predicted_cost_posture
+  - predicted_risk_posture
+optional_payload_fields:
+  - chosen_branch
+  - stop_condition_refs
+  - realized_outcome_refs
+  - owner_targets
+rules:
+  - summarize the completed fork set instead of replacing the branch cards
+  - keep gain, cost, and risk posture descriptive rather than predictive theater
+  - preserve hold or defer posture when no branch should be treated as final authority

--- a/.agents/skills/aoa-session-route-forks/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-session-route-forks/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-session-self-diagnose
+++ b/.agents/skills/aoa-session-self-diagnose
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-session-self-diagnose

--- a/.agents/skills/aoa-session-self-diagnose/SKILL.md
+++ b/.agents/skills/aoa-session-self-diagnose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: aoa-session-self-diagnose
+description: Classify drift, friction, proof gaps, ownership confusion, and repeated failure patterns from a reviewed session into a bounded diagnosis packet without mutating anything yet. Use when the next honest move is diagnosis before repair and the reviewed material points to repeated contradictions, blockers, or boundary blur. Do not use for live sessions, for issues that are already fully diagnosed, or when the real task is final quest-promotion triage.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-session-self-diagnose/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0080,AOA-T-0081
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-session-self-diagnose
+
+## Intent
+Use this skill to turn a reviewed session into a `DIAGNOSIS_PACKET`.
+
+It should answer: what drifted, what hurt, what boundary blurred, what proof is
+missing, and what repair shape is most plausible.
+
+## Trigger boundary
+Use this skill when:
+- a reviewed session contains repeated friction, contradiction, or drift
+- the next honest move is diagnosis before repair
+- boundary confusion or missing proof may be more important than immediate output production
+- blocked automation readiness may need root-cause classification before any automation claim becomes honest
+- the same class of problem may be appearing across sessions
+
+Do not use this skill when:
+- the session is still live
+- the issue is already fully diagnosed and only needs repair execution
+- the material is a celebration recap with no meaningful friction
+- the route is actually a single quest-promotion decision
+
+## Inputs
+- reviewed session artifact or harvest packet
+- observed frictions, failures, or contradictions
+- relevant owner layers and touched repos
+- previous related session evidence if available
+
+## Outputs
+- `DIAGNOSIS_PACKET` with drift types, symptoms, probable causes, repair shapes, and owner hints
+- severity or urgency notes when evidence supports them
+- explicit unknowns when diagnosis remains incomplete
+- optional blocked-automation findings such as unstable inputs, hidden approval,
+  rollback gaps, or secret coupling
+- optional handoff to `aoa-session-self-repair`
+- one `DIAGNOSIS_PACKET_RECEIPT` using
+  `references/stats-event-envelope.md` and
+  `references/diagnosis-packet-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. gather reviewed symptoms and evidence refs
+2. separate symptom from probable cause
+3. classify drift types such as boundary drift, proof debt, role leakage, memory contamination, route collapse, compaction damage, or repeated blocker patterns
+4. call out blocked automation causes when the route looks repetitive but still fails readiness because of unstable inputs, hidden authority, weak rollback posture, or secret coupling
+5. map each diagnosis toward the likely owner layer
+6. suggest a repair shape without silently performing it
+7. preserve unknowns where evidence does not justify stronger claims
+8. emit one bounded `DIAGNOSIS_PACKET_RECEIPT` when the diagnosis packet
+   closes, keeping the payload smaller than the diagnosis itself
+9. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+   that points back to the bounded detail receipt and records one finished
+   kernel-skill application
+
+## Contracts
+- diagnosis is read-only
+- one odd anecdote is not enough for structural certainty
+- probable cause must remain probabilistic when evidence is thin
+- owner hints must not override owner-layer law
+- no hidden mutation or silent patching
+- diagnosis does not grant automation readiness by itself
+- the receipt remains descriptive and cannot become proof or repair authority
+- the generic core receipt remains subordinate to the diagnosis receipt and
+  cannot become diagnosis, proof, or repair authority
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- mistaking symptom for cause
+- using vague vibes as diagnosis
+- smuggling repair work into diagnosis
+- turning every inconvenience into a system flaw
+- blaming one owner layer for a cross-layer issue
+- treating automation frustration as if it automatically proved readiness
+- letting a diagnosis receipt read like a final blame or repair verdict
+
+## Verification
+- confirm each diagnosis cites evidence refs
+- confirm symptoms and causes are separated
+- confirm a likely owner layer is named
+- confirm unknowns are preserved where needed
+- confirm no mutation happened
+- confirm any emitted receipt stays evidence-linked and smaller than the diagnosis packet
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the detail
+  diagnosis receipt and stays finish-only
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0080 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/recovery/diagnosis-repair/session-drift-taxonomy/TECHNIQUE.md` and sections: Intent, Outputs, Risks, Validation
+- AOA-T-0081 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/recovery/diagnosis-repair/diagnosis-from-reviewed-evidence/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Core procedure, Contracts, Validation
+
+## Adaptation points
+Project overlays may add:
+- local drift taxonomies
+- repo-specific failure classes
+- severity bands

--- a/.agents/skills/aoa-session-self-diagnose/agents/openai.yaml
+++ b/.agents/skills/aoa-session-self-diagnose/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Session Self Diagnose
+  short_description: Diagnose reviewed session drift
+  default_prompt: Use $aoa-session-self-diagnose to turn reviewed session evidence into a diagnosis packet with drift types, symptoms, probable causes, repair shapes, and owner hints.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-self-diagnose/assets/large-logo.svg
+++ b/.agents/skills/aoa-session-self-diagnose/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-self-diagnose/assets/small-logo.svg
+++ b/.agents/skills/aoa-session-self-diagnose/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-self-diagnose/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-self-diagnose/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-session-self-diagnose
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-session-self-diagnose`
+  - `detail_event_kind` must equal `diagnosis_packet_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-session-self-diagnose/references/diagnosis-packet-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-self-diagnose/references/diagnosis-packet-receipt-schema.yaml
@@ -1,0 +1,20 @@
+receipt_name: DIAGNOSIS_PACKET_RECEIPT
+event_kind: diagnosis_packet_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - skill_name
+  - result_kind
+  - diagnosis_types
+  - symptom_refs
+  - probable_cause_hypotheses
+  - confidence_band
+  - owner_hints
+optional_payload_fields:
+  - route_ref
+  - blocked_automation_causes
+  - repair_handoff
+  - unknowns
+rules:
+  - set `skill_name` to `aoa-session-self-diagnose`
+  - set `result_kind` to `diagnosis_packet`
+  - keep probable causes probabilistic when evidence is thin

--- a/.agents/skills/aoa-session-self-diagnose/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-session-self-diagnose/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-session-self-repair
+++ b/.agents/skills/aoa-session-self-repair
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-session-self-repair

--- a/.agents/skills/aoa-session-self-repair/SKILL.md
+++ b/.agents/skills/aoa-session-self-repair/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: aoa-session-self-repair
+description: Turn a reviewed diagnosis packet into the smallest honest repair packet with checkpoint posture, rollback markers, health checks, and explicit owner-layer targets instead of silent self-mutation. Use when diagnosis already exists and the next honest move is a bounded repair plan or repair-ready packet. Do not use without a reviewed diagnosis, for playbook-scale rollout work, or for vague self-improvement rhetoric with no bounded target.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: evaluated
+  aoa_invocation_mode: explicit-only
+  aoa_source_skill_path: skills/core/session-growth/aoa-session-self-repair/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0082,AOA-T-0083
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-session-self-repair
+
+## Intent
+Use this skill to author a bounded `REPAIR_PACKET`.
+
+The repair packet should be small, explicit, reversible where needed, and
+aligned with checkpoint posture before any important system surface is changed.
+
+## Trigger boundary
+Use this skill when:
+- a reviewed diagnosis already exists
+- the next honest move is a bounded repair plan or repair-ready packet
+- the route may change skill, playbook, agent, eval, or memo surfaces and needs explicit checkpoint posture
+- the route may need prerequisite repair before later automation becomes honest
+- repair can still be kept inside one bounded execution unit
+
+Do not use this skill when:
+- there is no reviewed diagnosis yet
+- the repair is actually a large scenario rollout better owned by a playbook
+- the route is trying to bypass approval, rollback, or health-check posture
+- the request is vague self-improvement rhetoric with no bounded target
+
+## Inputs
+- reviewed diagnosis packet
+- owner-layer candidates
+- risk and approval posture
+- known validation surfaces
+- current rollback anchors if any
+
+## Outputs
+- `REPAIR_PACKET` with target owner repo, smallest diff shape, approval need, rollback marker, health check, and improvement-log stub
+- optional repair quest when execution should remain deferred
+- optional automation-readiness prerequisite packet when the real need is to
+  stabilize a route before later automation scanning or seeding
+- explicit stop conditions and escalation points
+- one `REPAIR_CYCLE_RECEIPT` using `references/stats-event-envelope.md` and
+  `references/repair-cycle-receipt-schema.yaml`
+- one `CORE_SKILL_APPLICATION_RECEIPT` using
+  `references/core-skill-application-receipt-schema.yaml`
+
+## Procedure
+1. start from the reviewed diagnosis rather than from general aspiration
+2. choose the smallest honest repair shape
+3. name the primary owner repo and target artifact class
+4. record checkpoint posture: constitution or policy check, approval gate, rollback marker, post-change health check, bounded iteration limit, improvement log
+5. if the target route was blocked automation, emit the smallest prerequisite repair that would make later automation classification more honest
+6. define validation and stop conditions
+7. emit a repair quest instead of mutating immediately when risk or approval posture requires it
+8. emit one `REPAIR_CYCLE_RECEIPT` when the repair packet or repair-quest handoff closes, keeping the receipt smaller than the packet
+9. when the finish path closes, emit one `CORE_SKILL_APPLICATION_RECEIPT`
+   that points back to the bounded repair receipt and records one finished
+   kernel-skill application
+
+## Contracts
+- self-repair is not free self-modification
+- important surface changes must pass checkpoint posture
+- repair packets stay bounded and reviewable
+- role law changes route to `aoa-agents`
+- proof-law changes route to `aoa-evals`
+- scenario-scale repair routes to `aoa-playbooks`
+- repair does not smuggle live automation authority into the packet
+- repair-cycle receipts stay descriptive and append-only
+- generic core receipts stay subordinate to the repair receipt and do not
+  replace checkpoint or repair meaning
+- receipt corrections use `supersedes` rather than silent overwrite
+
+## Risks and anti-patterns
+- silent doctrine edits
+- approval bypass
+- retry loops disguised as repair
+- using repair to hide broader governance debt
+- changing too many surfaces at once
+- letting a repair receipt pretend the repair is already verified when it is only planned
+
+## Verification
+- confirm diagnosis exists and is cited
+- confirm the chosen repair is the smallest honest shape
+- confirm checkpoint fields are present
+- confirm validation and rollback posture are named
+- confirm escalation route exists if the repair widens
+- confirm any emitted receipt cites diagnosis and validation refs without duplicating the whole packet
+- confirm any emitted `CORE_SKILL_APPLICATION_RECEIPT` points to the repair
+  detail receipt and stays finish-only
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0082 from `8Dionysus/aoa-techniques` at `bfb4281c60295ab85605e188b350e0f6008b3184` using path `techniques/recovery/diagnosis-repair/repair-shape-from-diagnosis/TECHNIQUE.md` and sections: Intent, Inputs, Outputs, Core procedure, Validation
+- AOA-T-0083 from `8Dionysus/aoa-techniques` at `bfb4281c60295ab85605e188b350e0f6008b3184` using path `techniques/recovery/diagnosis-repair/checkpoint-bound-self-repair/TECHNIQUE.md` and sections: Outputs, Contracts, Risks, Validation
+
+## Adaptation points
+Project overlays may add:
+- local approval classes
+- repo-specific rollback anchors
+- bounded repair templates

--- a/.agents/skills/aoa-session-self-repair/agents/openai.yaml
+++ b/.agents/skills/aoa-session-self-repair/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Session Self Repair
+  short_description: Author checkpointed repair packets
+  default_prompt: Use $aoa-session-self-repair to turn a reviewed diagnosis packet into a bounded repair packet with owner target, checkpoint posture, rollback marker, health check, and stop conditions.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-self-repair/assets/large-logo.svg
+++ b/.agents/skills/aoa-session-self-repair/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-self-repair/assets/small-logo.svg
+++ b/.agents/skills/aoa-session-self-repair/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-session-self-repair/references/checkpoint-bridge.md
+++ b/.agents/skills/aoa-session-self-repair/references/checkpoint-bridge.md
@@ -1,0 +1,36 @@
+# Self-Repair Checkpoint Bridge
+
+`aoa-session-self-repair` should stay skill-shaped, but it must respect the
+self-agent checkpoint stack.
+
+## Required checkpoints
+
+- constitution or policy check
+- approval gate
+- rollback marker
+- post-change health check
+- bounded iteration limit
+- explicit improvement log
+
+## Repair rule
+
+Self-repair may propose or author the smallest bounded repair packet, but it
+must not silently mutate important system surfaces without naming checkpoint
+posture.
+
+## Good repair outputs
+
+- repair quest
+- bounded skill delta
+- playbook correction note
+- owner-layer issue packet
+- explicit validation plan
+- improvement-log stub
+
+## Anti-patterns
+
+- "the system fixed itself"
+- hidden doctrine changes
+- role-law changes without `aoa-agents`
+- proof-law changes without `aoa-evals`
+- silent retries disguised as reanchor

--- a/.agents/skills/aoa-session-self-repair/references/core-skill-application-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-self-repair/references/core-skill-application-receipt-schema.yaml
@@ -1,0 +1,22 @@
+receipt_name: CORE_SKILL_APPLICATION_RECEIPT
+event_kind: core_skill_application_receipt
+envelope_ref: references/stats-event-envelope.md
+kernel_id: project-core-session-growth-v1
+skill_name: aoa-session-self-repair
+required_payload_fields:
+  - kernel_id
+  - skill_name
+  - application_stage
+  - detail_event_kind
+  - detail_receipt_ref
+optional_payload_fields:
+  - route_ref
+  - surface_detection_context
+rules:
+  - `application_stage` must equal `finish`
+  - `kernel_id` must equal `project-core-session-growth-v1`
+  - `skill_name` must equal `aoa-session-self-repair`
+  - `detail_event_kind` must equal `repair_cycle_receipt`
+  - `detail_receipt_ref` must point to the bounded finish receipt for the same completed run
+  - include `route_ref` only when the detail receipt already names it honestly
+  - if present, `surface_detection_context` stays advisory and may only preserve shortlist, ambiguity, handoff, and closeout-link truth; it must not claim non-skill activation

--- a/.agents/skills/aoa-session-self-repair/references/repair-cycle-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-self-repair/references/repair-cycle-receipt-schema.yaml
@@ -1,0 +1,18 @@
+receipt_name: REPAIR_CYCLE_RECEIPT
+event_kind: repair_cycle_receipt
+envelope_ref: references/stats-event-envelope.md
+required_payload_fields:
+  - repair_cycle_state
+  - linked_diagnosis_refs
+  - action_family
+  - approval_posture
+  - rollback_marker
+  - health_check_refs
+optional_payload_fields:
+  - resolution_status
+  - escalation_route
+  - iteration_limit
+rules:
+  - keep the receipt smaller than the REPAIR_PACKET itself
+  - make checkpoint posture explicit without granting silent mutation authority
+  - reopen or correction should arrive through a new receipt, not silent overwrite

--- a/.agents/skills/aoa-session-self-repair/references/stats-event-envelope.md
+++ b/.agents/skills/aoa-session-self-repair/references/stats-event-envelope.md
@@ -1,0 +1,39 @@
+# Stats Event Envelope
+
+Use this shared envelope when the session-harvest family emits one bounded
+finish receipt.
+
+Canonical owner:
+
+- `aoa-stats` owns the shared envelope and active event-kind vocabulary at
+  `repo:aoa-stats/schemas/stats-event-envelope.schema.json`.
+- owner repos keep payload meaning in their own receipt schemas.
+
+## Required fields
+
+- `event_kind`
+- `event_id`
+- `observed_at`
+- `run_ref`
+- `session_ref`
+- `actor_ref`
+- `object_ref`
+- `evidence_refs`
+- `payload`
+
+## Optional fields
+
+- `supersedes`
+- `notes`
+- `owner_ref`
+- `related_event_refs`
+
+## Rules
+
+- Keep receipts append-only.
+- If a correction is needed, emit a new receipt and set `supersedes`.
+- Link to inspectable artifacts through `evidence_refs` instead of duplicating
+  raw transcripts, patches, or reports.
+- Keep `payload` bounded to the skill's own emitted packet or card set.
+- Do not let receipt presence act as proof, routing authority, or score
+  authority.

--- a/.agents/skills/aoa-source-of-truth-check
+++ b/.agents/skills/aoa-source-of-truth-check
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-source-of-truth-check

--- a/.agents/skills/aoa-source-of-truth-check/SKILL.md
+++ b/.agents/skills/aoa-source-of-truth-check/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: aoa-source-of-truth-check
+description: Clarify which files are authoritative for repository guidance, operational instructions, architecture, and status, and keep entrypoint docs short and link-driven once canonical homes exist. Use when docs overlap, conflict, or confuse contributors about which file to trust. Do not use for purely code-local tasks or when authoritative files are already clear and the main need is decision rationale.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-source-of-truth-check/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0013,AOA-T-0002,AOA-T-0009
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-source-of-truth-check
+
+## Intent
+Use this skill to clarify which repository surfaces are authoritative for status, architecture, source behavior, configuration, run instructions, policy, and change guidance.
+
+## Trigger boundary
+Use this skill when:
+- a repository has several docs that may overlap or conflict
+- contributors may not know which file, source surface, config, schema, manifest, report, or export to trust first
+- a change touches docs, source, config, process, generated output, or operational guidance and the question is which surface is authoritative
+- confusion exists between overview docs and authoritative docs
+- one authoritative source must stay aligned across multiple downstream consumer surfaces
+- top-level status docs such as `README` or `MANIFEST` are accumulating status/history that should live in canonical homes instead
+- the repository already has canonical detail surfaces and the summary docs should stay short, navigable, and link-driven
+- root docs, mechanics packages, source/config/schema surfaces, legacy receipts, provenance bridges, decisions, generated surfaces, runtime receipts, or owner-local handoff docs are being confused with one another
+- a public repository must stay portable while still pointing to project-local, ecosystem, or downstream owner context
+
+Do not use this skill when:
+- the repository is tiny and has no meaningful source-of-truth ambiguity
+- the task is purely code-local with no guidance, configuration, generated/export, or policy authority impact
+- the authoritative files are already clear and the main need is recording rationale for a decision; use `aoa-adr-write`
+- the main problem is deciding whether logic belongs in the core or at the edge; use `aoa-core-logic-boundary` first
+- the main problem is broader policy design rather than document authority or ownership
+- the task is only about building or maintaining a derived docs surface; that belongs in a separate review-surface workflow
+- the generated or exported surface has a known source owner and only needs a deterministic rebuild or no-drift check
+
+## Inputs
+- repository guidance, source, configuration, schema, manifest, generated/export, operational, and status surfaces
+- target area of ambiguity or overlap
+- known canonical files or source-owned surfaces if any
+- active, legacy, provenance, generated, or decision surfaces involved
+- owner repositories or stronger owner layers involved
+- current contributor confusion points
+
+## Outputs
+- clearer source-of-truth map
+- active/current versus historical/provenance/generated placement map
+- fan-out map when one source feeds multiple downstream consumers
+- note of overlaps or conflicts
+- proposed or implemented document role clarification
+- lightweight snapshot guidance for entrypoint docs when canonical homes already exist
+- verification summary
+
+## Procedure
+1. identify the main docs, source/config/schema surfaces, route cards, generated outputs, mechanics surfaces, runtime receipts, legacy/provenance bridges, and owner-local handoff files involved in the target area
+2. when the authority question spans more than ordinary docs, choose the smallest useful shape from `references/authority-surface-shapes.md`
+3. determine which file or surface should be authoritative for each concern and which surfaces are entrypoints, active contracts, provenance bridges, historical receipts, generated companions, operational receipts, or decision rationale
+4. note any overlap, contradiction, role ambiguity, or stale route caused by old growth rather than current source truth
+5. if one source feeds multiple consumers, name each consumer and refresh them from the same source
+6. if top-level status docs are bloating, trim them into short snapshots and route detail to canonical homes
+7. when historical or raw material matters, route it through legacy/provenance rather than letting it burden the active contract
+8. clarify or propose clarifying ownership and purpose without inserting broad law blocks into unrelated sections
+9. keep the change bounded to the authority surface under review
+10. verify that the result reduces ambiguity for future changes and preserves standalone readability where the repo is public
+
+## Contracts
+- authoritative sources should be visible and named explicitly
+- overview documents should not silently replace canonical ones
+- lightweight entrypoint docs should link outward instead of duplicating chronology or changing counters
+- active behavior should live in active surfaces; legacy and provenance should preserve lineage without becoming the first route
+- generated, exported, compact, and derived surfaces should remain subordinate to source-authored files
+- public portable surfaces should not require a full local ecosystem deployment to make sense, even when project-owner routes are linked
+- role separation should reduce confusion, not create extra ceremony
+- the resulting guidance should be understandable to another human or agent
+
+## Risks and anti-patterns
+- over-formalizing a tiny docs surface
+- creating many labels without reducing ambiguity
+- moving truth across files without clearly signaling the change
+- letting summaries masquerade as canonical instructions
+- trimming top-level docs too aggressively before canonical homes are actually available
+- widening the skill into generic docs hygiene or derived surface maintenance
+- treating provenance as trash archive, or treating raw legacy as the active contract
+- inserting direct law/local-form blocks everywhere instead of making the existing route surface clearer
+- hiding sibling-owner authority inside a local docs surface because the local repo is nearby
+- letting a generated, compact, installed, or runtime convenience surface override the authored source it describes
+
+## Verification
+- confirm the main source-of-truth ambiguity was reduced
+- confirm authoritative files are named explicitly
+- confirm overlaps or conflicts were surfaced rather than hidden
+- confirm summary docs stay short and route detail to canonical homes where those already exist
+- confirm active, legacy/provenance, generated, and decision surfaces keep distinct roles when they are involved
+- confirm generated, exported, compact, installed, and runtime receipt surfaces remain weaker than their source owners
+- confirm public portable surfaces remain understandable without hidden local system knowledge
+- confirm the result helps future contributors orient faster
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0013 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/instruction-surface/single-source-rule-distribution/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0002 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/source-of-truth-layout/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0009 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/instruction/docs-boundary/lightweight-status-snapshot/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+
+## Adaptation points
+Future project overlays may add:
+- local doc hierarchies
+- mixed ADR, architecture, and operations doc maps that split authority by concern
+- preferred canonical-file patterns
+- local review rules for doc changes
+- repository-specific examples of authoritative surfaces
+- lightweight snapshot rules for README or MANIFEST surfaces
+- rules for keeping entrypoint docs short once deeper canonical homes already exist
+- legacy/provenance placement rules and generated-surface rebuild checks
+- local authority examples from `references/authority-surface-shapes.md`

--- a/.agents/skills/aoa-source-of-truth-check/agents/openai.yaml
+++ b/.agents/skills/aoa-source-of-truth-check/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA Source Of Truth Check
+  short_description: Clarify authoritative docs
+  default_prompt: Use $aoa-source-of-truth-check to map which files are authoritative, surface overlaps, and keep top-level guidance short and link-driven.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-source-of-truth-check/assets/large-logo.svg
+++ b/.agents/skills/aoa-source-of-truth-check/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-source-of-truth-check/assets/small-logo.svg
+++ b/.agents/skills/aoa-source-of-truth-check/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-source-of-truth-check/references/authority-surface-shapes.md
+++ b/.agents/skills/aoa-source-of-truth-check/references/authority-surface-shapes.md
@@ -1,0 +1,50 @@
+# Authority Surface Shapes
+
+Use this reference when source-of-truth ambiguity is wider than ordinary docs.
+It is not a checklist. Pick the smallest shape that names one concern, one
+authoritative source, weaker companion surfaces, and one verification path.
+
+## How To Use
+
+1. Name the concern readers are confused about.
+2. Name every surface that appears to carry authority for that concern.
+3. Choose the narrowest authority shape below.
+4. State which surface is authoritative and what the others are allowed to do.
+5. Verify that future readers can follow the route without hidden local context.
+
+## Shape Set
+
+| Shape | Authoritative For | Weaker Surfaces | Common Failure | Verify |
+|---|---|---|---|---|
+| Overview to canonical detail | Orientation, start route, public entry, or quick status. | README, MANIFEST, START_HERE, index docs, route cards. | Overview silently becomes the real manual. | Overview names canonical homes and stays short. |
+| Source, config, schema, or manifest | Runtime behavior, allowed values, validation shape, registry identity. | Generated docs, examples, reports, compact catalogs, installed copies. | Generated summary overrides source-owned fields. | Source path is named; generated surfaces rebuild from it. |
+| Operations or runbook | How to run, deploy, recover, rotate, or inspect a live surface. | README snippets, issue notes, incident history, one-off terminal logs. | Historical incident text becomes current run guidance. | Runbook owns current commands; history links outward. |
+| Generated, exported, compact, or installed | Derived transport, routing aid, release artifact, compatibility view. | Catalogs, exports, installed skill copies, compact indexes, SDK reports. | Derived surface is treated as authoring truth. | Builder/source owner is named; no-drift or rebuild check passes. |
+| Legacy, provenance, or history | Lineage, receipts, preserved raw material, audit trail. | Active contracts, roadmap, tutorial docs, generated indexes. | Raw old wording becomes active instruction. | Active path links to provenance without copying legacy law into it. |
+| Decision, ADR, or review note | Why a choice was made, reviewed gate result, rationale and alternatives. | README, roadmap, changelog, code comment, generated report. | Rationale is hidden in status prose or mistaken for current procedure. | Decision surface is linked where future maintainers need the why. |
+| Public entrypoint with project overlay | Portable public meaning plus route to local owner context. | Local runtime paths, ecosystem-only names, downstream mirrors. | Public surface requires private deployment knowledge to make sense. | Public text stands alone and links owner context as extra depth. |
+| Sibling or downstream owner context | Which repo, organ, or layer owns meaning outside the local surface. | Local summaries, bridge notes, generated cross-repo indexes. | Nearby local file captures authority that belongs to another owner. | Owner route is explicit; local file stays a pointer or consumer. |
+| Status, roadmap, or changelog | Current direction, planned movement, shipped changes, or open follow-up. | README counters, old plans, release reports, checkpoint notes. | Status documents accumulate history that belongs elsewhere. | Current status is short; history and detailed plans have named homes. |
+
+## Compact Authority Pass
+
+| Field | Answer |
+|---|---|
+| Concern |  |
+| Candidate authority surfaces |  |
+| Shape selected |  |
+| Authoritative source |  |
+| Weaker companions |  |
+| Consumer/downstream surfaces |  |
+| Conflict or stale route |  |
+| Verification path |  |
+
+## Verification
+
+- the authoritative surface is named in plain language
+- weaker surfaces are allowed to orient, summarize, transport, or preserve
+  evidence without becoming source truth
+- generated, exported, compact, installed, and runtime receipt surfaces remain
+  subordinate to authored sources
+- public surfaces remain understandable without hidden deployment knowledge
+- sibling or downstream owner context is linked without being swallowed locally

--- a/.agents/skills/aoa-tdd-slice
+++ b/.agents/skills/aoa-tdd-slice
@@ -1,1 +1,0 @@
-/srv/AbyssOS/aoa-skills/.agents/skills/aoa-tdd-slice

--- a/.agents/skills/aoa-tdd-slice/SKILL.md
+++ b/.agents/skills/aoa-tdd-slice/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: aoa-tdd-slice
+description: Implement a bounded feature slice through test-first discipline, minimal implementation, and explicit refactor boundaries. Use when a behavior change can be specified in tests before code and confidence or regression resistance matters. Do not use for undefined exploratory work, one-off glue, or broader architectural restructuring.
+license: Apache-2.0
+compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
+metadata:
+  aoa_scope: core
+  aoa_status: canonical
+  aoa_invocation_mode: explicit-preferred
+  aoa_source_skill_path: skills/core/engineering/aoa-tdd-slice/SKILL.md
+  aoa_source_repo: 8Dionysus/aoa-skills
+  aoa_technique_dependencies: AOA-T-0014,AOA-T-0001
+  aoa_portable_profile: codex-facing-wave-3
+---
+
+# aoa-tdd-slice
+
+## Intent
+Use test-first discipline to implement a small behavior slice with a clear observable target, minimal implementation, and explicit verification.
+
+## Trigger boundary
+Use this skill when:
+- a behavior change can be expressed as tests before implementation
+- a module, CLI, builder, parser, validator, schema check, generated/export path, adapter, router, or workflow step has observable behavior that can be specified before implementation
+- the task fits a bounded slice rather than a broad rewrite
+- confidence and regression resistance matter enough to justify a red-green-refactor loop
+
+Do not use this skill when:
+- the task is purely exploratory and behavior is still undefined
+- the task is mostly one-off glue with no reusable logic
+- the main problem is a stable interface or boundary contract rather than a feature slice; use `aoa-contract-test`
+- the main problem is invariant coverage rather than slice implementation; use `aoa-property-invariants`
+- the main problem is source-of-truth, ownership, or guidance authority rather than observable behavior; use `aoa-source-of-truth-check`
+- the behavior cannot be observed without broad architecture work, long-running discovery, or a new proof strategy
+- broader architectural restructuring is the real need
+
+## Inputs
+- desired behavior
+- target module, command, builder, validator, adapter, generated/export path, or workflow step
+- constraints and non-goals
+- available test surface
+- fixture, golden, schema, fake adapter, CLI, or focused smoke surface when relevant
+
+## Outputs
+- new or updated tests
+- minimal implementation
+- small refactor if needed
+- verification summary
+- explicit slice boundary and untouched behavior
+
+## Procedure
+1. define the desired behavior in a bounded way
+2. when the behavior is wider than a simple module change, choose the smallest useful shape from `references/tdd-slice-shapes.md`
+3. add or update tests before implementation
+4. make the smallest change that satisfies the tests
+5. refactor only inside the declared slice after the behavior is green
+6. run the tests and record the result
+7. report what behavior is now specified, what surface was intentionally untouched, and what remains out of scope
+
+## Contracts
+- behavior should be made explicit before implementation when reasonably possible
+- the implementation should stay bounded to the slice
+- unrelated refactors should be avoided
+- tests should express behavior, not incidental implementation detail
+- generated/export behavior should be tested through the source-owned builder or fixture path, not by hand-editing derived output
+- workflow or CLI behavior should test the stable machine-readable contract, exit state, or observable route rather than incidental log prose
+- refactor work should start only after the focused behavior check is green
+
+## Risks and anti-patterns
+- writing tests that merely mirror the implementation
+- turning a small slice into a hidden architectural rewrite
+- using TDD ritualistically where the problem is not well-shaped yet
+- overfitting tests to brittle internal details
+- treating snapshot churn, generated file bytes, or current sort order as the behavior unless consumers rely on it
+- adding a broad fixture matrix before the slice has one clear target behavior
+
+## Verification
+- confirm tests were added or updated first when the task was suitable for TDD
+- confirm the implementation stayed bounded
+- confirm the relevant test suite passed
+- confirm the report names the covered behavior and the untouched behavior
+- confirm any generated/export or workflow assertion still points back to the source-owned behavior under test
+
+## Technique traceability
+Manifest-backed techniques:
+- AOA-T-0014 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/tdd-slice/TECHNIQUE.md` and sections: Intent, When to use, Inputs, Outputs, Core procedure, Contracts, Risks, Validation
+- AOA-T-0001 from `8Dionysus/aoa-techniques` at `cd276f040d55d490bd015b8698c7a5d594b9f875` using path `techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md` and sections: Contracts, Validation
+
+## Adaptation points
+Project overlays should add:
+- local test commands
+- local module boundaries
+- guidance for when TDD is mandatory versus optional
+- local CLI, builder, validator, adapter, generated/export, or workflow examples from `references/tdd-slice-shapes.md`
+- local rules for when fixtures, snapshots, or golden files are stable enough to test

--- a/.agents/skills/aoa-tdd-slice/agents/openai.yaml
+++ b/.agents/skills/aoa-tdd-slice/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: AoA TDD Slice
+  short_description: Build slices test-first
+  default_prompt: Use $aoa-tdd-slice to define behavior in tests first, make the smallest implementation change, and report what stays out of scope.
+  icon_small: ./assets/small-logo.svg
+  icon_large: ./assets/large-logo.svg
+  brand_color: '#2563EB'
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/aoa-tdd-slice/assets/large-logo.svg
+++ b/.agents/skills/aoa-tdd-slice/assets/large-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-tdd-slice/assets/small-logo.svg
+++ b/.agents/skills/aoa-tdd-slice/assets/small-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="32" height="32" fill="none" role="img" aria-label="core skill icon">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#2563EB"/>
+<path d="M18 23 H46" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M18 32 H46" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.95"/>
+  <path d="M18 41 H38" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+</svg>

--- a/.agents/skills/aoa-tdd-slice/references/tdd-slice-shapes.md
+++ b/.agents/skills/aoa-tdd-slice/references/tdd-slice-shapes.md
@@ -1,0 +1,49 @@
+# TDD Slice Shapes
+
+Use this reference when the test-first slice is wider than a simple function or
+method change. It is not a checklist. Pick the smallest shape that names one
+observable behavior, one red check, one minimal green implementation, and one
+refactor stop-line.
+
+## How To Use
+
+1. Name the behavior in terms a consumer or maintainer can observe.
+2. Choose the narrowest slice shape below.
+3. Write the red check before changing implementation.
+4. Make the smallest green change.
+5. Refactor only inside the declared slice after the check passes.
+
+## Shape Set
+
+| Shape | Red Check | Minimal Green | Refactor Boundary | Avoid | Verify |
+|---|---|---|---|---|---|
+| Pure module behavior | Unit or focused regression test for input, output, error, or state. | Change the smallest rule or branch. | The module or function under test. | Testing private helper choreography. | Focused unit tests plus relevant existing suite. |
+| CLI or tool behavior | Command invocation, exit code, machine-readable report, or stable stderr/stdout contract. | Add the flag, parser branch, or report field. | Command handler and report shape only. | Freezing incidental log prose. | CLI test with success and failure path when useful. |
+| Parser, validator, schema, or manifest | Valid and invalid fixture that names the accepted or rejected shape. | Add the narrow validation or parse rule. | Parser/validator and fixture set. | Treating current formatting as semantic behavior. | Fixture test plus schema or invalid-case failure. |
+| Builder or generated/export path | Source fixture rebuilds one derived artifact or detects no-drift. | Update source-to-output mapping, not derived output by hand. | Builder and source fixture. | Making generated artifacts the source of truth. | Rebuild/no-drift check plus focused assertion. |
+| Router or selection behavior | Equivalent inputs route the same; decisive signal changes route. | Add or adjust the small selection rule. | Router rule and its fixtures. | Encoding incidental ordering as law. | Permutation or tie-break test with claim limit. |
+| Adapter or facade behavior | Fake adapter or facade test for one observable dependency interaction. | Add the narrow port call or mapping. | Facade/adapter seam already chosen. | Redesigning the dependency boundary mid-slice. | Fake plus one smoke if the real adapter is cheap and available. |
+| Workflow or gate behavior | Minimal route trial, state transition, receipt field, or stop condition. | Add the narrow phase, gate, or receipt rule. | Workflow step and receipt/report fields. | Turning one slice into a whole process rewrite. | Focused workflow test plus negative skip case when relevant. |
+| Regression repair | Failing test that reproduces the observed break. | Fix the smallest behavior that makes the regression pass. | Fault-local code and tests. | Broad cleanup before the regression is pinned. | Regression test stays in suite and explains the behavior. |
+
+## Compact Slice Pass
+
+| Field | Answer |
+|---|---|
+| Observable behavior |  |
+| Shape selected |  |
+| Red check |  |
+| Minimal green change |  |
+| Refactor boundary |  |
+| Out of scope |  |
+| Existing checks to rerun |  |
+| Claim limit |  |
+
+## Verification
+
+- the first failing check constrains consumer-visible or maintainer-visible
+  behavior
+- the green change is smaller than a redesign
+- generated/export assertions point back to source-owned builder behavior
+- snapshots or goldens are treated as stable only when consumers rely on them
+- the closeout names both covered behavior and untouched behavior


### PR DESCRIPTION
## Summary
- installs the portable AoA skill foundation into the repository-local `.agents/skills` surface
- materializes reviewable copy-mode skill directories instead of symlink installs
- keeps the broader project foundation available from the repository entry plane

## Verification
- workspace skill adoption audit: missing=0 drift=0 across rollout targets
- symlink scan: 0 skill symlinks across install roots
- git diff --check passed across rollout repositories