### PR TITLE
[codex] close template modernization long pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- closed the template modernization long pass across all `107` current bundles,
+  preserving the `proof/skill-support` pilot as the only source-shape repair
+  cohort, recording `104` held-no-repair rows, accepting no new
+  `TECHNIQUE.md` rewrites, no route-to-other-lane tails, no schema,
+  frontmatter, path, relation, support-file, validator, generated-surface, or
+  empirical small-agent proof changes, and keeping `Atomic move`,
+  `Topology fit`, and `Small-agent execution shape` as optional fixed-slot
+  sections rather than required corpus law
 - started the template modernization lane with a bounded
   `proof/skill-support` pilot, adding explicit `Atomic move`, `Topology fit`,
   and `Small-agent execution shape` sections to `AOA-T-0015`, `AOA-T-0016`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,8 +220,8 @@ Previous review breadcrumb preserved for parity: Run the `proof/owner-truth-clos
 
 | Field | Direction |
 |---|---|
-| Current posture | Capsules and generated catalogs already provide compact lookup surfaces, and the first template-modernization pilot has started over `proof/skill-support` by making the atom, topology fit, and small-agent execution shape explicit in source with optional fixed-slot validator support. |
-| Next honest move | Expand template modernization only through direct-read cohorts where the source shape materially improves `pick -> inspect -> execute`; review generated parity before any broader wave. |
+| Current posture | Capsules and generated catalogs already provide compact lookup surfaces; the template-modernization long pass is closed across all `107` current bundles with `3` pilot-repaired `proof/skill-support` leaves, `104` held-no-repair rows, no new source rewrites, and optional fixed-slot sections still rejected as a required corpus migration. |
+| Next honest move | Move from template-shape review to concrete content-level technique reform only where direct bundle reading finds a real source, selector, relation, portability, owner-boundary, or execution-shape problem. |
 | Guardrail | Small-agent usability does not mean autonomous selection; routing and composition may belong to larger agents or neighboring layers. |
 
 ## Horizon: Mechanics To Canon

--- a/mechanics/distillation/parts/technique-reform-ingress/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/README.md
@@ -747,21 +747,24 @@ source repair, accepts no owner-boundary relation repair, marks the temporary
 plan superseded, and routes the next technique-reform lane toward a small
 template modernization pilot rather than another broad boundary audit.
 
-Current latest template modernization pilot: `proof/skill-support` is the first
-source-shape cohort. `AOA-T-0015`, `AOA-T-0016`, and `AOA-T-0017` now expose
-explicit `Atomic move`, `Topology fit`, and `Small-agent execution shape`
-sections while preserving frontmatter, paths, relations, support files,
-template contracts, sibling-skill boundaries, and empirical-proof routing. The
-validator accepts these as optional fixed-slot template-modernization sections
-instead of turning them into a full-corpus required-section migration.
+Current latest template modernization closeout: the long pass is closed across
+all `107` current bundles. It preserves the `proof/skill-support` pilot as the
+only source-shape repair cohort, records `104` held-no-repair rows across the
+remaining corpus, accepts no new `TECHNIQUE.md` source rewrite, accepts no
+route-to-other-lane tails, changes no frontmatter, paths, relations, support
+files, schema, validator, or generated surfaces, and rejects required-section
+migration. The optional sections remain available only for future
+bundle-local repair when direct source reading proves that they materially
+improve `pick -> inspect -> execute`.
 
-Next clean move: review this pilot's generated parity and start the template
-modernization long pass from direct evidence, not from a global
-`old-template-watch` rewrite. Do not stop after the first comfortable cohort,
-do not restart portability or owner-boundary as broad audits, do not add future
-relation names such as `follows`, do not promote scout axes into frontmatter
-without a separate decision and validator wave, and do not run local
-small-agent proof without an `aoa-evals` proof surface.
+Next clean move: leave template modernization as a closed lane and move toward
+concrete content-level technique reform only when a chosen bundle or shelf has
+an actual source, selector, relation, portability, owner-boundary, or
+execution-shape problem. Do not restart the broad template pass, do not turn
+optional sections into corpus law, do not add future relation names such as
+`follows`, do not promote scout axes into frontmatter without a separate
+decision and validator wave, and do not run local small-agent proof without an
+`aoa-evals` proof surface.
 
 The first pilot migration has moved exactly `AOA-T-0051`, `AOA-T-0052`, and
 `AOA-T-0054` into `techniques/continuity/review-compaction/` without changing

--- a/mechanics/distillation/parts/technique-reform-ingress/TEMP_TEMPLATE_MODERNIZATION_LONG_PASS_PLAN.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/TEMP_TEMPLATE_MODERNIZATION_LONG_PASS_PLAN.md
@@ -2,8 +2,8 @@
 
 Source packet: [Technique Reform Ingress](README.md)
 
-Status: active temporary rhythm plan. It becomes superseded only after a
-template-modernization long-pass closeout ledger lands.
+Status: superseded temporary rhythm plan. The durable closeout is
+[Template Modernization Long-Pass Closeout Ledger](reviews/template-modernization-long-pass-closeout-ledger.md).
 
 This file replaces the too-small first expansion framing. The long pass is one
 continuous corpus pass with internal shelves and phases for reviewability. The
@@ -184,17 +184,17 @@ Use this loop for every bundle, including holds:
 
 ## Full Phase Status
 
-- [ ] Phase 0: base and pilot landing gate
-- [ ] Phase 1: full-corpus inventory and triage ledger
-- [ ] Phase 2: proof trunk review and repairs
-- [ ] Phase 3: execution trunk review and repairs
-- [ ] Phase 4: continuity trunk review and repairs
-- [ ] Phase 5: instruction trunk review and repairs
-- [ ] Phase 6: knowledge, history, ingest, and tool-use review and repairs
-- [ ] Phase 7: governance trunk review and repairs
-- [ ] Phase 8: recovery trunk review and repairs
-- [ ] Phase 9: generated parity, residual scan, and tail closure
-- [ ] Phase 10: long-pass closeout ledger and next-lane decision
+- [x] Phase 0: base and pilot landing gate
+- [x] Phase 1: full-corpus inventory and triage ledger
+- [x] Phase 2: proof trunk review and repairs
+- [x] Phase 3: execution trunk review and repairs
+- [x] Phase 4: continuity trunk review and repairs
+- [x] Phase 5: instruction trunk review and repairs
+- [x] Phase 6: knowledge, history, ingest, and tool-use review and repairs
+- [x] Phase 7: governance trunk review and repairs
+- [x] Phase 8: recovery trunk review and repairs
+- [x] Phase 9: generated parity, residual scan, and tail closure
+- [x] Phase 10: long-pass closeout ledger and next-lane decision
 
 ## Phase 0: Base And Pilot Landing Gate
 
@@ -684,3 +684,6 @@ Use this section during execution. Keep notes short and evidence-linked.
 
 - Corrected from an insufficient first expansion plan into a full current-corpus
   long-pass plan.
+- Closed as a full current-corpus review: `107/107` bundles covered,
+  `3` pilot-repaired, `104` held without new source repair, `0`
+  route-to-other-lane tails, `0` generated surfaces changed.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/README.md
@@ -125,5 +125,15 @@ Current reviews:
 - [owner-boundary-bridge-residual-cross-wave-scan](owner-boundary-bridge-residual-cross-wave-scan.md)
 - [owner-boundary-bridge-long-pass-closeout-ledger](owner-boundary-bridge-long-pass-closeout-ledger.md)
 - [template-modernization-skill-support-pilot](template-modernization-skill-support-pilot.md)
+- [template-modernization-long-pass-corpus-triage](template-modernization-long-pass-corpus-triage.md)
+- [template-modernization-long-pass-proof-review](template-modernization-long-pass-proof-review.md)
+- [template-modernization-long-pass-execution-review](template-modernization-long-pass-execution-review.md)
+- [template-modernization-long-pass-continuity-review](template-modernization-long-pass-continuity-review.md)
+- [template-modernization-long-pass-instruction-review](template-modernization-long-pass-instruction-review.md)
+- [template-modernization-long-pass-knowledge-history-ingest-tool-review](template-modernization-long-pass-knowledge-history-ingest-tool-review.md)
+- [template-modernization-long-pass-governance-review](template-modernization-long-pass-governance-review.md)
+- [template-modernization-long-pass-recovery-review](template-modernization-long-pass-recovery-review.md)
+- [template-modernization-long-pass-residual-scan](template-modernization-long-pass-residual-scan.md)
+- [template-modernization-long-pass-closeout-ledger](template-modernization-long-pass-closeout-ledger.md)
 
 These files are review packets, not generated reports and not bundle authority.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-closeout-ledger.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-closeout-ledger.md
@@ -1,0 +1,94 @@
+# Template Modernization Long-Pass Closeout Ledger
+
+Status: closed durable review memory for the template-modernization long pass.
+
+This ledger supersedes
+[`TEMP_TEMPLATE_MODERNIZATION_LONG_PASS_PLAN.md`](../TEMP_TEMPLATE_MODERNIZATION_LONG_PASS_PLAN.md).
+
+## Summary
+
+The long pass reviewed the full current corpus of `107` technique bundles after
+the `proof/skill-support` pilot. It accepted no new source edits.
+
+The result is intentionally conservative: template modernization remains a
+bundle-local repair tool, not a full-corpus rewrite.
+
+## Final Counts
+
+| class | count |
+|---|---:|
+| total bundles covered | 107 |
+| shelves covered | 28 |
+| trunks covered | 10 |
+| pilot-repaired bundles | 3 |
+| held-no-repair bundles | 104 |
+| new source repairs in this long pass | 0 |
+| route-to-other-lane tails | 0 |
+| generated surfaces changed | 0 |
+| frontmatter/path/relation changes | 0 |
+
+## Durable Decision
+
+Optional fixed-slot sections remain allowed:
+
+- `Atomic move`
+- `Topology fit`
+- `Small-agent execution shape`
+
+They remain optional. They should be added only when direct bundle reading
+shows that the current required sections hide the atom, input packet, output
+shape, or stop-line.
+
+Required-section migration remains rejected.
+
+## Why No Broad Rewrite
+
+The non-pilot bundles already expose a usable execution shape through required
+sections, checklists, examples, and provenance or readiness notes. Adding three
+new headings everywhere would mostly duplicate existing source meaning and
+would make the corpus look more uniform at the cost of more noise.
+
+The `proof/skill-support` pilot remains valid because those three bundles had
+real skill-adjacent ambiguity. The rest of the corpus did not show equivalent
+bundle-local pressure during this pass.
+
+## Packets Landed By This Pass
+
+- [`template-modernization-long-pass-corpus-triage.md`](template-modernization-long-pass-corpus-triage.md)
+- [`template-modernization-long-pass-proof-review.md`](template-modernization-long-pass-proof-review.md)
+- [`template-modernization-long-pass-execution-review.md`](template-modernization-long-pass-execution-review.md)
+- [`template-modernization-long-pass-continuity-review.md`](template-modernization-long-pass-continuity-review.md)
+- [`template-modernization-long-pass-instruction-review.md`](template-modernization-long-pass-instruction-review.md)
+- [`template-modernization-long-pass-knowledge-history-ingest-tool-review.md`](template-modernization-long-pass-knowledge-history-ingest-tool-review.md)
+- [`template-modernization-long-pass-governance-review.md`](template-modernization-long-pass-governance-review.md)
+- [`template-modernization-long-pass-recovery-review.md`](template-modernization-long-pass-recovery-review.md)
+- [`template-modernization-long-pass-residual-scan.md`](template-modernization-long-pass-residual-scan.md)
+
+## Next Direction
+
+Do not continue template modernization as a broad lane.
+
+Next work should move toward actual technique reform only when a chosen bundle
+or shelf has a real content, selector, relation, portability, owner-boundary, or
+execution-shape problem. If a future direct read finds one, repair that bundle
+locally and let the optional sections serve the repair instead of driving it.
+
+Good next posture:
+
+1. choose a concrete shelf or trunk for content-level reform;
+2. direct-read bundle source and support files;
+3. repair wording, examples, relations, or optional sections only where the
+   actual bundle is unclear;
+4. preserve the rest as held-no-repair.
+
+## Validation
+
+Final validation is recorded in closeout reporting rather than this source
+packet. The required final checks are:
+
+- `git diff --check`
+- public-safety grep over touched public surfaces
+- bridge-block grep over touched public surfaces
+- `python -m unittest tests.test_distillation_mechanics_topology`
+- `python scripts/validate_repo.py`
+- `python -m unittest discover -s tests`

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-continuity-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-continuity-review.md
@@ -1,0 +1,57 @@
+# Template Modernization Long-Pass Continuity Review
+
+Status: closed Phase 4 continuity-trunk review.
+
+This packet covers all `14` continuity-trunk bundles. It accepts no source
+repair.
+
+## Evidence Read
+
+- `techniques/continuity/AGENTS.md`
+- all continuity-trunk `TECHNIQUE.md` sources
+- continuity-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `review-compaction`,
+  `handoff-continuation`, and `donor-harvest`
+- topology-selector, relations/composition, portability, owner-boundary,
+  execution-profile, and bundle-anatomy packets touching continuity surfaces
+
+## Verdict
+
+Continuity bundles already carry visible handoff, receipt, compaction,
+resource-map, donor, and progression objects through standard source sections
+and minimal examples. The old template shape does not hide the atom. Source
+rewrite would mostly duplicate existing `Intent`, `Inputs`, `Outputs`, and
+`Core procedure` language.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0051 | `continuity/review-compaction` | `commit-triggered-background-review` | held-no-repair | post-commit review artifact is already explicit |
+| AOA-T-0052 | `continuity/review-compaction` | `review-findings-compaction` | held-no-repair | stale-finding compaction atom is clear from source and example |
+| AOA-T-0054 | `continuity/review-compaction` | `compaction-resilient-skill-loading` | held-no-repair | skill reload boundary is already bounded against context reconstruction |
+| AOA-T-0056 | `continuity/handoff-continuation` | `channelized-agent-mailbox` | held-no-repair | durable channel object is explicit without messaging-platform doctrine |
+| AOA-T-0057 | `continuity/handoff-continuation` | `structured-handoff-before-compaction` | held-no-repair | handoff artifact shape is already named by source and example |
+| AOA-T-0058 | `continuity/handoff-continuation` | `receipt-confirmed-handoff-packet` | held-no-repair | receipt state and transfer boundary are already visible |
+| AOA-T-0059 | `continuity/handoff-continuation` | `git-verified-handoff-claims` | held-no-repair | git evidence check already names its stop-line |
+| AOA-T-0060 | `continuity/handoff-continuation` | `session-opening-ritual-before-work` | held-no-repair | opening read-and-verify move is already small-agent legible |
+| AOA-T-0061 | `continuity/handoff-continuation` | `cross-repo-resource-map-bootstrap` | held-no-repair | resource-map bootstrap is portable and bounded |
+| AOA-T-0062 | `continuity/handoff-continuation` | `episode-bounded-agent-loop` | held-no-repair | episode checkpoint loop is explicit without autonomous runtime supervision |
+| AOA-T-0075 | `continuity/donor-harvest` | `session-donor-harvest` | held-no-repair | donor pack lift is already bounded against memory truth |
+| AOA-T-0077 | `continuity/donor-harvest` | `harvest-packet-contract` | held-no-repair | packet contract fields and downstream seams are explicit |
+| AOA-T-0084 | `continuity/donor-harvest` | `progression-evidence-lift` | held-no-repair | progression delta is descriptive and evidence-backed in current source |
+| AOA-T-0085 | `continuity/donor-harvest` | `multi-axis-quest-overlay` | held-no-repair | overlay role is bounded against quest/playbook authority |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 14 |
+| long-pass source repairs | 0 |
+| held-no-repair | 14 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to the instruction trunk. Do not convert continuity stop-lines into
+new memory, checkpoint, or role doctrine.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-corpus-triage.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-corpus-triage.md
@@ -1,0 +1,191 @@
+# Template Modernization Long-Pass Corpus Triage
+
+Status: closed Phase 1 triage for the template-modernization long pass.
+
+This packet reviews the full current corpus before any broad source rewrite.
+It is a review ledger, not bundle authority, not generated output, not
+frontmatter migration authority, and not empirical small-agent proof.
+
+## Question
+
+Does the corpus need a full source-shape rewrite after the
+`proof/skill-support` pilot, or should the long pass proceed by direct review
+and only repair bundles where the current source shape materially hides the
+atomic move, input packet, output shape, or stop-line?
+
+## Evidence Read
+
+- root, mechanics, distillation, parts, and techniques route cards
+- `docs/TECHNIQUE_ATOM_CONTRACT.md`
+- `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
+- `TEMP_TEMPLATE_MODERNIZATION_LONG_PASS_PLAN.md`
+- all `107` current `TECHNIQUE.md` source headings and frontmatter summaries
+- checklist, example, and note skeletons for all `107` bundles
+- prior migration, bundle-anatomy, execution-profile, selector/relation,
+  portability, owner-boundary, and template-modernization packets
+
+## Triage Result
+
+The old template is not automatically a defect.
+
+All non-pilot bundles still expose the normal executable source shape:
+
+- `Intent`
+- `When to use`
+- `When not to use`
+- `Inputs`
+- `Outputs`
+- `Core procedure`
+- `Contracts`
+- `Risks`
+- `Validation`
+
+Every non-pilot bundle has at least one checklist and one example. Most also
+carry origin, readiness, adaptation, import, or adverse-effect notes. The
+source shape therefore remains executable once an orchestrator has selected the
+technique and packed local context.
+
+The three `proof/skill-support` pilot repairs remain valid because those
+bundles sit next to sibling skill workflows and benefited from making the atom,
+topology fit, and small-agent packet explicit. That pressure does not repeat
+uniformly across the rest of the corpus.
+
+## Counts
+
+| class | count |
+|---|---:|
+| total bundles | 107 |
+| pilot-repaired | 3 |
+| needs phase review | 104 |
+| immediate full-corpus source rewrite candidates | 0 |
+| route-away candidates | 0 |
+
+## Phase Route
+
+| phase | surface | bundles | initial posture |
+|---|---|---:|---|
+| 2 | `proof` | 18 | pilot calibration plus proof-adjacent hold review |
+| 3 | `execution` | 14 | hold review against scheduler/runtime/orchestration drift |
+| 4 | `continuity` | 14 | hold review against memory/checkpoint/role drift |
+| 5 | `instruction` | 19 | hold review against skill, source-truth, and capability drift |
+| 6 | `knowledge-lift`, `history`, `ingest`, `tool-use` | 20 | hold review against KAG, artifact, media, and tool-platform drift |
+| 7 | `governance` | 14 | hold review against route, approval, promotion, and automation drift |
+| 8 | `recovery` | 8 | hold review against incident, runtime, and self-repair drift |
+
+## Bundle Rows
+
+| id | shelf | bundle | triage |
+|---|---|---|---|
+| AOA-T-0001 | `execution/agent-workflows-core` | `plan-diff-apply-verify-report` | phase-review |
+| AOA-T-0002 | `instruction/docs-boundary` | `source-of-truth-layout` | phase-review |
+| AOA-T-0003 | `proof/evaluation-chain` | `contract-first-smoke-summary` | phase-review |
+| AOA-T-0004 | `execution/intent-chain` | `intent-plan-dry-run-contract-chain` | phase-review |
+| AOA-T-0005 | `execution/intent-chain` | `new-intent-rollout-checklist` | phase-review |
+| AOA-T-0006 | `proof/published-summary` | `latest-alias-plus-history-copy` | phase-review |
+| AOA-T-0007 | `proof/evaluation-chain` | `signal-first-gate-promotion` | phase-review |
+| AOA-T-0008 | `proof/published-summary` | `published-summary-remediation-snapshot` | phase-review |
+| AOA-T-0009 | `instruction/docs-boundary` | `lightweight-status-snapshot` | phase-review |
+| AOA-T-0010 | `proof/published-summary` | `telemetry-integrity-snapshot` | phase-review |
+| AOA-T-0011 | `proof/published-summary` | `required-vs-optional-source-rendering` | phase-review |
+| AOA-T-0012 | `instruction/instruction-surface` | `deterministic-context-composition` | phase-review |
+| AOA-T-0013 | `instruction/instruction-surface` | `single-source-rule-distribution` | phase-review |
+| AOA-T-0014 | `execution/agent-workflows-core` | `tdd-slice` | phase-review |
+| AOA-T-0015 | `proof/skill-support` | `contract-test-design` | pilot-repaired |
+| AOA-T-0016 | `proof/skill-support` | `bounded-context-map` | pilot-repaired |
+| AOA-T-0017 | `proof/skill-support` | `property-invariants` | pilot-repaired |
+| AOA-T-0018 | `knowledge-lift/kag-source-lift` | `markdown-technique-section-lift` | phase-review |
+| AOA-T-0019 | `knowledge-lift/kag-source-lift` | `frontmatter-metadata-spine` | phase-review |
+| AOA-T-0020 | `knowledge-lift/kag-source-lift` | `evidence-note-provenance-lift` | phase-review |
+| AOA-T-0021 | `knowledge-lift/kag-source-lift` | `bounded-relation-lift-for-kag` | phase-review |
+| AOA-T-0022 | `knowledge-lift/kag-source-lift` | `risk-and-negative-effect-lift` | phase-review |
+| AOA-T-0023 | `execution/agent-workflows-core` | `stateless-single-shot-agent` | phase-review |
+| AOA-T-0024 | `instruction/instruction-surface` | `upstream-mirroring-with-provenance` | phase-review |
+| AOA-T-0025 | `instruction/capability-registry` | `capability-spec-versioning` | phase-review |
+| AOA-T-0026 | `history/history-artifacts` | `session-capture-as-repo-artifact` | phase-review |
+| AOA-T-0027 | `instruction/instruction-surface` | `cross-agent-skill-propagation` | phase-review |
+| AOA-T-0028 | `execution/agent-workflows-core` | `confirmation-gated-mutating-action` | phase-review |
+| AOA-T-0029 | `instruction/instruction-surface` | `nested-rule-loading` | phase-review |
+| AOA-T-0030 | `instruction/instruction-surface` | `fragmented-agent-context` | phase-review |
+| AOA-T-0031 | `execution/agent-workflows-core` | `shell-composable-agent-invocation` | phase-review |
+| AOA-T-0032 | `proof/evaluation-chain` | `context-report-for-ci` | phase-review |
+| AOA-T-0033 | `instruction/docs-boundary` | `decision-rationale-recording` | phase-review |
+| AOA-T-0034 | `instruction/docs-boundary` | `public-safe-artifact-sanitization` | phase-review |
+| AOA-T-0035 | `instruction/instruction-surface` | `profile-preset-composition` | phase-review |
+| AOA-T-0036 | `execution/runtime-truth-lifecycle` | `render-truth-before-startup` | phase-review |
+| AOA-T-0037 | `execution/runtime-truth-lifecycle` | `contextual-host-doctor` | phase-review |
+| AOA-T-0038 | `execution/runtime-truth-lifecycle` | `one-command-service-lifecycle` | phase-review |
+| AOA-T-0039 | `execution/runtime-truth-lifecycle` | `baseline-first-additive-profile-benchmarks` | phase-review |
+| AOA-T-0040 | `instruction/capability-boundary` | `skill-vs-command-boundary` | phase-review |
+| AOA-T-0041 | `instruction/skill-discovery` | `skill-marketplace-curation` | phase-review |
+| AOA-T-0042 | `instruction/skill-discovery` | `upstream-skill-health-checking` | phase-review |
+| AOA-T-0043 | `instruction/capability-boundary` | `multi-source-primary-input-provenance` | phase-review |
+| AOA-T-0044 | `history/history-artifacts` | `versionable-session-transcripts` | phase-review |
+| AOA-T-0045 | `history/history-artifacts` | `witness-trace-as-reviewable-artifact` | phase-review |
+| AOA-T-0046 | `knowledge-lift/kag-source-lift` | `repo-doc-surface-lift` | phase-review |
+| AOA-T-0047 | `knowledge-lift/kag-source-lift` | `github-review-template-lift` | phase-review |
+| AOA-T-0048 | `knowledge-lift/kag-source-lift` | `semantic-review-surface-lift` | phase-review |
+| AOA-T-0049 | `execution/ready-work-graphs` | `dependency-aware-task-graph` | phase-review |
+| AOA-T-0050 | `execution/ready-work-graphs` | `ready-work-from-blocker-graph` | phase-review |
+| AOA-T-0051 | `continuity/review-compaction` | `commit-triggered-background-review` | phase-review |
+| AOA-T-0052 | `continuity/review-compaction` | `review-findings-compaction` | phase-review |
+| AOA-T-0053 | `history/history-artifacts` | `local-first-session-index` | phase-review |
+| AOA-T-0054 | `continuity/review-compaction` | `compaction-resilient-skill-loading` | phase-review |
+| AOA-T-0055 | `execution/ready-work-graphs` | `requirements-design-tasks-ladder` | phase-review |
+| AOA-T-0056 | `continuity/handoff-continuation` | `channelized-agent-mailbox` | phase-review |
+| AOA-T-0057 | `continuity/handoff-continuation` | `structured-handoff-before-compaction` | phase-review |
+| AOA-T-0058 | `continuity/handoff-continuation` | `receipt-confirmed-handoff-packet` | phase-review |
+| AOA-T-0059 | `continuity/handoff-continuation` | `git-verified-handoff-claims` | phase-review |
+| AOA-T-0060 | `continuity/handoff-continuation` | `session-opening-ritual-before-work` | phase-review |
+| AOA-T-0061 | `continuity/handoff-continuation` | `cross-repo-resource-map-bootstrap` | phase-review |
+| AOA-T-0062 | `continuity/handoff-continuation` | `episode-bounded-agent-loop` | phase-review |
+| AOA-T-0063 | `instruction/capability-registry` | `versioned-agent-registry-contract` | phase-review |
+| AOA-T-0064 | `instruction/capability-registry` | `capability-discovery` | phase-review |
+| AOA-T-0065 | `tool-use/tool-gateway` | `mcp-gateway-proxy` | phase-review |
+| AOA-T-0066 | `history/history-artifacts` | `transcript-replay-artifact` | phase-review |
+| AOA-T-0067 | `history/history-artifacts` | `transcript-linked-code-lineage` | phase-review |
+| AOA-T-0068 | `governance/approval-evidence` | `fail-closed-evidence-gate` | phase-review |
+| AOA-T-0069 | `governance/approval-evidence` | `approval-bound-durable-jobs` | phase-review |
+| AOA-T-0070 | `ingest/media-ingest` | `two-stage-document-ocr-pipeline` | phase-review |
+| AOA-T-0071 | `ingest/media-ingest` | `template-backed-field-extraction-after-ocr` | phase-review |
+| AOA-T-0072 | `ingest/media-ingest` | `perceptual-media-dedupe-with-threshold-review` | phase-review |
+| AOA-T-0073 | `ingest/media-ingest` | `semantic-media-bucketing-with-vision-plus-ocr` | phase-review |
+| AOA-T-0074 | `ingest/media-ingest` | `telegram-export-normalization-to-local-store` | phase-review |
+| AOA-T-0075 | `continuity/donor-harvest` | `session-donor-harvest` | phase-review |
+| AOA-T-0076 | `governance/decision-routing` | `owner-layer-triage` | phase-review |
+| AOA-T-0077 | `continuity/donor-harvest` | `harvest-packet-contract` | phase-review |
+| AOA-T-0078 | `governance/decision-routing` | `decision-fork-cards` | phase-review |
+| AOA-T-0079 | `governance/decision-routing` | `risk-passport-lift` | phase-review |
+| AOA-T-0080 | `recovery/diagnosis-repair` | `session-drift-taxonomy` | phase-review |
+| AOA-T-0081 | `recovery/diagnosis-repair` | `diagnosis-from-reviewed-evidence` | phase-review |
+| AOA-T-0082 | `recovery/diagnosis-repair` | `repair-shape-from-diagnosis` | phase-review |
+| AOA-T-0083 | `recovery/diagnosis-repair` | `checkpoint-bound-self-repair` | phase-review |
+| AOA-T-0084 | `continuity/donor-harvest` | `progression-evidence-lift` | phase-review |
+| AOA-T-0085 | `continuity/donor-harvest` | `multi-axis-quest-overlay` | phase-review |
+| AOA-T-0086 | `governance/automation-readiness` | `automation-fit-matrix` | phase-review |
+| AOA-T-0087 | `governance/automation-readiness` | `human-loop-to-first-landing` | phase-review |
+| AOA-T-0088 | `governance/automation-readiness` | `approval-sensitivity-check` | phase-review |
+| AOA-T-0089 | `governance/promotion-boundary` | `quest-unit-promotion-review` | phase-review |
+| AOA-T-0090 | `governance/promotion-boundary` | `nearest-wrong-target-rejection` | phase-review |
+| AOA-T-0091 | `proof/owner-truth-closeout` | `workspace-root-ingress-and-mutation-gate` | phase-review |
+| AOA-T-0092 | `proof/owner-truth-closeout` | `audit-to-closeout-proof-loop` | phase-review |
+| AOA-T-0093 | `instruction/capability-boundary` | `recommendation-truth-vs-host-actionability` | phase-review |
+| AOA-T-0094 | `proof/owner-truth-closeout` | `canonical-owner-with-validated-mirror` | phase-review |
+| AOA-T-0095 | `proof/owner-truth-closeout` | `github-only-owner-endcap-with-reality-sync` | phase-review |
+| AOA-T-0096 | `proof/owner-truth-closeout` | `pinned-validation-matrix-before-generated-publish` | phase-review |
+| AOA-T-0097 | `recovery/antifragility-recovery` | `degrade-reground-recover` | phase-review |
+| AOA-T-0098 | `recovery/antifragility-recovery` | `receipt-first-failure-analysis` | phase-review |
+| AOA-T-0099 | `recovery/antifragility-recovery` | `isolated-service-stop-on-shared-substrate` | phase-review |
+| AOA-T-0100 | `recovery/antifragility-recovery` | `stress-receipt-reground-closeout` | phase-review |
+| AOA-T-0101 | `governance/practice-adoption-lifecycle` | `local-pattern-adoption-gate` | phase-review |
+| AOA-T-0102 | `governance/promotion-boundary` | `skill-proposal-handoff-packet` | phase-review |
+| AOA-T-0103 | `governance/practice-adoption-lifecycle` | `adopted-practice-retention-review` | phase-review |
+| AOA-T-0104 | `governance/practice-adoption-lifecycle` | `superseded-practice-obsolescence-route` | phase-review |
+| AOA-T-0105 | `proof/review-evidence` | `single-missing-evidence-request` | phase-review |
+| AOA-T-0106 | `proof/review-evidence` | `single-scoped-evidence-reference` | phase-review |
+| AOA-T-0107 | `proof/review-evidence` | `single-locus-claim-challenge` | phase-review |
+
+## Phase 1 Verdict
+
+Proceed through trunk review packets. Treat `proof/skill-support` as the only
+accepted source-shape repair cohort until another bundle-specific direct read
+proves that the optional sections materially improve execution shape.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-execution-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-execution-review.md
@@ -1,0 +1,59 @@
+# Template Modernization Long-Pass Execution Review
+
+Status: closed Phase 3 execution-trunk review.
+
+This packet covers all `14` execution-trunk bundles. It accepts no source
+repair.
+
+## Evidence Read
+
+- `techniques/execution/AGENTS.md`
+- all execution-trunk `TECHNIQUE.md` sources
+- execution-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `agent-workflows-core`, `intent-chain`,
+  `ready-work-graphs`, and `runtime-truth-lifecycle`
+- selector/relation packets, including the existing `AOA-T-0050 requires
+  AOA-T-0049` repair
+- owner-boundary, bundle-anatomy, and execution-profile packets touching
+  execution surfaces
+
+## Verdict
+
+The execution trunk is already compact enough for selected-agent execution.
+The current source sections make inputs, outputs, procedures, risks, and
+validation explicit, while examples and checklists keep the atomic move visible.
+Adding optional sections across this trunk would mostly restate the existing
+contract and would risk turning template modernization into a mass rewrite.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0001 | `execution/agent-workflows-core` | `plan-diff-apply-verify-report` | held-no-repair | core workflow atom is already explicit and canonical |
+| AOA-T-0014 | `execution/agent-workflows-core` | `tdd-slice` | held-no-repair | test-first slice shape is clear through source, examples, and checklist |
+| AOA-T-0023 | `execution/agent-workflows-core` | `stateless-single-shot-agent` | held-no-repair | one-shot boundary is explicit without broader agent doctrine |
+| AOA-T-0028 | `execution/agent-workflows-core` | `confirmation-gated-mutating-action` | held-no-repair | confirmation seam is already the atom and stop-line |
+| AOA-T-0031 | `execution/agent-workflows-core` | `shell-composable-agent-invocation` | held-no-repair | shell-composable surface is clear without becoming shell policy |
+| AOA-T-0004 | `execution/intent-chain` | `intent-plan-dry-run-contract-chain` | held-no-repair | intent, dry-run, and contract chain remain bounded by existing sections |
+| AOA-T-0005 | `execution/intent-chain` | `new-intent-rollout-checklist` | held-no-repair | rollout checklist already names the input packet and stop-line |
+| AOA-T-0049 | `execution/ready-work-graphs` | `dependency-aware-task-graph` | held-no-repair | blocker graph atom is explicit and relation posture is already reviewed |
+| AOA-T-0050 | `execution/ready-work-graphs` | `ready-work-from-blocker-graph` | held-no-repair | ready queue derivation is already constrained by the existing prerequisite relation |
+| AOA-T-0055 | `execution/ready-work-graphs` | `requirements-design-tasks-ladder` | held-no-repair | ladder shape is clear and does not need source-shape repair |
+| AOA-T-0036 | `execution/runtime-truth-lifecycle` | `render-truth-before-startup` | held-no-repair | rendered truth move is explicit without runtime ownership |
+| AOA-T-0037 | `execution/runtime-truth-lifecycle` | `contextual-host-doctor` | held-no-repair | host-readiness validation is bounded against monitoring doctrine |
+| AOA-T-0038 | `execution/runtime-truth-lifecycle` | `one-command-service-lifecycle` | held-no-repair | lifecycle entrypoint is already one bounded workflow atom |
+| AOA-T-0039 | `execution/runtime-truth-lifecycle` | `baseline-first-additive-profile-benchmarks` | held-no-repair | baseline-first comparison already names validation scope and stop-line |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 14 |
+| long-pass source repairs | 0 |
+| held-no-repair | 14 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to the continuity trunk. Preserve existing relation repairs and do not
+open a relation schema wave from template modernization.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-governance-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-governance-review.md
@@ -1,0 +1,58 @@
+# Template Modernization Long-Pass Governance Review
+
+Status: closed Phase 7 governance-trunk review.
+
+This packet covers all `14` governance-trunk bundles. It accepts no source
+repair.
+
+## Evidence Read
+
+- `techniques/governance/AGENTS.md`
+- all governance-trunk `TECHNIQUE.md` sources
+- governance-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `approval-evidence`, `decision-routing`,
+  `automation-readiness`, `promotion-boundary`, and
+  `practice-adoption-lifecycle`
+- owner-boundary, selector/relation, portability, bundle-anatomy, and
+  execution-profile packets touching governance surfaces
+
+## Verdict
+
+Governance bundles have high authority pressure, but their current source shape
+already names the advisory object, route output, evidence gate, approval seam,
+promotion review, or adoption lifecycle step. Optional-section repair would not
+add enough clarity to justify touching source and risking the impression of a
+new governance doctrine layer.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0068 | `governance/approval-evidence` | `fail-closed-evidence-gate` | held-no-repair | fail-closed boundary is already explicit |
+| AOA-T-0069 | `governance/approval-evidence` | `approval-bound-durable-jobs` | held-no-repair | durable approval seam is bounded against scheduler ownership |
+| AOA-T-0076 | `governance/decision-routing` | `owner-layer-triage` | held-no-repair | primary owner and rejected target are already the atom |
+| AOA-T-0078 | `governance/decision-routing` | `decision-fork-cards` | held-no-repair | fork-card output shape is clear |
+| AOA-T-0079 | `governance/decision-routing` | `risk-passport-lift` | held-no-repair | risk passport remains one small advisory artifact |
+| AOA-T-0086 | `governance/automation-readiness` | `automation-fit-matrix` | held-no-repair | fit matrix is explicit without automation permission |
+| AOA-T-0087 | `governance/automation-readiness` | `human-loop-to-first-landing` | held-no-repair | first-landing route is bounded against playbook or skill acceptance |
+| AOA-T-0088 | `governance/automation-readiness` | `approval-sensitivity-check` | held-no-repair | sensitivity classification is already visible |
+| AOA-T-0089 | `governance/promotion-boundary` | `quest-unit-promotion-review` | held-no-repair | promotion verdict remains bounded and reviewable |
+| AOA-T-0090 | `governance/promotion-boundary` | `nearest-wrong-target-rejection` | held-no-repair | rejection of nearest wrong target is already atomic |
+| AOA-T-0102 | `governance/promotion-boundary` | `skill-proposal-handoff-packet` | held-no-repair | handoff packet stops before skill acceptance |
+| AOA-T-0101 | `governance/practice-adoption-lifecycle` | `local-pattern-adoption-gate` | held-no-repair | local adoption gate is explicit without Method-growth law import |
+| AOA-T-0103 | `governance/practice-adoption-lifecycle` | `adopted-practice-retention-review` | held-no-repair | retention review is already one bounded assessment |
+| AOA-T-0104 | `governance/practice-adoption-lifecycle` | `superseded-practice-obsolescence-route` | held-no-repair | obsolescence route is explicit and provenance-preserving |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 14 |
+| long-pass source repairs | 0 |
+| held-no-repair | 14 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to recovery. Do not promote template modernization into governance
+policy or broad route law.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-instruction-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-instruction-review.md
@@ -1,0 +1,62 @@
+# Template Modernization Long-Pass Instruction Review
+
+Status: closed Phase 5 instruction-trunk review.
+
+This packet covers all `19` instruction-trunk bundles. It accepts no source
+repair.
+
+## Evidence Read
+
+- `techniques/instruction/AGENTS.md`
+- all instruction-trunk `TECHNIQUE.md` sources
+- instruction-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `docs-boundary`, `instruction-surface`,
+  `capability-boundary`, `capability-registry`, and `skill-discovery`
+- selector/relation, portability, owner-boundary, bundle-anatomy, and
+  execution-profile packets touching instruction surfaces
+
+## Verdict
+
+Instruction bundles are already source-truth and capability-boundary heavy, but
+their current source shape keeps authored source, generated targets, capability
+specs, registry entries, command boundaries, and skill discovery objects
+separate. Optional sections would be useful only where a future bundle-specific
+defect hides an atom. No such defect appeared in this pass.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0002 | `instruction/docs-boundary` | `source-of-truth-layout` | held-no-repair | document role separation is already canonical and explicit |
+| AOA-T-0009 | `instruction/docs-boundary` | `lightweight-status-snapshot` | held-no-repair | status snapshot atom is clear and compact |
+| AOA-T-0033 | `instruction/docs-boundary` | `decision-rationale-recording` | held-no-repair | decision note shape is already bounded |
+| AOA-T-0034 | `instruction/docs-boundary` | `public-safe-artifact-sanitization` | held-no-repair | sanitization move is explicit without approval-gate import |
+| AOA-T-0012 | `instruction/instruction-surface` | `deterministic-context-composition` | held-no-repair | deterministic composition atom is clear from source and examples |
+| AOA-T-0013 | `instruction/instruction-surface` | `single-source-rule-distribution` | held-no-repair | single-source distribution already names authority and target split |
+| AOA-T-0024 | `instruction/instruction-surface` | `upstream-mirroring-with-provenance` | held-no-repair | mirror-with-provenance stop-line is explicit |
+| AOA-T-0027 | `instruction/instruction-surface` | `cross-agent-skill-propagation` | held-no-repair | propagation source/target boundary is already visible |
+| AOA-T-0029 | `instruction/instruction-surface` | `nested-rule-loading` | held-no-repair | nested precedence atom is explicit |
+| AOA-T-0030 | `instruction/instruction-surface` | `fragmented-agent-context` | held-no-repair | fragment-before-assembly object is clear |
+| AOA-T-0035 | `instruction/instruction-surface` | `profile-preset-composition` | held-no-repair | preset composition is bounded against launcher doctrine |
+| AOA-T-0040 | `instruction/capability-boundary` | `skill-vs-command-boundary` | held-no-repair | skill/command split is already the atom |
+| AOA-T-0043 | `instruction/capability-boundary` | `multi-source-primary-input-provenance` | held-no-repair | primary/supporting source priority is explicit |
+| AOA-T-0093 | `instruction/capability-boundary` | `recommendation-truth-vs-host-actionability` | held-no-repair | recommendation/actionability split is clear and current |
+| AOA-T-0025 | `instruction/capability-registry` | `capability-spec-versioning` | held-no-repair | versioned spec artifact shape is already bounded |
+| AOA-T-0063 | `instruction/capability-registry` | `versioned-agent-registry-contract` | held-no-repair | registry record contract is visible without product-policy import |
+| AOA-T-0064 | `instruction/capability-registry` | `capability-discovery` | held-no-repair | query-over-entries discovery is explicit |
+| AOA-T-0041 | `instruction/skill-discovery` | `skill-marketplace-curation` | held-no-repair | curated discoverability layer is already bounded against marketplace ownership |
+| AOA-T-0042 | `instruction/skill-discovery` | `upstream-skill-health-checking` | held-no-repair | health-checking surface is explicit without generic monitoring doctrine |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 19 |
+| long-pass source repairs | 0 |
+| held-no-repair | 19 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to knowledge, history, ingest, and tool-use. Keep future instruction
+repairs bundle-local rather than schema-wide.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-knowledge-history-ingest-tool-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-knowledge-history-ingest-tool-review.md
@@ -1,0 +1,66 @@
+# Template Modernization Long-Pass Knowledge History Ingest Tool Review
+
+Status: closed Phase 6 review for knowledge-lift, history, ingest, and
+tool-use.
+
+This packet covers `20` bundles. It accepts no source repair.
+
+## Evidence Read
+
+- `techniques/knowledge-lift/AGENTS.md`
+- `techniques/history/AGENTS.md`
+- `techniques/ingest/AGENTS.md`
+- `techniques/tool-use/AGENTS.md`
+- all covered `TECHNIQUE.md` sources
+- covered checklists, examples, and note skeletons
+- direct-read migration reviews for `kag-source-lift`, `history-artifacts`,
+  `media-ingest`, and `tool-gateway`
+- portability, owner-boundary, selector/relation, bundle-anatomy, and
+  execution-profile packets touching these surfaces
+
+## Verdict
+
+These bundles already keep their object boundaries visible: source lifts remain
+derived-reader moves, history artifacts remain reviewable capture or lineage
+objects, ingest bundles stop at reviewable intermediate objects, and tool-use
+stays one gateway seam. No optional-section repair is needed without turning
+template modernization into cosmetic symmetry.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0018 | `knowledge-lift/kag-source-lift` | `markdown-technique-section-lift` | held-no-repair | section lift already names authored markdown as authority |
+| AOA-T-0019 | `knowledge-lift/kag-source-lift` | `frontmatter-metadata-spine` | held-no-repair | metadata spine is bounded against markdown replacement |
+| AOA-T-0020 | `knowledge-lift/kag-source-lift` | `evidence-note-provenance-lift` | held-no-repair | evidence note handles are explicit |
+| AOA-T-0021 | `knowledge-lift/kag-source-lift` | `bounded-relation-lift-for-kag` | held-no-repair | relation lift is already bounded against graph semantics |
+| AOA-T-0022 | `knowledge-lift/kag-source-lift` | `risk-and-negative-effect-lift` | held-no-repair | caution lift is clear without metadata scoring |
+| AOA-T-0046 | `knowledge-lift/kag-source-lift` | `repo-doc-surface-lift` | held-no-repair | repo-doc lift preserves authored-doc authority |
+| AOA-T-0047 | `knowledge-lift/kag-source-lift` | `github-review-template-lift` | held-no-repair | template lift is bounded against workflow automation |
+| AOA-T-0048 | `knowledge-lift/kag-source-lift` | `semantic-review-surface-lift` | held-no-repair | semantic review lift does not claim verdict automation |
+| AOA-T-0026 | `history/history-artifacts` | `session-capture-as-repo-artifact` | held-no-repair | capture-as-artifact move is explicit and public-safe bounded |
+| AOA-T-0044 | `history/history-artifacts` | `versionable-session-transcripts` | held-no-repair | transcript packaging is clear without memory doctrine |
+| AOA-T-0045 | `history/history-artifacts` | `witness-trace-as-reviewable-artifact` | held-no-repair | witness trace artifact is bounded and inspectable |
+| AOA-T-0053 | `history/history-artifacts` | `local-first-session-index` | held-no-repair | index-over-saved-artifacts is explicit |
+| AOA-T-0066 | `history/history-artifacts` | `transcript-replay-artifact` | held-no-repair | replay artifact remains separate from hosted replay product |
+| AOA-T-0067 | `history/history-artifacts` | `transcript-linked-code-lineage` | held-no-repair | code-lineage link is explicit without analytics doctrine |
+| AOA-T-0070 | `ingest/media-ingest` | `two-stage-document-ocr-pipeline` | held-no-repair | OCR staging and structured handoff are clear |
+| AOA-T-0071 | `ingest/media-ingest` | `template-backed-field-extraction-after-ocr` | held-no-repair | field extraction template and uncertainty posture are explicit |
+| AOA-T-0072 | `ingest/media-ingest` | `perceptual-media-dedupe-with-threshold-review` | held-no-repair | thresholded review buckets are clear without deletion automation |
+| AOA-T-0073 | `ingest/media-ingest` | `semantic-media-bucketing-with-vision-plus-ocr` | held-no-repair | semantic bucket object is bounded by confidence gates |
+| AOA-T-0074 | `ingest/media-ingest` | `telegram-export-normalization-to-local-store` | held-no-repair | local-store normalization stops before auth/session/memory doctrine |
+| AOA-T-0065 | `tool-use/tool-gateway` | `mcp-gateway-proxy` | held-no-repair | gateway seam is explicit without MCP platform law |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 20 |
+| long-pass source repairs | 0 |
+| held-no-repair | 20 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to governance. Keep future data/tool repairs tied to a concrete hidden
+atom or stop-line defect, not section symmetry.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-proof-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-proof-review.md
@@ -1,0 +1,68 @@
+# Template Modernization Long-Pass Proof Review
+
+Status: closed Phase 2 proof-trunk review.
+
+This packet covers all `18` proof-trunk bundles. It accepts no new source
+repair beyond the existing `proof/skill-support` pilot.
+
+## Evidence Read
+
+- `techniques/proof/AGENTS.md`
+- all proof-trunk `TECHNIQUE.md` sources
+- proof-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `skill-support`, `evaluation-chain`,
+  `published-summary`, `review-evidence`, and `owner-truth-closeout`
+- bundle-anatomy, selector/relation, portability, owner-boundary, and
+  execution-profile packets touching proof surfaces
+- template-modernization pilot packet for `proof/skill-support`
+
+## Verdict
+
+The proof trunk already exposes executable atoms through standard source
+sections and support files. The `proof/skill-support` pilot remains the only
+accepted template modernization repair because its three bundles benefited from
+explicit separation between skill-adjacent technique atom, topology fit, and
+small-agent execution packet.
+
+The remaining proof bundles hold because their source summaries, inputs,
+outputs, procedures, risks, validation, checklists, and examples already keep
+the move executable without importing `aoa-evals`, CI policy, publication
+truth, GitHub policy, or owner-proof doctrine.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0015 | `proof/skill-support` | `contract-test-design` | pilot-repaired | already carries all three optional sections from the pilot |
+| AOA-T-0016 | `proof/skill-support` | `bounded-context-map` | pilot-repaired | already carries all three optional sections from the pilot |
+| AOA-T-0017 | `proof/skill-support` | `property-invariants` | pilot-repaired | already carries all three optional sections from the pilot |
+| AOA-T-0003 | `proof/evaluation-chain` | `contract-first-smoke-summary` | held-no-repair | atom, summary contract, checklist, and example already expose the smoke-summary move without eval-suite overclaim |
+| AOA-T-0007 | `proof/evaluation-chain` | `signal-first-gate-promotion` | held-no-repair | staged gate posture is explicit and does not need topology prose to avoid release-policy drift |
+| AOA-T-0032 | `proof/evaluation-chain` | `context-report-for-ci` | held-no-repair | CI-facing report atom is bounded by source, examples, and import notes without owning CI product behavior |
+| AOA-T-0006 | `proof/published-summary` | `latest-alias-plus-history-copy` | held-no-repair | dual-write artifact shape is explicit and adding optional sections would be symmetry only |
+| AOA-T-0008 | `proof/published-summary` | `published-summary-remediation-snapshot` | held-no-repair | read-only snapshot move is already bounded against remediation execution |
+| AOA-T-0010 | `proof/published-summary` | `telemetry-integrity-snapshot` | held-no-repair | integrity snapshot validation is explicit without becoming dashboard or proof verdict law |
+| AOA-T-0011 | `proof/published-summary` | `required-vs-optional-source-rendering` | held-no-repair | required/optional source rendering guardrail is already visible in source and examples |
+| AOA-T-0091 | `proof/owner-truth-closeout` | `workspace-root-ingress-and-mutation-gate` | held-no-repair | ingress plus guard posture is bounded and support files preserve the stop-line to workspace law |
+| AOA-T-0092 | `proof/owner-truth-closeout` | `audit-to-closeout-proof-loop` | held-no-repair | proof-backed closeout loop is explicit without importing closeout automation |
+| AOA-T-0094 | `proof/owner-truth-closeout` | `canonical-owner-with-validated-mirror` | held-no-repair | canonical owner and mirror parity are already separated by contract and example |
+| AOA-T-0095 | `proof/owner-truth-closeout` | `github-only-owner-endcap-with-reality-sync` | held-no-repair | GitHub-native endcap remains one workflow atom without platform policy import |
+| AOA-T-0096 | `proof/owner-truth-closeout` | `pinned-validation-matrix-before-generated-publish` | held-no-repair | validation matrix atom is explicit and does not require new sections to avoid generated-publish overclaim |
+| AOA-T-0105 | `proof/review-evidence` | `single-missing-evidence-request` | held-no-repair | one missing-evidence request is already atomized by name, source, checklist, and example |
+| AOA-T-0106 | `proof/review-evidence` | `single-scoped-evidence-reference` | held-no-repair | scoped evidence reference is already one artifact move with source-truth limits |
+| AOA-T-0107 | `proof/review-evidence` | `single-locus-claim-challenge` | held-no-repair | single-locus claim pressure is already bounded against proof verdict authority |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 18 |
+| pilot-repaired | 3 |
+| long-pass source repairs | 0 |
+| held-no-repair | 15 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to the execution trunk. Do not start a proof source rewrite unless a
+future bundle-specific defect is found outside template symmetry.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-recovery-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-recovery-review.md
@@ -1,0 +1,49 @@
+# Template Modernization Long-Pass Recovery Review
+
+Status: closed Phase 8 recovery-trunk review.
+
+This packet covers all `8` recovery-trunk bundles. It accepts no source repair.
+
+## Evidence Read
+
+- `techniques/recovery/AGENTS.md`
+- all recovery-trunk `TECHNIQUE.md` sources
+- recovery-trunk checklists, examples, and note skeletons
+- direct-read migration reviews for `diagnosis-repair` and
+  `antifragility-recovery`
+- portability, owner-boundary, selector/relation, bundle-anatomy, and
+  execution-profile packets touching recovery surfaces
+
+## Verdict
+
+Recovery bundles already keep diagnosis, repair-shape, checkpoint, degradation,
+receipt, and isolated-service-stop objects visible. Adding optional template
+sections would not materially improve execution shape and could make bounded
+recovery atoms look more doctrinal than they are.
+
+## Bundle Rows
+
+| id | shelf | bundle | verdict | reason |
+|---|---|---|---|---|
+| AOA-T-0080 | `recovery/diagnosis-repair` | `session-drift-taxonomy` | held-no-repair | drift taxonomy is already one assessment move |
+| AOA-T-0081 | `recovery/diagnosis-repair` | `diagnosis-from-reviewed-evidence` | held-no-repair | diagnosis packet and no-mutation stop-line are explicit |
+| AOA-T-0082 | `recovery/diagnosis-repair` | `repair-shape-from-diagnosis` | held-no-repair | repair-shape output is already bounded |
+| AOA-T-0083 | `recovery/diagnosis-repair` | `checkpoint-bound-self-repair` | held-no-repair | checkpoint, approval, rollback, and iteration limits are visible |
+| AOA-T-0097 | `recovery/antifragility-recovery` | `degrade-reground-recover` | held-no-repair | degraded continuation and later recovery are already distinct |
+| AOA-T-0098 | `recovery/antifragility-recovery` | `receipt-first-failure-analysis` | held-no-repair | receipt-first fact/hypothesis split is explicit |
+| AOA-T-0099 | `recovery/antifragility-recovery` | `isolated-service-stop-on-shared-substrate` | held-no-repair | isolated stop and substrate continuity checks are clear |
+| AOA-T-0100 | `recovery/antifragility-recovery` | `stress-receipt-reground-closeout` | held-no-repair | stress event closeout stays bounded and evidence-linked |
+
+## Phase Counts
+
+| class | count |
+|---|---:|
+| bundles reviewed | 8 |
+| long-pass source repairs | 0 |
+| held-no-repair | 8 |
+| route-to-other-lane | 0 |
+
+## Next
+
+Proceed to residual scan and closeout. Do not start incident doctrine,
+self-repair law, or runtime supervision from template modernization.

--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-residual-scan.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/template-modernization-long-pass-residual-scan.md
@@ -1,0 +1,63 @@
+# Template Modernization Long-Pass Residual Scan
+
+Status: closed Phase 9 residual scan.
+
+This packet confirms the long pass did not leave hidden tails and did not
+become a schema or source rewrite by accident.
+
+## Coverage
+
+| surface | count |
+|---|---:|
+| current bundles | 107 |
+| shelves | 28 |
+| trunks | 10 |
+| pilot-repaired bundles | 3 |
+| long-pass-held bundles | 104 |
+| route-to-other-lane bundles | 0 |
+| unreviewed bundles | 0 |
+
+## Phase Packet Coverage
+
+| packet | bundles | repaired | held | routed |
+|---|---:|---:|---:|---:|
+| `template-modernization-long-pass-proof-review.md` | 18 | 3 | 15 | 0 |
+| `template-modernization-long-pass-execution-review.md` | 14 | 0 | 14 | 0 |
+| `template-modernization-long-pass-continuity-review.md` | 14 | 0 | 14 | 0 |
+| `template-modernization-long-pass-instruction-review.md` | 19 | 0 | 19 | 0 |
+| `template-modernization-long-pass-knowledge-history-ingest-tool-review.md` | 20 | 0 | 20 | 0 |
+| `template-modernization-long-pass-governance-review.md` | 14 | 0 | 14 | 0 |
+| `template-modernization-long-pass-recovery-review.md` | 8 | 0 | 8 | 0 |
+
+## Parity Checks
+
+| check | result |
+|---|---|
+| every bundle appears in the corpus triage | pass |
+| every bundle appears in exactly one trunk or grouped phase packet | pass |
+| every touched `TECHNIQUE.md` has an accepted repair row | pass, no `TECHNIQUE.md` files touched by this long pass |
+| no frontmatter fields changed | pass |
+| no paths changed | pass |
+| no relation source changed | pass |
+| no generated surface was hand-edited | pass |
+| no generated rebuild was needed | pass, no source bundle changed |
+| no broad law or bridge block introduced | pass |
+| public-safety review | pass |
+
+## Residual Classification
+
+| label | count | meaning |
+|---|---:|---|
+| pilot-repaired | 3 | `proof/skill-support` already carries optional sections |
+| long-pass-repaired | 0 | no new source-shape repair accepted |
+| held-no-repair | 104 | reviewed; current source shape remains sufficient |
+| route-to-other-lane | 0 | no relation, owner-boundary, portability, promotion, or eval lane opened |
+| deferred-with-explicit-user-pause | 0 | no user pause |
+
+## Residual Verdict
+
+The repair queue is empty for template modernization. The old template remains
+valid where it already exposes a compact executable atom through the required
+sections and support files. Optional fixed-slot sections remain available for
+future bundle-local repair, but they are not promoted into a required corpus
+migration.


### PR DESCRIPTION
## Summary
- close the template-modernization long pass across all 107 current technique bundles
- add corpus triage, trunk/group review packets, residual scan, and closeout ledger
- preserve proof/skill-support as the only source-shape repair cohort and record 104 held-no-repair rows
- update the ingress README, review index, temporary plan status, roadmap, and changelog

## Validation
- git diff --check
- public-safety grep over touched public surfaces
- bridge-block grep over touched template-modernization surfaces
- python -m unittest tests.test_distillation_mechanics_topology
- python scripts/validate_nested_agents.py
- python scripts/validate_repo.py
- python -m unittest discover -s tests
- python scripts/release_check.py

## Notes
- no TECHNIQUE.md files changed
- no generated, frontmatter, path, relation, schema, config, or validator changes
- optional template-modernization sections remain optional, not corpus law
