### PR TITLE
[codex] Refresh shared AoA skill pack

### DIFF
--- a/.agents/skills/aoa-adr-write/agents/openai.yaml
+++ b/.agents/skills/aoa-adr-write/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-adr-write/examples/example.md
+++ b/.agents/skills/aoa-adr-write/examples/example.md
@@ -1,0 +1,36 @@
+# Example
+
+## Scenario
+
+A team is splitting a monolithic service into a reusable domain package and a thin delivery layer. Several contributors agree on the direction, but future maintainers will need to know why the split was chosen, what alternatives were considered, and what tradeoffs were accepted.
+
+## Why this skill fits
+
+- the change introduces a meaningful architectural decision rather than a tiny local edit
+- several plausible paths exist, and the rationale matters for future work
+- the value comes from preserving why the choice was made, not only what files changed
+
+## Expected inputs
+
+- the decision to record and the problem it solves
+- the main alternatives that were considered
+- the chosen path and the rationale behind it
+- known tradeoffs, consequences, or follow-up constraints
+
+## Expected outputs
+
+- a concise ADR or decision note
+- explicit rationale for the chosen path
+- consequence notes that future contributors can review
+- a short verification note confirming the ADR matches the real change
+
+## Boundary notes
+
+- this example is about recording a decision after the decision is real enough to matter
+- it is not a substitute for clarifying authoritative documentation or resolving document conflicts first
+
+## Verification notes
+
+- verify that the ADR explains why the split was chosen, not only that it happened
+- verify that alternatives and tradeoffs are named in plain language
+- verify that the final note still matches the actual implementation direction

--- a/.agents/skills/aoa-approval-gate-check/agents/openai.yaml
+++ b/.agents/skills/aoa-approval-gate-check/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#B45309'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-approval-gate-check/checks/review.md
+++ b/.agents/skills/aoa-approval-gate-check/checks/review.md
@@ -1,0 +1,24 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that claims to classify whether an action should proceed, require explicit approval, or be refused.
+
+## When it applies
+
+- the task may be destructive, security-relevant, or operationally sensitive
+- the current authority level is unclear or easy to over-assume
+- the work claims to recommend a bounded next step without silently overreaching
+
+## Review checklist
+
+- [ ] The requested action and touched surfaces are named explicitly.
+- [ ] The classification is concrete: safe to proceed, explicit approval required, or do not execute.
+- [ ] Unclear authority is not treated as implicit permission.
+- [ ] The next-step recommendation matches the stated authority level.
+- [ ] Safer bounded alternatives are named when full execution is not justified.
+
+## Not a fit
+
+- tasks where authority is already clear and the main question is how to preview execution
+- tasks that only prepare a sanitized artifact for sharing

--- a/.agents/skills/aoa-approval-gate-check/examples/runtime.md
+++ b/.agents/skills/aoa-approval-gate-check/examples/runtime.md
@@ -1,0 +1,28 @@
+# Runtime Example
+
+## Scenario
+You are asked to rotate credentials for a production service, but the request does not say who approved the change or whether the work is allowed in the current window.
+
+## Why this skill fits
+This is an authority question first. The task may be sensitive, so the right step is to classify whether execution can proceed or needs explicit approval before anything changes.
+
+## Expected inputs
+- the requested action
+- the target surface
+- any stated approval or authority context
+- risk signals such as production impact or data access
+
+## Expected outputs
+- a clear classification: safe to proceed, explicit approval required, or do not execute
+- the missing authority assumption, if any
+- the safest bounded next step, such as waiting for approval or using an inspect-only path
+
+## Boundary notes
+- If the request is already clearly authorized, this skill should not be used to add extra process.
+- If the main task is only to preview a safe execution path, a different workflow is a better fit.
+- Do not treat uncertainty as permission.
+
+## Verification notes
+- Confirm the authority question was answered explicitly.
+- Confirm the next step matches the stated approval level.
+- Confirm unresolved authority gaps were named, not hidden.

--- a/.agents/skills/aoa-automation-opportunity-scan/agents/openai.yaml
+++ b/.agents/skills/aoa-automation-opportunity-scan/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-automation-opportunity-scan/checks/review.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/checks/review.md
@@ -1,0 +1,34 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that detects automation-ready routes
+from reviewed evidence and packages them into a bounded
+`AUTOMATION_OPPORTUNITY_PACKET`.
+
+## When it applies
+
+- a reviewed session or recurring project slice is being scanned for honest automation value
+- the reviewer must check whether the route should stay manual, become a bounded skill, become a playbook automation seed candidate, or stay deferred
+- the route may touch approval, rollback, or self-change posture
+- the output must stay detection-shaped rather than scheduler-shaped
+
+## Review checklist
+
+- [ ] The candidate route is reviewed, real, and currently manual rather than speculative.
+- [ ] Repeat signal and friction are evidenced rather than asserted from enthusiasm.
+- [ ] Input clarity, output clarity, proof surface, reversibility, and approval sensitivity were assessed explicitly.
+- [ ] Each candidate received an explicit `seed_ready` or `not_now` verdict.
+- [ ] Each candidate named an `automation_mode_posture` that is no stronger than the evidence supports.
+- [ ] The next artifact and likely owner layer were named.
+- [ ] The nearest wrong target was rejected explicitly.
+- [ ] `checkpoint_required` was raised for self-changing, approval-heavy, or important mutation routes.
+- [ ] No schedule hint was presented as runtime authority.
+- [ ] Any `AUTOMATION_CANDIDATE_RECEIPT` stayed evidence-linked, append-only, and detector-shaped.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` stayed finish-only, pointed to the detail receipt, and did not widen into scheduler authority.
+
+## Not a fit
+
+- one-off creative or exploratory work
+- live scheduling, autonomous background execution, or secret-bearing ops
+- routes that still need donor harvest or source-of-truth clarification first

--- a/.agents/skills/aoa-automation-opportunity-scan/examples/runtime.md
+++ b/.agents/skills/aoa-automation-opportunity-scan/examples/runtime.md
@@ -1,0 +1,53 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed run shows that the same weekly doc drift check keeps repeating with
+the same inputs, the same checklist, and the same small report output. The
+team wants to know whether this should stay manual, become a bounded skill, or
+become a playbook automation seed candidate.
+
+## Why this skill fits
+
+The route is no longer just donor residue. It is a recurring manual process
+with repeat evidence, identifiable triggers, and a real question about whether
+automation is honest yet.
+
+## Expected inputs
+
+- reviewed session or review packet
+- current manual route
+- repeat signal and friction notes
+- input/output clarity and current proof posture
+- approval or rollback posture if known
+
+## Expected outputs
+
+- one `AUTOMATION_OPPORTUNITY_PACKET`
+- one `AUTOMATION_CANDIDATE` card for the doc drift check
+- an explicit `seed_ready` or `not_now` verdict
+- `automation_mode_posture: dry_run_preview` when the first honest automation mode is preview-only
+- `checkpoint_required: false` if the route is read-only and previewable
+- a next-artifact suggestion such as `skill` or `playbook_seed`
+- one `AUTOMATION_CANDIDATE_RECEIPT` with repeat signal posture,
+  `checkpoint_required`, and the next-artifact hint
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-automation-opportunity-scan` run without replacing the detector receipt
+
+## Boundary notes
+
+- Do not use this skill to grant live schedule authority.
+- Do not use this skill when the route is still a one-off creative exploration.
+- Do not smuggle self-repair or self-upgrade through an automation verdict.
+
+## Verification notes
+
+- Confirm the candidate names the current manual route.
+- Confirm repeat evidence is explicit.
+- Confirm the likely owner layer is named honestly.
+- Confirm the automation mode posture is conservative.
+- Confirm schedule hints stay hints.
+- Confirm the finish receipt stays detector-shaped and does not pretend to
+  grant schedule authority.
+- Confirm the generic core receipt points back to the detector receipt and does
+  not widen into automation authority.

--- a/.agents/skills/aoa-bounded-context-map/agents/openai.yaml
+++ b/.agents/skills/aoa-bounded-context-map/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-bounded-context-map/examples/example.md
+++ b/.agents/skills/aoa-bounded-context-map/examples/example.md
@@ -1,0 +1,40 @@
+# Example
+
+## Scenario
+
+A public practice repository is both a standalone library and one component in a larger ecosystem. Contributors keep mixing reusable practice patterns, execution skills, proof doctrine, generated reader surfaces, and ecosystem route law because the same words appear across neighboring repositories.
+
+## Why this skill fits
+
+- the main problem is semantic drift and overloaded terminology
+- future changes need sharper boundaries before coding safely
+- naming and interface clarity matter more here than immediate implementation
+- the public portable core needs to stay distinct from ecosystem-only integration context
+
+## Expected inputs
+
+- the target repo or subsystem where terminology is overloaded
+- the current names and responsibilities attached to "practice", "skill", "proof", "route", or another overloaded term
+- known neighboring contexts such as practice canon, skill execution, proof evaluation, routing, generated surfaces, and ecosystem center law
+- confusion points that have caused mis-scoped changes
+
+## Expected outputs
+
+- named contexts with a rough boundary map
+- notes on what belongs inside each context
+- interface or handoff notes between the contexts
+- recommended vocabulary that reduces overload
+- stop-lines for what routes to a stronger owner rather than staying local
+
+## Boundary notes
+
+- this example is about clarifying context boundaries, not redesigning the whole architecture
+- it should reduce confusion first, then guide future code changes
+- it should not copy every neighboring repository's law into the local document
+
+## Verification notes
+
+- confirm that the overloaded terms were split into clearer context-specific language
+- confirm that the handoff points between contexts are named
+- confirm that portable public wording and ecosystem integration wording stay distinct
+- confirm that a future contributor could place the next change more safely after reading the map

--- a/.agents/skills/aoa-change-protocol/agents/openai.yaml
+++ b/.agents/skills/aoa-change-protocol/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-change-protocol/checks/review.md
+++ b/.agents/skills/aoa-change-protocol/checks/review.md
@@ -1,0 +1,28 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing a non-trivial change that claims to follow `aoa-change-protocol`.
+
+## When it applies
+
+- the change touches code, config, docs, or operational guidance in a meaningful way
+- the author claims the work stayed bounded and explicitly verified
+- the review needs to confirm that the workflow was visible rather than implicit
+- the change relies on route cards, source-of-truth surfaces, generated exports, mechanics, legacy/provenance bridges, or sibling-owner boundaries
+
+## Review checklist
+
+- [ ] The owner route and relevant source-of-truth surfaces are inspected before the plan is treated as stable.
+- [ ] The goal, touched surfaces, and inspected evidence are named before the change is applied.
+- [ ] The main risk, owner boundary, and rollback or recovery thinking exist before execution.
+- [ ] The diff stays inside the declared scope and avoids unrelated cleanup.
+- [ ] Generated, exported, compact, or derived surfaces are rebuilt from source when canonical inputs changed.
+- [ ] At least one explicit verification step was run, or a clear reason is given for intentionally skipping it.
+- [ ] The post-change route review touched only surfaces whose meaning moved.
+- [ ] The final report names what changed, what was verified, what was skipped, and what remains risky or deferred.
+
+## Not a fit
+
+- tiny wording or formatting edits with no meaningful review or operational consequence
+- tasks where a more specific risk skill should own the workflow

--- a/.agents/skills/aoa-change-protocol/examples/runtime.md
+++ b/.agents/skills/aoa-change-protocol/examples/runtime.md
@@ -1,0 +1,39 @@
+# Runtime Example
+
+## Scenario
+
+Update a public README route and a validator message after a root source-of-truth contract changes in the repository.
+
+## Why this skill fits
+
+This is a non-trivial change because it touches documentation, validation-facing text, and a route contract. It benefits from reading the owner route first, then making scoped edits and running a clear verification step.
+
+## Expected inputs
+
+- target goal
+- owner route and relevant `AGENTS.md` or source-of-truth surfaces
+- touched files or surfaces
+- the main risk of the change
+- the validation path to run after editing
+
+## Expected outputs
+
+- a small, reviewable diff
+- a short verification note
+- a post-change route review note for any roadmap, changelog, generated, decision, quest, or mechanics surface whose meaning moved
+- a concise final report that names what changed and what was checked
+
+## Boundary notes
+
+- Do not use this skill for a tiny typo fix with no meaningful review consequence.
+- If the main question is whether the task is allowed at all, use the approval-gate skill first.
+- If the main risk is operational rollback or preview behavior, use the dry-run-first skill instead.
+- If the change depends on legacy or provenance material, start from the active route and open legacy only when lineage must be audited.
+
+## Verification notes
+
+- Confirm the owner route and relevant source surfaces were read before editing.
+- Confirm the diff stayed inside the declared scope.
+- Confirm at least one explicit check was run or intentionally skipped with a reason.
+- Confirm derived or export surfaces were rebuilt when canonical inputs changed.
+- Confirm the final report names the outcome, skipped checks, and any remaining owner-route risk.

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/SKILL.md
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/SKILL.md
@@ -58,7 +58,7 @@ Do not use this skill when:
 - optional receipt refs from already published or staged session evidence
 - repo scope and touched owner hints
 - full session evidence available to the agent, such as the reviewed artifact,
-  Codex rollout trace, transcript excerpts, and relevant receipts
+  local agent rollout trace, transcript excerpts, and relevant receipts
 
 ## Outputs
 - in `checkpoint-collect` mode:
@@ -88,7 +88,7 @@ Do not use this skill when:
    - donor harvest first
    - progression lift second
    - quest harvest third
-4. before executing reviewed closeout, the Codex agent must reread the skill
+4. before executing reviewed closeout, the local coding agent must reread the skill
    instructions and the primary session evidence; checkpoint JSON, generated
    packets, and closeout reports are only navigation aids
 5. build one closeout context bundle with reviewed artifact refs, checkpoint

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/agents/openai.yaml
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
-  allow_implicit_invocation: true
+  implicit_activation_policy: suggest
+  allow_implicit_invocation: false

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/checks/review.md
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/checks/review.md
@@ -1,0 +1,34 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that claims to follow
+`aoa-checkpoint-closeout-bridge`.
+
+## When it applies
+
+- checkpoint-led session growth is being carried into reviewed closeout
+- the route needs one explicit bridge from provisional checkpoint evidence into
+  donor harvest, progression lift, and quest harvest
+- the reviewer must confirm that checkpoint hints narrow attention without
+  replacing the reviewed artifact or receipt evidence
+
+## Review checklist
+
+- [ ] Checkpoint collection stays provisional and does not emit final donor, progression, or quest verdicts.
+- [ ] Reviewed closeout rereads the reviewed artifact rather than trusting checkpoint notes alone.
+- [ ] Accepted, rejected, and unresolved focus hints are named before the first downstream skill runs.
+- [ ] The explicit execution chain preserves the fixed order donor -> progression -> quest.
+- [ ] Each downstream stage records `executed`, `skipped`, `deferred`, or
+      `stopped` with an evidence-linked reason.
+- [ ] A skipped or deferred stage was not presented as a successful final verdict.
+- [ ] Stats refresh remains downstream and outside the bridge skill itself.
+- [ ] The bridge coordinates core skills without replacing their contracts.
+
+## Not a fit
+
+- mid-session routes that only need checkpoint collection and no reviewed
+  closeout bridge yet
+- requests to hide the session-end chain inside `aoa closeout run`
+- attempts to derive final donor, progression, or quest verdicts from
+  checkpoint notes alone

--- a/.agents/skills/aoa-checkpoint-closeout-bridge/examples/runtime.md
+++ b/.agents/skills/aoa-checkpoint-closeout-bridge/examples/runtime.md
@@ -1,0 +1,51 @@
+# Runtime Example
+
+## Scenario
+
+A session accumulated checkpoint-led route and progression hints during several
+reviewable commits. At reviewed closeout the operator wants one explicit bridge
+that reuses those hints, rereads the full reviewed artifact, and then executes
+the core session-growth chain in order.
+
+## Why this skill fits
+
+The route needs one orchestrator layer that stays honest about checkpoint
+authority. Mid-session capture should remain provisional, while reviewed
+closeout should explicitly drive donor harvest, progression lift, and quest
+triage in sequence.
+
+## Expected inputs
+
+- one reviewed session artifact
+- one optional local checkpoint note
+- one optional reviewed surface closeout handoff
+- any staged or published session receipts that sharpen the reread
+- repo scope or touched owner hints if they help bound the closeout route
+
+## Expected outputs
+
+- one closeout context bundle
+- one ordered reviewed-closeout execution chain
+- accepted, rejected, and unresolved focus hints before the chain starts
+- one status per downstream stage: `executed`, `skipped`, `deferred`, or
+  `stopped`
+- one execution report naming the emitted artifacts and receipts
+
+## Boundary notes
+
+- Do not use this skill to mint final verdicts from checkpoint notes alone.
+- Do not hide it inside `aoa closeout run`.
+- Do not force a downstream verdict when the reviewed evidence only supports a
+  skipped or deferred stage.
+- Do not refresh stats before the explicit closeout chain finishes.
+
+## Verification notes
+
+- Confirm checkpoint collection only updates provisional local ledger surfaces.
+- Confirm the reviewed artifact is reread during donor harvest, progression
+  lift, and quest harvest.
+- Confirm the execution order stays donor -> progression -> quest.
+- Confirm stage statuses are visible and evidence-linked.
+- Confirm checkpoint note and closeout handoff act as shortlist hints rather
+  than sole evidence.
+- Confirm stats refresh remains downstream of the bridge.

--- a/.agents/skills/aoa-commit-growth-seam/agents/openai.yaml
+++ b/.agents/skills/aoa-commit-growth-seam/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-commit-growth-seam/checks/review.md
+++ b/.agents/skills/aoa-commit-growth-seam/checks/review.md
@@ -1,0 +1,27 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing a change that claims to follow
+`aoa-commit-growth-seam`.
+
+## When it applies
+
+- a bounded diff is ready to cross a local commit boundary
+- the author claims the commit stayed narrow and honest
+- the review needs to confirm that commit, validation, and stop-line posture
+  stayed explicit
+
+## Review checklist
+
+- [ ] The exact bounded diff was isolated before the commit.
+- [ ] Unrelated local changes were excluded or explicitly deferred.
+- [ ] `commit_authorization_posture` was `authorized_now` before the local commit happened.
+- [ ] The validation state was named honestly before the commit happened.
+- [ ] The commit message matches the bounded unit rather than generic success language.
+- [ ] The workflow stopped at the local commit boundary instead of widening silently into push, PR, or publish work.
+
+## Not a fit
+
+- work that still needs more coding or verification before any commit is honest
+- routes whose real center is approval classification, publish choreography, or post-commit automation

--- a/.agents/skills/aoa-commit-growth-seam/examples/runtime.md
+++ b/.agents/skills/aoa-commit-growth-seam/examples/runtime.md
@@ -1,0 +1,47 @@
+# Runtime Example
+
+## Scenario
+
+A bounded `aoa-sdk` patch is already applied, the targeted tests and lint checks
+are green, and the next honest move is one local commit that preserves the
+repair as a distinct review boundary before any later push or merge step.
+
+## Why this skill fits
+
+The coding work is done for now, but the commit boundary still matters. The
+working tree needs one intentional commit with an honest message and a visible
+stop line so the session does not blur commit, push, and publication into one
+hidden loop.
+
+## Expected inputs
+
+- one bounded local diff
+- `git status` showing whether unrelated changes are present
+- the explicit validation results that justify the commit boundary
+- explicit operator authorization for one local commit now
+- the intended stop line after commit
+
+## Expected outputs
+
+- one bounded commit-or-defer decision
+- `commit_authorization_posture: authorized_now`
+- one local commit that matches the intended diff
+- one short note on what was verified and what remains outside the commit
+- one explicit stop line before push, PR, or publish
+
+## Boundary notes
+
+- Do not use this skill when the task still clearly needs more repair or verification.
+- Do not cross the commit boundary when the operator only asked for review,
+  preparation, or analysis.
+- Do not use this skill as a hidden push or publish workflow.
+- If the main question is whether the mutation is authorized at all, use the approval-gate skill first.
+- If the main need is the broader coding workflow rather than the commit boundary itself, use `aoa-change-protocol`.
+
+## Verification notes
+
+- Confirm the commit boundary matched the actual diff.
+- Confirm unrelated local changes were not swept in silently.
+- Confirm commit authorization was explicit before mutation.
+- Confirm the validation story was named honestly.
+- Confirm the route stopped after the local commit boundary.

--- a/.agents/skills/aoa-contract-test/agents/openai.yaml
+++ b/.agents/skills/aoa-contract-test/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-contract-test/examples/example.md
+++ b/.agents/skills/aoa-contract-test/examples/example.md
@@ -1,0 +1,41 @@
+# Example
+
+## Scenario
+
+A routing layer consumes generated catalogs from source-owner surfaces. The
+catalogs must keep stable IDs, source references, object type, and route fields
+so routing, SDK, and low-context readers can point back to owner truth without
+copying the authored payload into a second canon.
+
+## Why this skill fits
+
+- the important risk is a boundary contract between source-owned producers and downstream consumers
+- downstream assumptions need to become visible and reviewable
+- validation should focus on the generated/export shape and source-owner limits, not only on builder internals
+
+## Expected inputs
+
+- the source-owned catalog producer and the consuming router or SDK surface
+- the required generated/export fields and source references
+- the current schema, fixture, smoke, or build-check surface for the boundary
+- known downstream expectations that would break if the fields or claim limits drift
+
+## Expected outputs
+
+- explicit contract assumptions for the generated/export boundary
+- schema, fixture, smoke, or build checks tied to the contract
+- a short downstream impact note if the contract is changed or tightened
+- a claim limit that says the generated surface summarizes owner truth rather than owning it
+
+## Boundary notes
+
+- this example is not a broad redesign of routing, SDK, or source-owner surfaces
+- the point is to make the seam explicit, not to prove the whole federation correct
+- if the owner or object meaning is unclear, use bounded-context mapping before contract testing
+
+## Verification notes
+
+- verify that the generated/export contract is visible in tests or structured checks
+- verify that missing required fields fail in a reviewable way
+- verify that source-owned meaning remains stronger than the generated consumer surface
+- verify that the report names any unchanged weak spots in downstream coverage

--- a/.agents/skills/aoa-core-logic-boundary/agents/openai.yaml
+++ b/.agents/skills/aoa-core-logic-boundary/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-core-logic-boundary/examples/example.md
+++ b/.agents/skills/aoa-core-logic-boundary/examples/example.md
@@ -1,0 +1,43 @@
+# Example
+
+## Scenario
+
+A workflow catalog builder mixes source-owned bundle classification rules with
+installed export path formatting, markdown report rendering, runtime router
+hint assembly, and local filesystem discovery. Reviews keep getting stuck
+because contributors cannot tell whether a change alters reusable catalog
+semantics or only changes generated delivery surfaces.
+
+## Why this skill fits
+
+- the core problem is unclear responsibility between reusable catalog logic and export/report/runtime glue
+- the surface mixes stable source-to-catalog rules with projection, rendering, and local delivery detail
+- future changes will stay safer if the reusable center is separated before more generated surfaces depend on it
+
+## Expected inputs
+
+- the target builder or slice with mixed responsibilities
+- the current classification, source-ref, and source-to-catalog rules that appear stable
+- the surrounding export, rendering, runtime, path, and environment-specific code
+- the pressure points that make reviews or tests muddy today
+
+## Expected outputs
+
+- a clearer statement of what belongs in the reusable catalog core
+- notes on what should remain generated/export, report, runtime, or local-path glue
+- a bounded refactor proposal or small implementation move
+- a source-owner stop-line so generated surfaces do not become authored bundle truth
+- a short verification summary about improved clarity
+
+## Boundary notes
+
+- this example is about deciding what belongs in the reusable center versus generated or runtime-facing edge surfaces
+- it is not yet about introducing a port around a concrete dependency once the boundary is already clear
+- it is not a broad catalog redesign or a promotion of generated output into source authority
+
+## Verification notes
+
+- verify that stable catalog rules are separated conceptually from export formatting and report rendering
+- verify that generated, router, and local path details remain outside the reusable center
+- verify that authored bundle meaning stays stronger than the generated consumer surfaces
+- verify that the change improves review clarity without expanding into a broad rewrite

--- a/.agents/skills/aoa-dry-run-first/agents/openai.yaml
+++ b/.agents/skills/aoa-dry-run-first/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#B45309'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-dry-run-first/checks/review.md
+++ b/.agents/skills/aoa-dry-run-first/checks/review.md
@@ -1,0 +1,24 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that claims to prefer a preview, simulation, or inspect-only path before real execution.
+
+## When it applies
+
+- the task can be previewed before it changes a live or meaningful surface
+- a mistaken execution would cost more than a bounded preview step
+- the review needs to confirm that preview discipline stayed separate from real execution
+
+## Review checklist
+
+- [ ] A real preview, simulation, or inspect-only path was considered before execution.
+- [ ] The review names what the preview covers and what it does not prove.
+- [ ] Preview output is not presented as proof of total safety.
+- [ ] The preview step did not silently perform the real action.
+- [ ] The recommended next step matches the confidence created by the preview.
+
+## Not a fit
+
+- tasks where the central question is whether execution is authorized at all
+- tasks that are purely analytical and never approach execution

--- a/.agents/skills/aoa-dry-run-first/examples/runtime.md
+++ b/.agents/skills/aoa-dry-run-first/examples/runtime.md
@@ -1,0 +1,35 @@
+# Runtime Example
+
+## Scenario
+
+Preview a public configuration migration before applying it to a live service.
+
+## Why this skill fits
+
+This task can be inspected or simulated before execution, and the live surface may change if the migration is applied incorrectly.
+
+## Expected inputs
+
+- requested action
+- available preview or dry-run mechanism
+- the touched operational surface
+- known limits of the preview path
+
+## Expected outputs
+
+- the preview result or dry-run summary
+- the differences or risks observed
+- a recommendation for the next step
+
+## Boundary notes
+
+- Do not use this skill when there is no meaningful preview path and the task is already clearly harmless.
+- If the main question is whether the action is authorized, use the approval-gate skill first.
+- If the task is only about preparing a shareable artifact, use the sanitized-share skill instead.
+
+## Verification notes
+
+- Confirm the preview was run before any real execution.
+- Confirm the preview did not silently perform the real action.
+- Confirm any remaining risk was named explicitly.
+- Confirm the next step matches the confidence level of the preview.

--- a/.agents/skills/aoa-invariant-coverage-audit/agents/openai.yaml
+++ b/.agents/skills/aoa-invariant-coverage-audit/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-invariant-coverage-audit/examples/example.md
+++ b/.agents/skills/aoa-invariant-coverage-audit/examples/example.md
@@ -1,0 +1,38 @@
+# Example
+
+## Scenario
+
+A validation suite and generated report already cover a few happy-path and error-path cases for a bounded rule, but reviewers still are not sure whether the checks really constrain the stable truth or only repeat examples and complete-looking status.
+
+## Why this skill fits
+
+- the task is to audit existing invariant coverage, not to discover a brand-new invariant from scratch
+- the current question is whether the suite and report prove the stable rule across meaningful cases
+- the output should stay bounded to coverage mapping and the smallest next gaps, not widen into full test-strategy redesign
+
+## Expected inputs
+
+- the stable rule that should hold, such as "accepted input preserves required fields and rejected input fails before side effects"
+- the current tests, checks, report fields, generated parity checks, or example cases
+- known edge cases that already matter to reviewers
+- any bounds needed to keep the audit reviewable
+
+## Expected outputs
+
+- one plain-language statement of the invariant under review
+- a map from the invariant to the checks or report fields that currently constrain it
+- a short gap list for weak or missing coverage
+- the smallest bounded follow-up checks or revisions worth adding next
+- a claim-limit note that prevents the report from being read as broader proof
+
+## Boundary notes
+
+- do not use this skill when the invariant itself is still unknown and discovery work must happen first
+- do not widen the audit into generic boundary-contract design when `aoa-contract-test` is the better fit
+- do not treat generated freshness or report completeness as proof unless it constrains the invariant itself
+
+## Verification notes
+
+- verify that each claimed invariant is mapped to a real existing check
+- verify that the reported gaps are specific and actionable rather than abstract testing advice
+- verify that the result states what the current suite or report proves and what still remains outside the bounded audit

--- a/.agents/skills/aoa-local-stack-bringup/agents/openai.yaml
+++ b/.agents/skills/aoa-local-stack-bringup/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#B45309'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-local-stack-bringup/checks/review.md
+++ b/.agents/skills/aoa-local-stack-bringup/checks/review.md
@@ -1,0 +1,26 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that claims to bring up a bounded local multi-service stack through render review, readiness checks, and one explicit lifecycle path.
+
+## When it applies
+
+- the task starts a local stack with more than one meaningful service or runtime layer
+- the selected runtime shape can change what will actually start
+- readiness should be checked before launch rather than after startup failure
+- the review needs to confirm that startup stayed explicit, bounded, and locally reviewable
+
+## Review checklist
+
+- [ ] Rendered runtime truth was reviewed before any startup step.
+- [ ] The readiness verdict is selector-aware and names item-level `ok`, `warn`, or `fail` results.
+- [ ] Blockers or unresolved ambiguity stopped the launch path or were explicitly deferred.
+- [ ] Operator intent or confirmation is visible before the mutating launch step.
+- [ ] Startup status names what started and how to stop it.
+- [ ] Any full rendered config stayed local and controlled rather than becoming a share artifact.
+
+## Not a fit
+
+- remote deployment, continuous monitoring, or fleet orchestration work
+- generic bootstrap or install flows that do not stay inside a bounded local runtime bring-up

--- a/.agents/skills/aoa-local-stack-bringup/examples/runtime.md
+++ b/.agents/skills/aoa-local-stack-bringup/examples/runtime.md
@@ -1,0 +1,37 @@
+# Runtime Example
+
+## Scenario
+
+Bring up a local application stack with an API, worker, and database after choosing a profile that may change which services actually start.
+
+## Why this skill fits
+
+This is a bounded local bring-up task, not just a generic configuration edit. The operator needs to see the rendered runtime shape, confirm host readiness for that exact selection, and then start the stack through one explicit lifecycle path.
+
+## Expected inputs
+
+- selected local profile, preset, or equivalent runtime choice
+- render command or surface for the chosen runtime
+- readiness or doctor command for the chosen runtime
+- explicit lifecycle entrypoint and known stop path
+- any blocker or warning policy that affects go versus hold
+
+## Expected outputs
+
+- rendered summary of what would actually start
+- readiness verdict with named blockers or warnings
+- explicit go, hold, or confirm-before-launch recommendation
+- startup status or deferred-start report with stop-path notes
+
+## Boundary notes
+
+- Do not use this skill for remote deployment, ongoing monitoring, or fleet orchestration.
+- If the task is a broader infrastructure change without a bounded local stack bring-up, use `aoa-safe-infra-change`.
+- If the main question is whether the action is authorized at all, use `aoa-approval-gate-check` first.
+
+## Verification notes
+
+- Confirm rendered truth was reviewed before startup.
+- Confirm readiness signals were tied to the selected runtime.
+- Confirm launch required explicit operator intent before mutating runtime state.
+- Confirm the result states what started, how to stop it, and what remains risky or deferred.

--- a/.agents/skills/aoa-port-adapter-refactor/agents/openai.yaml
+++ b/.agents/skills/aoa-port-adapter-refactor/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-port-adapter-refactor/examples/example.md
+++ b/.agents/skills/aoa-port-adapter-refactor/examples/example.md
@@ -1,0 +1,37 @@
+# Example
+
+## Scenario
+
+A catalog export workflow directly reads local profile paths and writes installed artifacts from inside reusable source-to-output mapping logic. Tests are brittle because they need workspace-specific setup, and adding a second export profile would repeat the same path and write mechanics again.
+
+## Why this skill fits
+
+- the main problem is concrete filesystem and export-profile dependency leaking into logic that should stay reusable
+- the module needs a clearer seam before further change
+- tests and future export profiles benefit from a narrower boundary
+
+## Expected inputs
+
+- the target builder or workflow slice and the concrete path/write dependency currently embedded in it
+- the source-to-output behavior the reusable logic actually needs from the dependency
+- the desired scope of the refactor
+- the validation path that will confirm behavior did not drift
+
+## Expected outputs
+
+- a narrower port that reflects what the mapping logic truly needs
+- an adapter or equivalent seam around path discovery and artifact writing
+- a clearer logic-versus-export-delivery boundary
+- a short verification summary confirming generated output behavior stayed stable
+
+## Boundary notes
+
+- this example assumes the logic-versus-edge boundary is already clear enough to act on
+- the focus is introducing a useful seam, not renaming packages or creating abstraction for ceremony alone
+- generated/export contract validation remains a separate follow-up if downstream consumers rely on stable artifact shape
+
+## Verification notes
+
+- verify that the new port is narrower than direct filesystem/profile access
+- verify that path discovery and artifact writing moved behind the adapter boundary
+- verify that the refactor reduces coupling without changing the intended export behavior

--- a/.agents/skills/aoa-property-invariants/agents/openai.yaml
+++ b/.agents/skills/aoa-property-invariants/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-property-invariants/examples/example.md
+++ b/.agents/skills/aoa-property-invariants/examples/example.md
@@ -1,0 +1,37 @@
+# Example
+
+## Scenario
+
+A generated catalog builder turns authored source bundles into compact indexes, installed copies, and route hints. The team has a few example fixtures, but regressions still appear because stable IDs, source references, eligibility filters, and rebuild repeatability need to hold across many source sets and profile options.
+
+## Why this skill fits
+
+- the system has stable truths that should hold across many artifacts, transformations, and profile states
+- example-only testing is too narrow for the risk surface
+- the important value comes from expressing source-to-generated invariants, not from enumerating a few happy paths
+
+## Expected inputs
+
+- the invariant candidates, such as "eligible sources appear once", "source refs are preserved", and "same source plus same options rebuilds equivalently"
+- the current example tests, fixtures, and known edge cases
+- the generator or input strategy for source sets, eligibility states, and profile options
+- limits needed to keep the property checks reviewable
+
+## Expected outputs
+
+- explicit invariants for the source-to-generated rules
+- property-oriented tests or repeated checks over bounded source sets and profile options
+- notes on generator assumptions, excluded profile behavior, and what the properties do not cover
+
+## Boundary notes
+
+- this example is not about UI rendering or snapshot-style presentation behavior
+- the point is to encode stable truths, not to replace every concrete example test
+- if the main question is only whether current checks already cover this rule, use `aoa-invariant-coverage-audit` first
+
+## Verification notes
+
+- verify that each property expresses a real invariant instead of a weak wish
+- verify that the generated cases broaden coverage beyond the original handpicked examples
+- verify that the report explains the invariant and the bounds of the generator strategy
+- verify that generated surfaces remain derived evidence rather than source authority

--- a/.agents/skills/aoa-quest-harvest/agents/openai.yaml
+++ b/.agents/skills/aoa-quest-harvest/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-quest-harvest/checks/review.md
+++ b/.agents/skills/aoa-quest-harvest/checks/review.md
@@ -1,0 +1,35 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that classifies repeated quest evidence into a promotion target.
+
+## When it applies
+
+- a repeated reviewed pattern is being harvested after bounded work
+- the reviewer must check whether the target should stay a quest, become a skill, or move into another owner layer
+- the route risks confusing orchestrator identity, route canon, proof, or memory with skill meaning
+
+## Review checklist
+
+- [ ] The repeated unit was named explicitly as leaf workflow, route, proof pattern, recall pattern, or boundary law.
+- [ ] Exactly one repeated reviewed unit was isolated before final triage.
+- [ ] Repeat evidence posture is named before the promotion target.
+- [ ] Repeated discussion, urgency, or theme resonance was not counted as repeat evidence.
+- [ ] The verdict names the correct owner repo and follow-up surface.
+- [ ] The output rejects the nearest wrong target instead of only asserting the chosen one.
+- [ ] The review does not let quest metadata define orchestrator class identity.
+- [ ] The decision does not force promotion when repetition or ownership is still weak.
+- [ ] Weak, contested, topic-only, mixed, or owner-pending repetition was kept as quest/defer posture rather than promoted as if settled.
+- [ ] The next surface is framed as a proposal or follow-through target rather
+      than downstream owner acceptance.
+- [ ] Any emitted `QUEST_PROMOTION_RECEIPT` stays smaller than the triage and keeps the rejected nearest-wrong target visible.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` points to the promotion detail receipt and stays generic finish telemetry rather than promotion authority.
+
+## Not a fit
+
+- active routes that still need execution or review before harvest
+- mixed donor units that still need donor harvest, route forks, diagnosis,
+  repair, automation scan, or progression reflection first
+- direct playbook authoring when no real promotion triage remains
+- attempts to create memo truth out of active source-owned quest state

--- a/.agents/skills/aoa-quest-harvest/examples/runtime.md
+++ b/.agents/skills/aoa-quest-harvest/examples/runtime.md
@@ -1,0 +1,56 @@
+# Runtime Example
+
+## Scenario
+
+Three reviewed runs repeat the same post-session question: should a bounded repeatable pattern stay a quest, become a skill, or move into a playbook or orchestrator surface.
+Donor harvest has already separated this unit from other session residue, so
+the remaining work is one final promotion verdict.
+The repeat posture is reviewed and isolated; downstream owner acceptance is
+still pending.
+
+## Why this skill fits
+
+The task is no longer about executing the original work. It is about harvesting reviewed repetition and choosing the correct owner layer without collapsing class identity, route method, proof, or memory into the wrong place.
+
+## Expected inputs
+
+- source quest reference
+- reviewed run summary or harvest pack
+- repeat count
+- repeat shape
+- isolated repeated unit ref
+- repeat evidence posture
+- owner layer candidates
+
+## Expected outputs
+
+- one promotion verdict
+- one repeat evidence posture
+- one rejected nearest-wrong target
+- one named owner repo and follow-up surface
+- one note that the verdict is a proposal/follow-through target rather than
+  acceptance by that owner repo
+- one short reason why promotion should wait if the pattern must remain a quest
+- one `QUEST_PROMOTION_RECEIPT` that records the closed triage without replacing it
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-quest-harvest` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill while the route is still active and unreviewed.
+- Do not use this skill while the repeated unit is still mixed with broader
+  session residue.
+- Do not use this skill to invent new orchestrator class identity.
+- Do not use this skill when the answer is already clearly a scenario playbook and no real triage remains.
+
+## Verification notes
+
+- Confirm the repetition is about work or law, not just topic similarity.
+- Confirm one repeated reviewed unit is isolated before the verdict.
+- Confirm repeat evidence posture supports the verdict.
+- Confirm the chosen target matches the correct owner layer.
+- Confirm the output names why the nearest wrong promotion target was rejected.
+- Confirm the next surface is not presented as already accepted downstream.
+- Confirm any finish receipt keeps the verdict, next surface, and nearest wrong target visible.
+- Confirm the generic core receipt points back to the promotion receipt and
+  does not become promotion authority.

--- a/.agents/skills/aoa-safe-infra-change/agents/openai.yaml
+++ b/.agents/skills/aoa-safe-infra-change/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#B45309'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-safe-infra-change/checks/review.md
+++ b/.agents/skills/aoa-safe-infra-change/checks/review.md
@@ -1,0 +1,24 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing a bounded infrastructure or configuration change that claims to follow `aoa-safe-infra-change`.
+
+## When it applies
+
+- the change touches infrastructure, orchestration, runtime configuration, or operational surfaces
+- the task has deployment, safety, or recovery implications
+- the review needs to confirm that the change stayed explicit, bounded, and verifiable
+
+## Review checklist
+
+- [ ] The operational surface and the main risk are named before execution.
+- [ ] The change remains small and reviewable rather than hiding broader churn.
+- [ ] Verification is explicit and proportional to the operational risk.
+- [ ] Rollback or recovery thinking is present before execution or recommendation.
+- [ ] The final report names unresolved risk, deferred work, or recovery notes.
+
+## Not a fit
+
+- purely local code changes with no operational implications
+- tasks where the main question is authority classification or preview-path selection rather than the infra change itself

--- a/.agents/skills/aoa-safe-infra-change/examples/runtime.md
+++ b/.agents/skills/aoa-safe-infra-change/examples/runtime.md
@@ -1,0 +1,30 @@
+# Runtime Example
+
+## Scenario
+You need to update a deployment setting that controls a service timeout and restart policy in a non-production environment before rolling the same change forward.
+
+## Why this skill fits
+This is a bounded infrastructure change with operational impact. The skill helps keep the change small, explicit, and verifiable while preserving rollback thinking.
+
+## Expected inputs
+- the target operational surface
+- the exact config or infra change
+- the rollout or validation plan
+- any rollback or recovery idea
+
+## Expected outputs
+- a bounded change plan
+- the updated infra or config action
+- verification results that match the risk level
+- any remaining operational risk or rollback note
+
+## Boundary notes
+- If the task is only about deciding whether the change is allowed, use approval-gate logic instead.
+- If the task is only about preparing a preview, keep it inspect-only.
+- Keep unrelated cleanup out of the change.
+
+## Verification notes
+- Confirm the operational surface was named clearly.
+- Confirm the change stayed bounded to the requested setting.
+- Confirm verification and rollback thinking were explicit.
+- Confirm no wider operational churn was introduced.

--- a/.agents/skills/aoa-sanitized-share/agents/openai.yaml
+++ b/.agents/skills/aoa-sanitized-share/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#B45309'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-sanitized-share/checks/review.md
+++ b/.agents/skills/aoa-sanitized-share/checks/review.md
@@ -1,0 +1,24 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing a shareable artifact that claims to sanitize sensitive technical material for a broader audience.
+
+## When it applies
+
+- logs, configs, diagnostics, reports, or examples may contain sensitive details
+- the result is intended for public or wider internal sharing
+- the review needs to confirm that sanitization preserved usefulness without leaking unsafe context
+
+## Review checklist
+
+- [ ] Secrets, tokens, private paths, topology clues, and unsafe operational details were explicitly considered.
+- [ ] The shared artifact preserves the technical lesson without preserving sensitive raw detail.
+- [ ] The sanitization level matches the intended audience.
+- [ ] Raw sensitive detail was not left behind by accident.
+- [ ] Remaining uncertainty or limits of sanitization are named clearly.
+
+## Not a fit
+
+- tasks whose main question is whether the underlying action should be allowed
+- tasks that are actually about executing or previewing an operational change rather than preparing a safe shareable surface

--- a/.agents/skills/aoa-sanitized-share/examples/runtime.md
+++ b/.agents/skills/aoa-sanitized-share/examples/runtime.md
@@ -1,0 +1,29 @@
+# Runtime Example
+
+## Scenario
+You want to share a support summary that includes a failing command, but the raw output contains hostnames, private paths, and an internal ticket reference.
+
+## Why this skill fits
+The task is to make the material shareable without exposing sensitive detail. The skill should preserve the lesson while removing or generalizing unsafe identifiers.
+
+## Expected inputs
+- the raw material to share
+- the intended audience
+- any known sensitive surfaces
+- the minimum level of detail needed for the audience to understand the point
+
+## Expected outputs
+- a sanitized, shareable version of the material
+- a short note about what was removed or generalized
+- any remaining sensitivity warning that still matters
+
+## Boundary notes
+- If the material is already public-safe, do not over-sanitize it.
+- If the real task is the underlying operational change, use a different skill first.
+- Prefer summaries over raw excerpts when secrets or topology could leak.
+
+## Verification notes
+- Confirm sensitive surfaces were checked deliberately.
+- Confirm the result still teaches the intended lesson.
+- Confirm raw paths, tokens, and internal identifiers were not preserved by accident.
+- Confirm any remaining uncertainty was called out plainly.

--- a/.agents/skills/aoa-session-donor-harvest/agents/openai.yaml
+++ b/.agents/skills/aoa-session-donor-harvest/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-donor-harvest/checks/review.md
+++ b/.agents/skills/aoa-session-donor-harvest/checks/review.md
@@ -1,0 +1,45 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that turns a reviewed session artifact
+into a bounded `HARVEST_PACKET` with AoA owner-layer candidates and explicit
+family handoff hints.
+
+## When it applies
+
+- a reviewed session, transcript, or compaction packet is being distilled after the fact
+- the reviewer must check whether reusable units belong in `aoa-techniques`, `aoa-skills`, `aoa-playbooks`, `aoa-evals`, `aoa-memo`, `aoa-agents`, or should remain deferred
+- the route risks collapsing source-owned meaning into derivative layers or vague "good ideas"
+- the result may also need explicit automation scan, route-forks, diagnosis, progression, or
+  quest-triage follow-through
+
+## Review checklist
+
+- [ ] The source artifact was reviewed and bounded before harvest.
+- [ ] Checkpoint notes, closeout handoffs, and ledger hints were dispositioned
+      before harvest as accepted, rejected, stale, cross-session,
+      contaminated, or unresolved.
+- [ ] No `candidate_ref` was minted from a checkpoint or handoff hint unless
+      the reviewed artifact or receipt evidence confirmed the same reusable
+      unit.
+- [ ] Each kept candidate names one reusable unit rather than one topic cluster.
+- [ ] Each candidate has one primary owner layer.
+- [ ] Each accepted candidate minted `candidate_ref` only after reviewed donor harvest.
+- [ ] Any carried `cluster_ref` stayed linked instead of being treated as final object identity.
+- [ ] Stale, neighboring-session, or diagnostic residue stayed out of the
+      current session's accepted donor candidates.
+- [ ] The output names the nearest wrong target and rejects it explicitly.
+- [ ] `aoa-routing` and `aoa-kag` were not treated as first authoring targets for source-owned meaning.
+- [ ] `usefulness` was treated as a reuse signal, not as an owner layer.
+- [ ] Weak or unclear candidates were allowed to remain `hold` instead of being forced into canon.
+- [ ] The result names one concrete next artifact for each accepted candidate.
+- [ ] Automation candidates, quest residue, route forks, diagnosis hints, repair follow-through, or progression follow-through were surfaced explicitly when they survived the harvest.
+- [ ] Any `HARVEST_PACKET_RECEIPT` stayed evidence-linked, append-only, and smaller than the packet it summarizes.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` stayed generic, finish-only, and pointed back to the bounded detail receipt instead of duplicating packet meaning.
+
+## Not a fit
+
+- active sessions that still need execution or review
+- raw session capture, transcript export, or local indexing work
+- narrow final promotion triage for one repeated quest unit where `aoa-quest-harvest` is already the honest next step

--- a/.agents/skills/aoa-session-donor-harvest/examples/runtime.md
+++ b/.agents/skills/aoa-session-donor-harvest/examples/runtime.md
@@ -1,0 +1,63 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed session artifact contains several potentially reusable outcomes:
+1. a repeatable practice for turning raw post-session notes into a bounded donor packet
+2. one bounded leaf workflow for explicit post-session harvesting by a local coding agent
+3. one broader recurring rollout route that spans skill drafting, review, and later proof updates
+4. one unresolved post-session branch where the next route should stay explicit
+5. one repeated manual review-closeout ritual that may be ripe for automation but still needs explicit readiness classification
+6. one checkpoint hint that looks relevant but must be accepted or rejected
+   against the reviewed artifact before it can influence candidate minting
+
+## Why this skill fits
+
+The task is no longer about executing the original work. It is about extracting reusable units from a finished session and routing each one to the correct owner layer without collapsing practice, workflow, and scenario composition into one object.
+
+## Expected inputs
+
+- reviewed session transcript or compaction note
+- candidate repeat or reuse signals
+- touched AoA layers
+- uncertainty notes and residual boundary risk
+
+## Expected outputs
+
+- one `HARVEST_PACKET`
+- one reviewed intake note that accepts, rejects, or carries checkpoint and
+  closeout-handoff hints before any `candidate_ref` is minted
+- one reviewed accepted candidate with a minted `candidate_ref`
+- one carried `cluster_ref` when the reviewed source already named it
+- one candidate routed to `aoa-techniques` as reusable practice meaning
+- one candidate routed to `aoa-skills` as a bounded executable leaf workflow
+- one candidate routed to `aoa-playbooks` or deferred because it is route-shaped rather than skill-shaped
+- one optional `automation_candidate` extract plus an explicit handoff hint to
+  `aoa-automation-opportunity-scan`
+- one explicit rejected-nearest-wrong-target note for each accepted candidate
+- one explicit handoff hint to `aoa-session-route-forks` because the session
+  still has more than one honest next route
+- one `HARVEST_PACKET_RECEIPT` with bounded counts, owner-layer distribution,
+  and evidence-linked candidate refs
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records a finished
+  `aoa-session-donor-harvest` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill while the session is still active.
+- Do not use this skill to turn session history directly into memory canon.
+- Do not author `aoa-routing` or `aoa-kag` first when the real source-owned object has not been named yet.
+
+## Verification notes
+
+- Confirm the kept units are reusable objects rather than themes.
+- Confirm checkpoint and handoff hints were filtered through reviewed evidence
+  instead of becoming candidates by presence alone.
+- Confirm `candidate_ref` was minted only after reviewed owner-shaping.
+- Confirm the chosen owner layer matches the unit shape.
+- Confirm each accepted candidate names the next artifact, not only the repo.
+- Confirm any post-session family handoff stays explicit.
+- Confirm the finish receipt stays smaller than the packet and links evidence
+  instead of duplicating raw recap.
+- Confirm the generic core receipt stays finish-only and references the detail
+  receipt instead of becoming a second donor packet.

--- a/.agents/skills/aoa-session-progression-lift/agents/openai.yaml
+++ b/.agents/skills/aoa-session-progression-lift/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-progression-lift/checks/review.md
+++ b/.agents/skills/aoa-session-progression-lift/checks/review.md
@@ -1,0 +1,41 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that turns reviewed session evidence into
+one bounded `PROGRESSION_DELTA`.
+
+## When it applies
+
+- the route needs progression legibility after a reviewed session
+- the reviewer must check whether movement claims stay evidence-backed,
+  qualitative, and multi-axis
+- quest or RPG reflection is present only as adjunct reading, not authority
+
+## Review checklist
+
+- [ ] Meaningful axis claims cite reviewed evidence.
+- [ ] Baseline posture is explicit before comparative movement claims.
+- [ ] Checkpoint, donor, closeout, and generated hints were separated from
+      confirmed current-session evidence before any movement claim was written.
+- [ ] The output stays multi-axis instead of collapsing into one score.
+- [ ] Each meaningful axis records evidence posture such as confirmed,
+      contested, provisional, stale, not-current-session, or no-movement.
+- [ ] The verdict matches the evidence and allows hold, reanchor, or downgrade.
+- [ ] Provisional or contested evidence did not become an inflated advance.
+- [ ] First-observed or missing-baseline axes were not presented as proven improvement.
+- [ ] Unlock hints are small, explicit, and reviewable.
+- [ ] Progression is not being used as hidden routing or policy authority.
+- [ ] Quest or RPG language stays reflective rather than sovereign.
+- [ ] No authority rights or status jumps were granted without evidence.
+- [ ] Negative or zero movement remained available where honest.
+- [ ] Quest hooks stayed reflective unless one repeated reviewed quest unit was
+      ready for `aoa-quest-harvest`.
+- [ ] Any `PROGRESSION_DELTA_RECEIPT` stayed multi-axis, evidence-linked, and non-sovereign.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` pointed to the progression detail receipt and stayed generic finish telemetry only.
+
+## Not a fit
+
+- routes with no reviewed evidence
+- requests for one universal power number
+- attempts to mint authority rights through flavor instead of proof

--- a/.agents/skills/aoa-session-progression-lift/examples/runtime.md
+++ b/.agents/skills/aoa-session-progression-lift/examples/runtime.md
@@ -1,0 +1,55 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed session did not just produce reusable artifacts.
+It also showed cleaner boundary discipline, sharper review posture, and one safe
+unlock hint for how the next session-harvest move could widen.
+The checkpoint note also contains two provisional axis hints that need review:
+one is confirmed by the session artifact, and one is carried as no movement.
+The prior delta exists for two axes, while one new axis is only first-observed.
+
+## Why this skill fits
+
+The next honest output is a small evidence-backed progression overlay, not one
+more owner-layer routing pass and not one fake universal score.
+
+## Expected inputs
+
+- reviewed session artifact or harvest packet
+- named evidence refs
+- role or cohort context if known
+- any current progression baseline if one exists
+
+## Expected outputs
+
+- one `PROGRESSION_DELTA`
+- baseline posture before any comparative movement claim
+- qualitative axis movement
+- evidence posture for each meaningful axis, including confirmed and
+  no-movement rows where appropriate
+- one verdict such as advance, hold, reanchor, or downgrade
+- optional unlock hints, quest hooks, or chronicle stub
+- one `PROGRESSION_DELTA_RECEIPT` with axis delta summary, verdict, and any
+  caution refs
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-session-progression-lift` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill without reviewed evidence.
+- Do not turn progression into routing authority.
+- Do not flatten multi-axis growth into one number.
+
+## Verification notes
+
+- Confirm meaningful claims cite evidence.
+- Confirm baseline posture is named before comparative movement.
+- Confirm provisional checkpoint or closeout hints did not become growth claims
+  without reviewed support.
+- Confirm negative or zero movement remains possible.
+- Confirm unlock hints stay small and explicit.
+- Confirm the finish receipt stays multi-axis and does not collapse movement
+  into a universal score.
+- Confirm the generic core receipt points back to the progression receipt and
+  does not become progression authority.

--- a/.agents/skills/aoa-session-route-forks/SKILL.md
+++ b/.agents/skills/aoa-session-route-forks/SKILL.md
@@ -25,7 +25,7 @@ matters, what each one likely costs, and where each route probably lands first.
 ## Trigger boundary
 Use this skill when:
 - a reviewed session ended with multiple plausible next moves
-- the operator or Codex needs explicit branch choices instead of a buried recommendation
+- the operator or local coding agent needs explicit branch choices instead of a buried recommendation
 - the next route may change owner repo, risk posture, or difficulty posture
 - the choice may include staying manual, becoming a bounded skill, becoming a playbook automation seed candidate, or waiting for prerequisite repair
 - the session needs quest-board legibility without pretending to be runtime state

--- a/.agents/skills/aoa-session-route-forks/agents/openai.yaml
+++ b/.agents/skills/aoa-session-route-forks/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-route-forks/checks/review.md
+++ b/.agents/skills/aoa-session-route-forks/checks/review.md
@@ -1,0 +1,35 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that turns one reviewed session or
+harvest packet into explicit next-route forks.
+
+## When it applies
+
+- several plausible next routes remain after a reviewed session
+- the reviewer must check whether the branch cards are evidence-backed and
+  materially different
+- the route needs visible stop conditions and owner targets instead of one
+  hidden recommendation
+
+## Review checklist
+
+- [ ] The source artifact was reviewed and bounded before fork analysis.
+- [ ] Each branch differs materially rather than cosmetically.
+- [ ] Each branch names a likely first owner repo.
+- [ ] Each branch names a likely gain, cost, and risk.
+- [ ] Risky or expensive branches include explicit stop conditions.
+- [ ] Hold, defer, or reanchor remains available when uncertainty is real.
+- [ ] A single selected child route was not launched from the fork cards; if it is anchored and output-named, it was routed to `aoa-summon`.
+- [ ] Quest-board language stays reflective rather than authoritative.
+- [ ] `aoa-routing` and `aoa-kag` were not treated as first-authoring targets.
+- [ ] Any `DECISION_FORK_RECEIPT` stayed evidence-linked and subordinate to the fork cards.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` pointed to the fork detail receipt and stayed generic finish telemetry rather than route authority.
+
+## Not a fit
+
+- sessions that still need first-pass donor harvest
+- routes with only one obvious next bounded move
+- single anchored child-route launches that belong to `aoa-summon`
+- final promotion triage for one repeated quest unit

--- a/.agents/skills/aoa-session-route-forks/examples/runtime.md
+++ b/.agents/skills/aoa-session-route-forks/examples/runtime.md
@@ -1,0 +1,53 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed session has already produced a donor packet, but three honest next
+routes remain:
+1. deepen the donor-harvest nucleus
+2. add a new sibling skill for route choice
+3. defer the family split and keep the work as one bounded owner-repo change
+
+## Why this skill fits
+
+The surviving problem is not donor extraction anymore.
+It is explicit branch analysis across several plausible next routes with
+different gains, costs, and risks.
+
+## Expected inputs
+
+- reviewed session artifact or harvest packet
+- named next-route candidates
+- known risks and dependencies
+- desired control mode or operator preference if already known
+
+## Expected outputs
+
+- `FORK_CARDS` for each materially different route
+- one likely first owner repo for each branch
+- one suggested default route if the evidence is strong enough
+- one hold or defer option if uncertainty remains meaningful
+- one `DECISION_FORK_RECEIPT` with branch ids, risk posture, and stop-condition refs
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-session-route-forks` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill before donor harvest exists.
+- Do not use this skill as hidden routing policy.
+- Do not launch a child route from the cards; once one branch is selected,
+  anchored, and output-named, use `aoa-summon`.
+- Do not confuse branch analysis with final promotion triage.
+- Treat historical fixture suffixes such as wave labels as lineage only. Skill
+  output should use stable names like `FORK_CARDS`,
+  `DECISION_FORK_RECEIPT`, and `CORE_SKILL_APPLICATION_RECEIPT`.
+
+## Verification notes
+
+- Confirm each branch is materially distinct.
+- Confirm costs, risks, and stop conditions are visible.
+- Confirm the cards preserve choice rather than erase alternatives.
+- Confirm the finish receipt stays descriptive rather than pretending the route
+  is already chosen by policy.
+- Confirm the generic core receipt stays separate from route authority and
+  references the detail receipt.

--- a/.agents/skills/aoa-session-self-diagnose/agents/openai.yaml
+++ b/.agents/skills/aoa-session-self-diagnose/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-self-diagnose/checks/review.md
+++ b/.agents/skills/aoa-session-self-diagnose/checks/review.md
@@ -1,0 +1,35 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that turns one reviewed session into a
+bounded `DIAGNOSIS_PACKET`.
+
+## When it applies
+
+- the route needs diagnosis before repair
+- repeated friction, contradiction, proof debt, or boundary drift survived the
+  reviewed session
+- the reviewer must check whether symptoms, causes, and owner hints stayed
+  separate and honest
+
+## Review checklist
+
+- [ ] The source artifact was reviewed and bounded before diagnosis.
+- [ ] Each diagnosis cites concrete evidence refs.
+- [ ] Symptoms and probable causes stay separate.
+- [ ] Probable causes remain probabilistic when evidence is thin.
+- [ ] Each meaningful symptom and probable cause carries an evidence posture such as reviewed symptom, reviewed inference, provisional hint, contested evidence, stale evidence, or unknown.
+- [ ] Checkpoint, closeout, generated, or stale hints were not treated as settled diagnosis evidence.
+- [ ] A likely owner layer is named without pretending the verdict is already final.
+- [ ] Unknowns are preserved where evidence is incomplete.
+- [ ] No hidden mutation or silent repair happened.
+- [ ] Cross-layer issues are not lazily blamed on one convenient owner.
+- [ ] Any `DIAGNOSIS_PACKET_RECEIPT` stayed evidence-linked and descriptive rather than blame-shaped.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` pointed to the detail diagnosis receipt and stayed generic finish telemetry only.
+
+## Not a fit
+
+- live or unreviewed sessions
+- issues that are already fully diagnosed and only need repair execution
+- single promotion verdict questions that belong to `aoa-quest-harvest`

--- a/.agents/skills/aoa-session-self-diagnose/examples/runtime.md
+++ b/.agents/skills/aoa-session-self-diagnose/examples/runtime.md
@@ -1,0 +1,50 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed session repeatedly mixed technique language with skill language,
+lost proof boundaries during recap, and kept reopening the same ownership
+confusion in follow-up steps.
+
+## Why this skill fits
+
+The next honest move is not immediate repair or promotion.
+It is a bounded read-only diagnosis pass that separates symptoms from probable
+causes and names the likely owner layers involved.
+
+## Expected inputs
+
+- reviewed session artifact or harvest packet
+- observed frictions, contradictions, or failures
+- touched owner layers and repos
+- any earlier related evidence if available
+- checkpoint, closeout, generated, or earlier-session hints marked as hints
+
+## Expected outputs
+
+- one `DIAGNOSIS_PACKET`
+- named drift types, symptoms, probable causes, and repair shapes
+- evidence posture for each meaningful symptom and probable cause
+- owner hints and explicit unknowns
+- optional handoff to `aoa-session-self-repair`
+- one `DIAGNOSIS_PACKET_RECEIPT` that records diagnosis types, confidence
+  band, and evidence-linked owner hints
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-session-self-diagnose` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill for live-session debugging.
+- Do not perform the repair inside the diagnosis pass.
+- Do not turn one anecdote into structural certainty.
+
+## Verification notes
+
+- Confirm the diagnosis cites evidence.
+- Confirm symptoms and causes are separated.
+- Confirm likely causes do not outrun their evidence posture.
+- Confirm unknowns stay visible where evidence is weak.
+- Confirm the finish receipt stays smaller than the diagnosis packet and does
+  not read like a final repair verdict.
+- Confirm the generic core receipt points back to the diagnosis receipt and
+  does not claim repair or proof authority.

--- a/.agents/skills/aoa-session-self-repair/agents/openai.yaml
+++ b/.agents/skills/aoa-session-self-repair/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-session-self-repair/checks/review.md
+++ b/.agents/skills/aoa-session-self-repair/checks/review.md
@@ -1,0 +1,34 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that turns a reviewed diagnosis into a
+bounded `REPAIR_PACKET`.
+
+## When it applies
+
+- a diagnosis already exists and the next honest move is repair planning
+- the reviewer must check checkpoint posture, rollback thinking, and owner-layer
+  fit
+- the route must stay smaller than a playbook-scale rollout
+
+## Review checklist
+
+- [ ] A reviewed diagnosis exists and is cited explicitly.
+- [ ] The chosen repair is the smallest honest shape.
+- [ ] The primary owner repo and artifact class are named.
+- [ ] Repair execution posture is explicit: proposed, prepared, executing, verified, blocked, or handoff_required.
+- [ ] Prepared repair is not described as executed, and executed repair is not described as verified without validation evidence.
+- [ ] Checkpoint posture is explicit: policy fit, approval gate, rollback marker, health check, iteration limit, and improvement log.
+- [ ] Validation and stop conditions are named.
+- [ ] Escalation exists if the repair widens beyond one bounded unit.
+- [ ] Role-law and proof-law changes were routed to the correct owner layers.
+- [ ] No silent doctrine edit or approval bypass happened.
+- [ ] Any `REPAIR_CYCLE_RECEIPT` stayed append-only, diagnosis-linked, and smaller than the repair packet.
+- [ ] Any `CORE_SKILL_APPLICATION_RECEIPT` pointed to the repair detail receipt and stayed generic finish telemetry only.
+
+## Not a fit
+
+- repair work without a reviewed diagnosis
+- broad scenario rollouts that belong in `aoa-playbooks`
+- vague self-improvement rhetoric with no bounded target

--- a/.agents/skills/aoa-session-self-repair/examples/runtime.md
+++ b/.agents/skills/aoa-session-self-repair/examples/runtime.md
@@ -1,0 +1,50 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed diagnosis packet found repeated owner-layer collapse and missing
+trigger-boundary fixtures in the session-harvest family.
+
+## Why this skill fits
+
+The next honest move is a bounded repair packet with checkpoint posture,
+rollback thinking, and explicit owner targets rather than immediate silent
+mutation.
+
+## Expected inputs
+
+- reviewed diagnosis packet
+- target owner-layer candidates
+- risk and approval posture
+- known validation surfaces
+- rollback anchors if available
+- whether the repair is proposed, prepared, executing, verified, blocked, or handed off
+
+## Expected outputs
+
+- one `REPAIR_PACKET`
+- a smallest diff shape or repair quest
+- execution posture that distinguishes prepared repair from executed or verified repair
+- approval need, rollback marker, health check, and improvement-log stub
+- explicit stop conditions and escalation points
+- one `REPAIR_CYCLE_RECEIPT` with diagnosis refs, checkpoint posture, and
+  bounded verification refs
+- one `CORE_SKILL_APPLICATION_RECEIPT` that records the finished
+  `aoa-session-self-repair` run and points back to the detail receipt
+
+## Boundary notes
+
+- Do not use this skill without a reviewed diagnosis.
+- Do not bypass approval or rollback posture.
+- Do not turn a playbook-scale rollout into one fake "repair packet".
+
+## Verification notes
+
+- Confirm checkpoint fields are present.
+- Confirm execution posture is present and does not overclaim validation.
+- Confirm the repair stays bounded.
+- Confirm escalation is named if the route widens.
+- Confirm the finish receipt cites rollback and health-check posture without
+  pretending the repair is already fully verified.
+- Confirm the generic core receipt points back to the repair receipt and does
+  not replace checkpoint posture or repair meaning.

--- a/.agents/skills/aoa-source-of-truth-check/agents/openai.yaml
+++ b/.agents/skills/aoa-source-of-truth-check/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-source-of-truth-check/examples/example.md
+++ b/.agents/skills/aoa-source-of-truth-check/examples/example.md
@@ -1,0 +1,45 @@
+# Example
+
+## Scenario
+
+A repository has a top-level `README`, `ROADMAP`, runbook, source manifest, generated export, and preserved legacy receipts. The entrypoint docs have started collecting historical audit detail, generated report fields, and package-local notes even though canonical source surfaces and provenance bridges already exist.
+
+## Why this skill fits
+
+- the main problem is authority mapping across docs, source manifests, generated outputs, run guidance, and provenance
+- contributors need a clearer map of which surface to trust first
+- the goal is to keep top-level docs short and link-driven once canonical homes already exist
+- the generated export must remain subordinate to the source-owned manifest or builder
+- the legacy material must stay recoverable without becoming the active contract
+
+## Expected inputs
+
+- the set of documents, manifests, generated outputs, and operational surfaces that currently overlap
+- the area of ambiguity, such as setup, deployment, incident response, or status reporting
+- any known canonical files, source-owned configs, schemas, manifests, builders, or unclear ownership rules
+- active, legacy/provenance, generated, and decision surfaces that may be carrying the same meaning
+- examples of contributor confusion caused by the overlap or bloated snapshot docs
+
+## Expected outputs
+
+- a clearer source-of-truth map for the affected concerns
+- a placement decision for active behavior, source-owned manifests, historical evidence, generated companions, and decision rationale
+- notes on conflicting or duplicated guidance
+- lightweight snapshot guidance for `README` or `MANIFEST` when canonical homes already exist
+- a short verification summary explaining why the authority route is easier to navigate
+
+## Boundary notes
+
+- this example is about clarifying authority and ownership, plus keeping summary docs lightweight
+- it is not about writing a decision record unless the main unresolved problem is rationale rather than conflicting docs
+- it is not about generic docs cleanup when no canonical homes exist yet
+- it is not about rebuilding a generated export when the source owner is already clear
+- it is not about erasing legacy evidence; it is about routing active readers through current surfaces first
+
+## Verification notes
+
+- verify that each concern now has a named authoritative file or source-owned surface
+- verify that overview docs no longer silently compete with canonical instructions
+- verify that top-level snapshot docs stay short and route detail outward
+- verify that legacy/provenance and generated surfaces remain discoverable but subordinate to active source surfaces
+- verify that a new contributor could orient faster after the clarification

--- a/.agents/skills/aoa-summon/SKILL.md
+++ b/.agents/skills/aoa-summon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aoa-summon
-description: Delegate one bounded child route through quest-passport law, local-first Codex execution defaults, hard gates for progression, self-agent, and stress posture, and governed return into reviewed closeout. Use when a parent route already has a real anchor and named outputs and the honest next move is a narrower child reviewer, evaluator, verifier, or leaf helper rather than a larger orchestration layer. Do not use when the route lacks an anchor, the outputs are unnamed, the work is `d3+` and still needs a split, or remote delegation is being used to bypass proof, approval, or closeout posture.
+description: Delegate one bounded child route through quest-passport law, local coding-agent execution defaults, hard gates for progression, self-agent, and stress posture, and governed return into reviewed closeout. Use when a parent route already has a real anchor and named outputs and the honest next move is a narrower child reviewer, evaluator, verifier, or leaf helper rather than a larger orchestration layer. Do not use when the route lacks an anchor, the outputs are unnamed, the work is `d3+` and still needs a split, or remote delegation is being used to bypass proof, approval, or closeout posture.
 license: Apache-2.0
 compatibility: Designed for Codex or similar coding agents with repository file access and an interactive shell. Network access is optional and only needed when repository validation or referenced workflows require it.
 metadata:
@@ -20,7 +20,7 @@ Use this skill to decide whether and how to launch one bounded child route from
 an already-anchored parent route.
 
 The goal is not delegation theater.
-The goal is to preserve quest-passport law, Codex-first local execution,
+The goal is to preserve quest-passport law, local coding-agent execution,
 stress narrowing, progression and self-agent gates, return planning,
 checkpoint-aware reviewed closeout, and owner-local publication mapping.
 
@@ -31,7 +31,7 @@ Use this skill when:
   implementation, or local verification
 - the child result must map back into return, closeout, and owner-publication
   surfaces
-- local Codex execution is the honest default unless a separate execution
+- local coding-agent execution is the honest default unless a separate execution
   surface is actually required
 
 Do not use this skill when:
@@ -51,15 +51,15 @@ Do not use this skill when:
   named expected outputs
 - named expected outputs for the child route
 - optional reviewed artifact path, stress bundle ref, checkpoint note ref,
-  Codex trace ref, progression overlay ref, self-agent checkpoint ref, and
+  local agent trace ref, progression overlay ref, self-agent checkpoint ref, and
   audit refs
 
 ## Outputs
 - one summon decision with allowed or blocked posture
-- one chosen lane such as `codex_local_leaf`, `codex_local_reviewed`,
+- one chosen lane such as local leaf execution, local reviewed execution,
   `remote_reviewed`, `split_required`, or `human_gate`
 - `execution_surface`, `cohort_pattern`, `reason_codes`, and `blocked_actions`
-- optional `codex_local_target`
+- optional local child target
 - `return_plan`, `checkpoint_bridge_plan`, `memo_export_plan`, and
   `owner_publication_plan`
 - return receipt or acceptance expectation when the child crosses an actor,
@@ -68,14 +68,14 @@ Do not use this skill when:
 
 ## Procedure
 1. start from the parent anchor and quest passport, not from raw pressure to delegate
-2. default `transport_preference` to `codex_local` when the request leaves it open
+2. default `transport_preference` to local execution when the request leaves it open
 3. verify that expected outputs are named before picking a lane
 4. classify the lane with difficulty, risk, control mode, requested role, and
    `references/passport-lane-matrix.v3.md`
 5. keep low-risk `d0_probe`, `d1_patch`, and bounded `d2_slice` leaf work in
-   `codex_local_leaf` when anchor and outputs are clear
+   local leaf execution when anchor and outputs are clear
 6. keep local reviewer, evaluator, and architect-like narrowing work in
-   `codex_local_reviewed`
+   local reviewed execution
 7. allow `remote_reviewed` only when a separate endpoint or execution surface
    is actually required
 8. if difficulty is `d3+`, return `split_required` instead of launching child execution
@@ -97,7 +97,7 @@ Do not use this skill when:
 ## Contracts
 - this skill governs one bounded child route; it does not grant hidden
   orchestration authority
-- local Codex child targeting is the default first choice, not an afterthought
+- local coding-agent child targeting is the default first choice, not an afterthought
 - branch choice must already be settled; unresolved route choice belongs to
   `aoa-session-route-forks`
 - the SDK-owned E2E fixture at

--- a/.agents/skills/aoa-summon/agents/openai.yaml
+++ b/.agents/skills/aoa-summon/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: manual
   allow_implicit_invocation: false

--- a/.agents/skills/aoa-summon/checks/review.md
+++ b/.agents/skills/aoa-summon/checks/review.md
@@ -1,0 +1,36 @@
+# Review Checklist
+
+## Purpose
+
+Use this checklist when reviewing work that decides whether one bounded child
+route may be summoned from an already-anchored parent route.
+
+## When it applies
+
+- a parent route wants a narrower child reviewer, evaluator, verifier, or leaf
+  implementation helper
+- the reviewer must check lane choice, gating posture, and return planning
+- the route may cross progression, self-agent, or stress posture
+- the output must stay child-route governance rather than hidden orchestration
+
+## Review checklist
+
+- [ ] The parent route has a real anchor and named expected outputs.
+- [ ] Branch choice is already settled; unresolved competing routes were sent to `aoa-session-route-forks` first.
+- [ ] The quest passport is present and was actually used for lane selection.
+- [ ] `codex_local` remained the default unless a separate execution surface was genuinely needed.
+- [ ] `d3+` work was blocked into `split_required` instead of being launched directly.
+- [ ] Stress posture only narrowed or blocked the route and did not widen authority.
+- [ ] Progression and self-agent gates were checked when the route required them.
+- [ ] The result names a lane, execution surface, reason codes, and blocked actions when relevant.
+- [ ] Return, checkpoint bridge, memo export, and owner publication plans stayed explicit.
+- [ ] Cross-boundary child work has a receipt or acceptance expectation before the parent route continues.
+- [ ] Child traces were kept subordinate to reviewed closeout and did not become proof or memo canon.
+- [ ] Remote transport, when allowed, preserved the same passport and closeout law as local execution.
+
+## Not a fit
+
+- parent routes with no real anchor or unnamed outputs
+- `d3+` routes that still need decomposition
+- requests for broad orchestration authority rather than one bounded child route
+- attempts to use remote delegation as a shortcut around approval, checkpoint, or reviewed closeout posture

--- a/.agents/skills/aoa-summon/examples/runtime.md
+++ b/.agents/skills/aoa-summon/examples/runtime.md
@@ -1,0 +1,61 @@
+# Runtime Example
+
+## Scenario
+
+A reviewed `aoa-sdk` route already has a parent task anchor, a clear list of
+expected outputs, and a bounded need for a local coding-agent reviewer to inspect one
+package-layer fix before the parent route proceeds to validation.
+
+## Why this skill fits
+
+The parent route is already real and anchored. What is needed is not a whole
+new orchestration layer but one bounded child route that keeps the same
+passport, returns explicit outputs, and maps cleanly back into reviewed
+closeout.
+
+## Expected inputs
+
+- a quest passport with the parent difficulty, risk, control mode, and
+  delegate tier
+- a summon request naming the child role, transport preference, anchor, and
+  expected outputs
+- the reviewed parent artifact or route note
+- optional stress, checkpoint, or progression refs when the route needs them
+
+## Expected outputs
+
+- one summon decision that selects the local reviewed execution lane
+- one local child target with named expected outputs
+- reason codes explaining why local reviewed execution is sufficient
+- a return plan that says how the child result rejoins the parent route
+- a checkpoint bridge plan for reviewed closeout if the child narrows but does
+  not fully finish the route
+- an owner publication plan that keeps terminal meaning in the parent owner
+  repo rather than in derived traces
+
+The SDK-owned fixture
+`repo:aoa-sdk/examples/a2a/summon_return_checkpoint_e2e.fixture.json` is the
+current full-chain check for this scenario. It should validate this skill's v3
+`summon_request` and `summon_result` schemas while leaving the SDK helper,
+checkpoint bridge, memo candidate, eval packet, runtime dry-run receipt, and
+routing re-entry in their owning repositories.
+
+## Boundary notes
+
+- Do not use this skill until the parent route has a real anchor and named outputs.
+- Do not use this skill while several next routes still compete; use
+  `aoa-session-route-forks` first.
+- Do not let `d3+` work skip the split step.
+- Do not let remote transport bypass the same gates that local execution must satisfy.
+- Treat historical fixture suffixes such as wave labels as lineage only. Skill
+  output should use stable v3 request/result names and explicit route refs.
+
+## Verification notes
+
+- Confirm the lane is justified by the passport and requested role.
+- Confirm local coding-agent execution stayed the default.
+- Confirm return and closeout planning are explicit.
+- Confirm receipt or acceptance expectations are clear when the child crosses
+  actor, session, or owner boundaries.
+- Confirm any traces remain subordinate to reviewed closeout.
+- Confirm owner publication stays in the canonical owner family.

--- a/.agents/skills/aoa-tdd-slice/agents/openai.yaml
+++ b/.agents/skills/aoa-tdd-slice/agents/openai.yaml
@@ -6,4 +6,5 @@ interface:
   icon_large: ./assets/large-logo.svg
   brand_color: '#2563EB'
 policy:
+  implicit_activation_policy: invoke
   allow_implicit_invocation: true

--- a/.agents/skills/aoa-tdd-slice/examples/example.md
+++ b/.agents/skills/aoa-tdd-slice/examples/example.md
@@ -1,0 +1,37 @@
+# Example
+
+## Scenario
+
+A catalog builder needs a new behavior: when a source bundle declares an optional support reference, the generated compact export should include that reference once with its source path, while existing bundles without support references should continue to export unchanged.
+
+## Why this skill fits
+
+- the desired behavior is clear before implementation starts
+- the change is small enough to stay inside one bounded slice
+- confidence matters because downstream readers rely on the generated export shape
+- the test can drive the source-to-output mapping without hand-editing the generated artifact
+
+## Expected inputs
+
+- the desired source-to-export behavior and the exact fixture shape
+- the builder or command that produces the compact export
+- the existing test surface for builder behavior
+- non-goals such as redesigning catalog schema, rewriting routing, or changing unrelated export fields
+
+## Expected outputs
+
+- a failing test that expresses the new support-reference mapping before implementation
+- the smallest implementation change that makes the test pass
+- a short verification summary naming the relevant passing tests
+
+## Boundary notes
+
+- this example is about a bounded behavior slice, not a broader rewrite of the validation framework
+- unrelated cleanup such as renaming modules, changing generated sort order, or rewriting export packaging stays out of scope
+- it is not a source-of-truth decision because the source owner is already clear; the task is to specify one observable builder behavior
+
+## Verification notes
+
+- add or update the builder fixture test first
+- run the focused test suite that covers source bundles with and without support references
+- report the covered behavior and note that unrelated export fields were left untouched


### PR DESCRIPTION
## Summary

Refreshes the shared AoA skill pack from canonical `aoa-skills` export after the core skills audit closure.

## Scope

- Updates exported `.agents/skills` metadata for implicit activation policy.
- Adds portable `checks/` and `examples/` resources where the canonical source provides them.
- Preserves downstream ownership: no local source doctrine or runtime files are changed.

## Verification

- Source `aoa-skills` PR passed `build-validate` and `Repo Validation`.
- Workspace adoption audits report zero missing and zero drift for foundation/session-growth packs and ATM10 overlay.
- Downstream staged scope was limited to `.agents/skills`.
