### PR TITLE
[codex] Preserve dry run helper malformed shapes

### DIFF
--- a/.agents/skills/aoa-dry-run-first/scripts/dry_run_contract.py
+++ b/.agents/skills/aoa-dry-run-first/scripts/dry_run_contract.py
@@ -50,18 +50,21 @@ def _command(step: dict[str, Any]) -> str:
 
 
 def build_contract(payload: dict[str, Any]) -> dict[str, Any]:
-    raw_preview_steps = payload.get("preview_steps") or []
+    raw_preview_steps = payload["preview_steps"] if "preview_steps" in payload else []
     preview_steps = raw_preview_steps if isinstance(raw_preview_steps, list) else []
-    raw_apply_step = payload.get("apply_step") or {}
+    raw_apply_step = payload["apply_step"] if "apply_step" in payload else {}
     apply_step = raw_apply_step if isinstance(raw_apply_step, Mapping) else {}
-    limitations = payload.get("limitations") or []
+    raw_limitations = payload["limitations"] if "limitations" in payload else []
+    limitations = raw_limitations if isinstance(raw_limitations, list) else []
     warnings: list[str] = []
     errors: list[str] = []
 
     if not isinstance(raw_preview_steps, list):
         errors.append("preview_steps must be a list.")
-    if raw_apply_step and not isinstance(raw_apply_step, Mapping):
+    if not isinstance(raw_apply_step, Mapping):
         errors.append("apply_step must be an object.")
+    if not isinstance(raw_limitations, list):
+        errors.append("limitations must be a list.")
     if not preview_steps:
         errors.append("No preview_steps were provided.")
     if not apply_step:

--- a/.agents/skills/aoa-dry-run-first/scripts/preview_gap_check.py
+++ b/.agents/skills/aoa-dry-run-first/scripts/preview_gap_check.py
@@ -18,9 +18,14 @@ def _load_payload(path: str | None) -> dict[str, Any]:
 
 
 def check_gaps(payload: dict[str, Any]) -> dict[str, Any]:
-    raw_preview_steps = payload.get("preview_steps") or []
-    apply_step = payload.get("apply_step") or {}
-    limitations = payload.get("limitations") or payload.get("honest_boundaries") or []
+    raw_preview_steps = payload["preview_steps"] if "preview_steps" in payload else []
+    apply_step = payload["apply_step"] if "apply_step" in payload else {}
+    if "limitations" in payload:
+        raw_limitations = payload["limitations"]
+    elif "honest_boundaries" in payload:
+        raw_limitations = payload["honest_boundaries"]
+    else:
+        raw_limitations = []
 
     gaps: list[str] = []
     notes: list[str] = []
@@ -36,6 +41,10 @@ def check_gaps(payload: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(apply_step, dict):
         gaps.append("apply-step-not-object")
         apply_step = {}
+    if not isinstance(raw_limitations, list):
+        gaps.append("limitations-not-list")
+        raw_limitations = []
+    limitations = raw_limitations
 
     apply_command = str(apply_step.get("command", "")).strip()
     if not preview_steps:


### PR DESCRIPTION
Changes:
- updates the installed aoa-dry-run-first helper scripts so falsy malformed preview_steps, apply_step, and limitations values stay visible as structured JSON failures instead of being coerced to empty defaults.

Validation:
- workspace malformed-shape smoke across 14 repositories and /srv/AbyssOS/.agents for preview_gap_check.py and dry_run_contract.py returned structured fail JSON with no stderr.

Risk:
- scoped to the portable .agents helper copies only; no repository source doctrine or workflow files changed.
