### PR TITLE
[codex] clarify root document roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- tightened root-document roles across [README](README.md), [CHARTER](CHARTER.md),
+  [DESIGN](DESIGN.md), [DESIGN.AGENTS](DESIGN.AGENTS.md), [ROADMAP](ROADMAP.md),
+  [CONTRIBUTING](CONTRIBUTING.md), and [QUESTBOOK](QUESTBOOK.md) so root stays
+  link-driven, owner-routed, and free of avoidable duplicated doctrine
 - slimmed old root Markdown entry surfaces by turning `README.md` back into a
   compact public front door and reducing `ROADMAP.md` to live repo direction;
   detailed mechanic runbooks, generated readers, semantic/shadow reviews, tree

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,26 +2,26 @@
 
 ## Purpose
 
-`aoa-techniques` is the public practice canon for reusable agentic techniques.
-It publishes compact, sanitized, reviewable moves that can be reused by humans,
-coding agents, small models, and downstream AoA layers without requiring a full
-OS Abyss deployment.
+`aoa-techniques` is the public practice canon for reusable agentic technique
+moves. It publishes compact, sanitized, reviewable practice that humans, coding
+agents, small models, and downstream AoA layers can reuse without requiring a
+full OS Abyss deployment.
 
 The repository is strongest when it keeps one technique small enough to select,
 template, execute, and verify. It is weakest when it absorbs skills, playbooks,
-proof doctrine, routing policy, memory semantics, or private project operation
-because those objects are nearby.
+proof doctrine, routing policy, memory semantics, private project operation, or
+other nearby objects that already have stronger owners.
 
 ## Authority Boundary
 
 This charter answers what `aoa-techniques` may claim about the practice canon.
 
-Operational editing routes live in `AGENTS.md`, contribution rules live in
-`CONTRIBUTING.md`, and detailed authoring contracts live in
-`docs/TECHNIQUE_ATOM_CONTRACT.md`, `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`, and
-`docs/TECHNIQUE_TREE_CONTRACT.md`.
-This charter gives those routes their repository boundary. It does not replace
-them.
+Operational editing routes live in [AGENTS](AGENTS.md). Public contribution
+rules live in [CONTRIBUTING](CONTRIBUTING.md). Detailed authoring contracts live
+in [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md),
+[TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md), and
+[TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md). This charter gives
+those routes their repository boundary; it does not replace them.
 
 ## Mission
 
@@ -42,18 +42,16 @@ It should:
 
 ## What This Repository Owns
 
-| Owned object | Meaning |
-|---|---|
-| Technique meaning | authored `techniques/**/TECHNIQUE.md` bundles and their bounded contracts |
-| Technique IDs | stable public identifiers and source paths for reusable practice |
-| Technique atom law | the rule that one technique is one compact executable move |
-| Technique topology | current `domain` and `kind` truth plus reviewed future axes such as family, capability, substrate, execution profile, risk posture, and relations |
-| Technique tree | scalable root path architecture for corpus trunks, shelves, and leaf bundles, kept distinct from frontmatter truth |
-| Public-safe wording | sanitized technique text, examples, checks, notes, and route docs |
-| Adaptation evidence | origin, reuse, adverse-effect, promotion, and external-origin notes at the technique layer |
-| Mechanics participation | owner-local movement around donor intake, audit, promotion, recurrence, checkpoint, release support, RPG reflection, and other AoA mechanics before a practice becomes canon |
-| Generated technique surfaces | catalogs, capsules, source-lift readers, and other derived outputs that stay subordinate to authored sources |
-| Technique contribution path | public proposal, review, promotion, deprecation, release, and validation posture for this repo |
+- Technique meaning: authored [techniques](techniques/) bundles and their bounded contracts
+- Technique IDs: stable public identifiers and source paths for reusable practice
+- Technique atom law: one technique is one compact executable move
+- Technique topology: current `domain` and `kind` truth plus reviewed future axes
+- Technique tree: scalable root path architecture, distinct from frontmatter truth
+- Public-safe wording: sanitized technique text, examples, checks, notes, and route docs
+- Adaptation evidence: origin, reuse, adverse-effect, promotion, and external-origin notes
+- Mechanics participation: owner-local movement before a practice becomes canon
+- Generated technique surfaces: catalogs, capsules, source-lift readers, and derived outputs
+- Technique contribution path: proposal, review, promotion, deprecation, release, and validation
 
 ## Routed To Stronger Owners
 
@@ -95,13 +93,13 @@ Before changing the repository's root posture, technique-canon boundary, or
 public route map, check:
 
 1. this charter for repository authority
-2. `docs/ROOT_SURFACE_LAW.md` for root and docs-root placement
-3. `docs/START_HERE.md` for the shortest current route
-4. `docs/TECHNIQUE_ATOM_CONTRACT.md` for atomicity
-5. `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md` for classification topology
-6. `docs/TECHNIQUE_TREE_CONTRACT.md` for corpus path architecture
-7. `docs/ECOSYSTEM_CONTEXT.md` for AoA layer boundaries
-8. `mechanics/README.md` when the change concerns practice movement before or
+2. [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) for root and docs-root placement
+3. [START_HERE](docs/START_HERE.md) for the shortest current route
+4. [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) for atomicity
+5. [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md) for classification topology
+6. [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) for corpus path architecture
+7. [ECOSYSTEM_CONTEXT](docs/ECOSYSTEM_CONTEXT.md) for AoA layer boundaries
+8. [mechanics README](mechanics/README.md) when the change concerns practice movement before or
    around canon
 9. generated surfaces, builders, validators, and tests before claiming parity
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,29 +4,30 @@ Thank you for contributing.
 
 ## What belongs here
 
-Good contributions:
-- reusable agent workflows
-- validation patterns
-- safe operational techniques
-- documentation patterns
-- evaluation and monitoring loops
-- cross-repo transfer patterns
-- infra safety patterns
+Good contributions are public-safe, reusable practice objects:
 
-Bad contributions:
-- random snippets
-- private hacks without generalization
-- internal-only assumptions
-- undocumented scripts
-- techniques with no clear validation path
+- one atomic technique bundle
+- focused improvement to an existing technique
+- promotion, deprecation, or review evidence for a technique
+- authoring, review, selection, capsule, or provenance template improvement
+- validation or generated-parity improvement owned by this repository
+- external-source adaptation with clear provenance and public-safe boundaries
+
+Route away or hold in mechanics when the object is a broad workflow, raw donor
+dump, internal-only hack, private operational note, undocumented script, or
+technique-shaped text with no validation path.
 
 ## Before opening a PR
 
 Please make sure:
 - the technique is sanitized
 - the technique has a clear purpose
-- the technique chooses exactly one primary `kind` using [Technique Kind Guide](docs/selection/TECHNIQUE_KIND_GUIDE.md) and the registry tie-break rules
-- `tags` carry extra nuance, while `family` stays scout-only and non-authoritative in this wave
+- the candidate passes [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- the technique chooses exactly one primary `kind` using
+  [Technique Kind Guide](docs/selection/TECHNIQUE_KIND_GUIDE.md) and registry
+  tie-break rules
+- `tags` carry extra nuance, while `family` stays scout-only and
+  non-authoritative in this wave
 - the technique includes a canonical `TECHNIQUE.md`
 - examples are public-safe
 - risks are documented as failure modes, negative effects, misuse patterns, detection signals, and mitigations
@@ -34,26 +35,33 @@ Please make sure:
 - maturity status is set correctly
 - origin is stated clearly
 
-Before opening a PR, run `python -m pip install -r requirements-dev.txt`, then run `python scripts/release_check.py` as the bounded repo-wide validation path.
+Before opening a PR, run `python -m pip install -r requirements-dev.txt`, then
+run `python scripts/release_check.py` as the bounded repo-wide validation path.
+The transparent lower-level breakdown lives in [RELEASING](docs/RELEASING.md).
 
-That command is the public release-check entrypoint for this repository.
-If you need the transparent lower-level breakdown, it runs the current build path and ends with `python -m unittest discover -s tests` plus `python scripts/validate_repo.py`, after the same `requirements-dev.txt` install step.
+When the `kind` choice feels ambiguous, start from
+[Technique Kind Guide](docs/selection/TECHNIQUE_KIND_GUIDE.md) and keep the
+review narrow instead of widening the axis.
 
-When the `kind` choice feels ambiguous, start from [Technique Kind Guide](docs/selection/TECHNIQUE_KIND_GUIDE.md) and keep the review narrow instead of widening the axis.
-
-See `docs/review/TECHNIQUE_SHADOW_GUIDE.md` for the repo-level shadow-discipline guidance behind the `## Risks` section.
+See [TECHNIQUE_SHADOW_GUIDE](docs/review/TECHNIQUE_SHADOW_GUIDE.md) for the
+repo-level shadow-discipline guidance behind the `## Risks` section.
 
 ## External provenance
 
-If a contribution is adapted from an external open-source source, include a normal `TECHNIQUE.md` and add `templates/EXTERNAL_ORIGIN.template.md` as the provenance note.
+If a contribution is adapted from an external open-source source, include a
+normal `TECHNIQUE.md` and add [EXTERNAL_ORIGIN.template](templates/EXTERNAL_ORIGIN.template.md)
+as the provenance note.
 
 Use the external-origin note only for external-source contributions.
 It should record `source_repo`, `source_license`, `inspired_by` or `adapted_from`, and `what_changed`.
 
 External imports must still be sanitized, reusable, and bounded.
 The provenance note complements the technique document; it does not replace the canonical `TECHNIQUE.md`.
-Use `mechanics/distillation/parts/external-import-runbook/README.md` for the maintainer-facing donor triage -> draft -> review -> merge path.
-Starter note templates for origin evidence, adaptation, promotion, adverse-effects review, external-origin provenance, and external review now live under `templates/`.
+Use [external-import-runbook](mechanics/distillation/parts/external-import-runbook/README.md)
+for the maintainer-facing donor triage -> draft -> review -> merge path.
+Starter note templates for origin evidence, adaptation, promotion,
+adverse-effects review, external-origin provenance, and external review live
+under [templates](templates/).
 
 ## GitHub intake surfaces
 
@@ -62,10 +70,12 @@ Use the GitHub templates for the first public intake layer:
 - `canonical` promotion review
 - external import review
 
-Use the pull request template when opening a PR so the summary, validation, and public-safety checks stay explicit and reviewable.
+Use the pull request template when opening a PR so the summary, validation, and
+public-safety checks stay explicit and reviewable.
+
 The agent-facing commit, push, pull request, validation, merge, and clean-main
-route lives in `AGENTS.md`. The GitHub templates keep the human-first intake
-shape aligned with that route; they do not replace the authored source docs.
+route lives in [AGENTS](AGENTS.md). The GitHub templates keep the human-first
+intake shape aligned with that route; they do not replace authored source docs.
 
 For new techniques or external imports, explicitly name:
 - the nearest existing technique or overlap watch
@@ -77,7 +87,8 @@ For new techniques or external imports, explicitly name:
 These issue and PR templates remain the authoritative human-first intake surfaces.
 Any later generated manifest over them is derived only and must not replace the authored templates themselves.
 
-Do not use public issues for leaks, secrets, credentials, or infrastructure-sensitive details; follow `SECURITY.md` instead.
+Do not use public issues for leaks, secrets, credentials, or
+infrastructure-sensitive details; follow [SECURITY](SECURITY.md) instead.
 
 The repo carries one narrow `CODEOWNERS` map for governance-critical root
 files, public docs, GitHub platform surfaces, mechanics, generated companions,
@@ -110,7 +121,7 @@ PRs are reviewed for:
 - validation quality
 - adaptation quality
 - maturity correctness
-- coherence with repository philosophy
+- fit with [CHARTER](CHARTER.md), [DESIGN](DESIGN.md), and the technique contracts
 
 ## Status transitions
 
@@ -133,4 +144,4 @@ Requires:
 ## Security
 
 If your contribution reveals a leak, secret, or security-sensitive detail,
-do not open a public issue. Use the process in `SECURITY.md`.
+do not open a public issue. Use the process in [SECURITY](SECURITY.md).

--- a/DESIGN.AGENTS.md
+++ b/DESIGN.AGENTS.md
@@ -20,24 +20,19 @@ validation, public safety, or return routes?
 
 It should give them a navigable mesh:
 
-- a root card that names repository identity, owner boundaries, and route
-  modes
-- top-level district cards that narrow source class and validation posture
-- mechanic package cards that keep practice-motion work owner-routed
-- technique trunk cards that protect published bundle meaning
-- deep cards for high-risk generated, legacy, part-local, or agent-lane
-  surfaces
-- validation surfaces that make the route checkable
-- generated companions that summarize the mesh without becoming the mesh
+- root card for repository identity, owner boundaries, and route modes
+- district cards for source class and validation posture
+- mechanic cards for practice-motion work
+- technique trunk cards for published bundle meaning
+- deep cards for generated, legacy, part-local, or agent-lane risk
+- validators and generated companions that check and summarize the mesh
 
 Agent guidance is not authority by volume. It is authority by placement,
 proximity, owner fit, validation, and explicit return.
 
-The root names the road system.
-The nearest card narrows the lane.
-The technique bundle keeps the move.
-The validator checks the claim.
-The closeout returns the work to the next reader.
+Root names the road system. The nearest card narrows the lane. The technique
+bundle keeps the move. The validator checks the claim. Closeout returns the
+work to the next reader.
 
 ## Design as Appearance
 
@@ -63,75 +58,30 @@ safety, or owner review.
 
 ## Design as Anatomy
 
-### Root card
+| Surface class | Role |
+|---|---|
+| Root card | repository identity, owner boundaries, route modes, broad validation, and closeout |
+| District cards | local source class, local risks, source surfaces, and local validation |
+| Technique cards | protection for bundle meaning and the split between tree placement and frontmatter truth |
+| Mechanic cards | practice-motion routes, provenance, generated mirrors, and sibling-owner stop lines |
+| Deep cards | high-friction generated, legacy, part-local, schema, manifest, or agent-lane surfaces |
+| Generated companions | reproducible mesh summaries that point back to source cards |
 
-The root `AGENTS.md` owns repository identity, owner boundaries, route modes,
-GitHub landing workflow, broad validation posture, and closeout expectations.
-
-It should not contain every local rule. Root law routes; local cards narrow.
-
-### District cards
-
-Top-level district cards own local source class, local risks, local source
-surfaces, and local validation.
-
-Examples include `docs/`, `techniques/`, `mechanics/`, `generated/`, `schemas/`,
-`templates/`, `tests/`, `.agents/`, and `.github/`.
-
-### Technique cards
-
-Technique trunk cards protect published bundle meaning. They should distinguish
-tree placement from frontmatter truth, and they should route agents back to
-`TECHNIQUE.md` instead of making the card a second technique.
-
-Bundle-local cards should be rare. Use them only when a surface has a genuine
-local rule that cannot live cleanly in the bundle.
-
-### Mechanic cards
-
-Mechanic cards protect practice-motion surfaces around canon. They should name
-active package surfaces, owner request or provenance routes, generated mirrors,
-local validation, and stop-lines to sibling AoA owners.
-
-They may shape candidate movement. They must not promote a candidate into canon
-by proximity.
-
-### Deep cards
-
-Deep cards protect high-friction surfaces such as legacy, generated reports,
-part-local scripts, manifests, schemas, or agent-lane exports.
-
-They exist because proximity matters. The safest rule is often nearest to the
-file that can be harmed.
-
-### Source surfaces
-
-Technique bundles, docs contracts, schemas, builders, validators, mechanics
-packages, generated-source configs, and neighboring owner repos keep meaning.
-
-`AGENTS.md` cards route agents to source truth. They do not become source truth
-by repetition.
-
-### Generated companions
-
-Generated AGENTS mesh indexes and other compact read models help low-context
-agents navigate.
-
-They are mirrors and companions. They must point back to source surfaces,
-remain reproducible, and avoid authoring new meaning.
+The source surfaces still keep meaning: technique bundles, docs contracts,
+schemas, builders, validators, mechanics packages, generated-source configs,
+and neighboring owner repositories. Agent cards route to them; they do not
+become source truth by repetition.
 
 ## Design as Operation
 
 A safe agent move follows a route before it touches content.
 
-1. Read the root card.
-2. Read the nearest local card for every touched path.
-3. Read the owner source surfaces named by those cards.
-4. Make the smallest change that preserves the owner boundary.
-5. Run the narrowest relevant validation first.
-6. Run broader gates when the change is release-facing, route-facing,
-   generated, structural, or cross-owner.
-7. Close out with changed surfaces, checks run, checks skipped, remaining risk,
+1. Read the root card and nearest local card for every touched path.
+2. Read the owner source surfaces named by those cards.
+3. Make the smallest change that preserves the owner boundary.
+4. Run narrow validation first, then broader gates for release-facing,
+   route-facing, generated, structural, or cross-owner changes.
+5. Close out with changed surfaces, checks run, checks skipped, remaining risk,
    and next owner route.
 
 Agency becomes stronger when it can stop, explain itself, and hand off cleanly.
@@ -218,48 +168,17 @@ legacy-card drift.
 
 ## Design Principles
 
-### 1. Locality before abstraction
-
-The nearest relevant card should carry the local rule. Root guidance should
-stay readable.
-
-### 2. Routes before commands
-
-A good card says which surface owns the claim, which route to follow, which
-check to run, and where to hand off.
-
-### 3. Source before instruction
-
-Instructions guide. Source surfaces own meaning. When they conflict, stop and
-route to the owner.
-
-### 4. Negative boundaries are design
-
-A clear "do not" prevents silent authority transfer.
-
-### 5. Validation is the handshake with reality
-
-Every substantial card should name the smallest useful validation path. Broad
-gates matter, but local checks keep work from becoming theatrical.
-
-### 6. Closeout is memory
-
-A closeout is the next agent's doorway: what changed, what was checked, what
-was skipped, what remains risky, and where work resumes.
-
-### 7. Generated companions are companions
-
-Machine-readable summaries are useful when they compress and route. They become
-dangerous when they author meaning or hide their source.
-
-### 8. Portability comes from repeated shape
-
-A portable agent layer is not copied text. It is copied discipline: same card
-shape, same owner logic, same validation posture, same closeout memory, adapted
-to local truth.
-
-### 9. Agency must remain returnable
-
-An agent may act, propose, validate, route, summarize, and hand off. Durable
-action should preserve review, rollback, evidence, and a way back to the owner
-surface.
+1. Locality before abstraction: the nearest relevant card carries the local rule.
+2. Routes before commands: a good card names owner, route, check, and handoff.
+3. Source before instruction: when instruction and source conflict, stop and
+   route to the owner.
+4. Negative boundaries are design: a clear "do not" prevents silent authority
+   transfer.
+5. Validation is the handshake with reality: local checks keep broad gates honest.
+6. Closeout is memory: say what changed, what was checked, what was skipped,
+   what remains risky, and where work resumes.
+7. Generated companions are companions: they compress and route, never author
+   meaning.
+8. Portability comes from repeated discipline, not copied text.
+9. Agency must remain returnable: durable action preserves review, rollback,
+   evidence, and a way back to the owner surface.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,8 +4,8 @@
 
 `DESIGN.md` describes the system form of `aoa-techniques`.
 
-It is not the charter, roadmap, technique index, authoring contract, or agent
-instruction file.
+It is not the charter, roadmap, technique index, authoring contract, or
+agent-instruction file.
 
 It answers one question:
 
@@ -16,27 +16,26 @@ library and an AoA organ?
 
 `aoa-techniques` is a public canon of reusable engineering practice.
 
-It should preserve small, source-authored technique meaning while giving humans,
-agents, and sibling AoA repositories enough route structure to select, verify,
-adapt, and lift a technique without confusing it with a skill, proof surface,
-playbook, memory object, routing policy, or runtime body.
+It preserves small, source-authored technique meaning while giving humans,
+agents, and sibling AoA repositories enough structure to select, verify, adapt,
+and lift a technique without confusing it with a skill, proof surface, playbook,
+memory object, routing policy, or runtime body.
 
-The technique bundle owns the move.
-The mechanics explain how practice moves.
-The generated surfaces help readers orient.
-The neighboring repositories own their own stronger layers.
+The bundle owns the move. Mechanics explain how practice moves. Generated
+surfaces help readers orient. Neighboring repositories own their stronger
+layers.
 
 ## Design as Appearance
 
 The repository should appear as a practice library with a clear public front
 door:
 
-- one compact repository entry route
-- a small set of durable authority and contract docs
-- a readable technique tree
-- mechanic districts for practice movement around canon
-- generated companions that make selection easier without authoring meaning
-- local agent cards that name the nearest safe route
+- compact entry route
+- durable authority and contract docs
+- readable technique tree
+- mechanic districts for practice movement
+- generated companions for selection
+- local agent cards for nearest-route safety
 
 A reader should be able to ask: what does this repo own, what is one technique,
 where does this bundle live, how mature is it, what validates it, and when
@@ -47,9 +46,9 @@ should I leave for another AoA owner?
 `aoa-techniques` is composed of different source classes:
 
 - root public entry and authority surfaces
-- source-authored technique bundles under `techniques/`
-- technique contracts and reader guides under `docs/`
-- practice-motion mechanics under `mechanics/`
+- source-authored technique bundles under [techniques](techniques/)
+- technique contracts and reader guides under [docs](docs/README.md)
+- practice-motion mechanics under [mechanics](mechanics/README.md)
 - repo-wide schemas, templates, configs, and examples
 - generated reader and machine companions
 - public-safe legacy and provenance surfaces
@@ -94,8 +93,8 @@ validation, or return clearer than before.
 
 ### 1. Atomic practice before orchestration
 
-One technique should describe one reusable move. Chains, workflows, scenarios,
-and live execution belong in stronger neighboring owners.
+One technique describes one reusable move. Chains, workflows, scenarios, and
+live execution belong in stronger neighboring owners.
 
 ### 2. Source before generated
 
@@ -137,13 +136,13 @@ technique canon.
 
 ## Good Design Feels Like
 
-A public reader can find one useful technique.
-An agent can find the nearest rule.
-A maintainer can find the owner surface.
-A generated file can find its source.
-A candidate can find its review path.
-A sibling repository can receive a bounded handoff.
-A future contributor can find why the route exists.
+- a public reader can find one useful technique
+- an agent can find the nearest rule
+- a maintainer can find the owner surface
+- a generated file can find its source
+- a candidate can find its review path
+- a sibling repository can receive a bounded handoff
+- a future contributor can find why the route exists
 
 ## Bad Design Smells Like
 
@@ -158,15 +157,12 @@ A future contributor can find why the route exists.
 
 ## Relationship to Other Root Surfaces
 
-[`README.md`](README.md) introduces.
-[`CHARTER.md`](CHARTER.md) authorizes.
-[`docs/START_HERE.md`](docs/START_HERE.md) routes.
-[`TECHNIQUE_INDEX.md`](TECHNIQUE_INDEX.md) maps the corpus.
-[`docs/ROOT_SURFACE_LAW.md`](docs/ROOT_SURFACE_LAW.md) governs placement.
-[`AGENTS.md`](AGENTS.md) routes agents.
-[`DESIGN.AGENTS.md`](DESIGN.AGENTS.md) holds the design form of the
-agent-facing layer.
-`DESIGN.md` holds the system form of the practice canon.
+[README](README.md) introduces. [CHARTER](CHARTER.md) authorizes.
+[START_HERE](docs/START_HERE.md) routes. [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md)
+maps the corpus. [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) governs
+placement. [AGENTS](AGENTS.md) routes agents. [DESIGN.AGENTS](DESIGN.AGENTS.md)
+holds the design form of the agent-facing layer. `DESIGN.md` holds the system
+form of the practice canon.
 
 ## Use by Agents
 

--- a/QUESTBOOK.md
+++ b/QUESTBOOK.md
@@ -7,8 +7,9 @@ It holds repo-level obligations for canon hardening, donor-refinery follow-up,
 and generated/source alignment. It is not a second roadmap, not a donor dump,
 and not a substitute for technique meaning.
 
-Program direction belongs in [ROADMAP](ROADMAP.md). Technique meaning belongs in
-`techniques/**/TECHNIQUE.md`. Candidate movement belongs in `mechanics/`.
+Program direction belongs in [ROADMAP](ROADMAP.md). Technique meaning belongs
+in [techniques](techniques/). Candidate movement belongs in
+[mechanics](mechanics/README.md).
 
 Use it for:
 - promotion-readiness follow-through
@@ -29,14 +30,14 @@ Update this root index when an obligation should remain visible across future
 work and belongs to the technique canon as a repo-level follow-through.
 
 Use the nearest owner route instead when the obligation is local to one bundle,
-mechanic, generated surface, or release. Use:
+mechanic, generated surface, or release:
 
-- `ROADMAP.md` for direction, horizon posture, and future trigger contours
-- `CHANGELOG.md` for released repository history
-- `mechanics/<slug>/LANDING_LOG.md` for checked mechanic landings
-- `mechanics/<slug>/ROADMAP.md` for mechanic-local future pressure
-- `docs/decisions/` for durable rationale
-- `techniques/**/notes/` for bundle-local evidence and review notes
+- [ROADMAP](ROADMAP.md) for direction, horizon posture, and future trigger contours
+- [CHANGELOG](CHANGELOG.md) for released repository history
+- mechanic landing logs for checked mechanic landings
+- mechanic roadmaps for mechanic-local future pressure
+- [decisions](docs/decisions/README.md) for durable rationale
+- bundle-local notes for technique evidence and review notes
 
 If a closeout leaves a durable obligation but this file stays unchanged, say why
 the obligation belongs to another owner route.
@@ -60,11 +61,11 @@ the obligation belongs to another owner route.
 
 ## Backing files
 
-- `quests/<lane>/<state>/`
-- `schemas/quest.schema.json`
-- `schemas/quest_dispatch.schema.json`
-- `generated/quest_catalog.min.example.json`
-- `generated/quest_dispatch.min.example.json`
+- [quests](quests/) with lane/state layout `quests/<lane>/<state>/`
+- [quest schema](schemas/quest.schema.json)
+- [quest dispatch schema](schemas/quest_dispatch.schema.json)
+- [quest catalog example](generated/quest_catalog.min.example.json)
+- [quest dispatch example](generated/quest_dispatch.min.example.json)
 
 ## Rule
 

--- a/README.md
+++ b/README.md
@@ -1,134 +1,115 @@
 # aoa-techniques
 
-`aoa-techniques` is the public practice canon of AoA: a library of reusable,
-sanitized, bounded engineering techniques for coding agents and humans.
+`aoa-techniques` is the public AoA practice canon: reusable, sanitized,
+bounded engineering techniques for coding agents and humans.
 
-A technique here is not a snippet, checklist dump, skill bundle, playbook,
-role, proof verdict, or runtime behavior. It is one atomic executable move:
-small enough to classify, template, verify, and hand to a small agent after
-orchestration supplies the right context.
+A technique here is one atomic executable move. It is not a snippet dump,
+skill bundle, playbook, proof verdict, role contract, routing policy, memory
+object, or runtime behavior.
 
-This repository has a dual posture. It must work as a standalone public
-library, where an external builder can reuse one technique, capsule, or bundle
-without deploying OS Abyss. It also works as an AoA organ, where authored
-techniques keep stable IDs, topology, provenance, review posture, mechanics,
-and generated companions for sibling repositories to consume.
-
-Use this README as the public front door. Use the linked source surfaces when
-the work becomes authoring, classification, review, release, mechanics, or
-agent-route work.
+This README is only the public front door. When the question becomes authority,
+authoring, classification, review, release, mechanics, or agent routing, follow
+the linked owner surface instead of expanding root prose.
 
 > Current release: `v0.4.2`. See [CHANGELOG](CHANGELOG.md) for release notes.
 
 ## What This Repository Does
 
-| Function | Surface |
-|---|---|
-| Defines the practice-canon authority boundary | [CHARTER](CHARTER.md) |
-| Describes the system form the technique canon should preserve | [DESIGN](DESIGN.md) |
-| Describes the shape of agent-facing route cards and the AGENTS mesh | [DESIGN.AGENTS](DESIGN.AGENTS.md) |
-| Positions this repository inside the AoA layer map | [ECOSYSTEM_CONTEXT](docs/ECOSYSTEM_CONTEXT.md) |
-| Routes new readers into the shortest repo-owned path | [START_HERE](docs/START_HERE.md) |
-| Keeps the public corpus map by ID, status, domain, kind, and path | [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md) |
-| Defines what counts as one atomic technique | [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| Defines corpus classification and path architecture | [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md), [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) |
-| Holds repo-level direction without becoming a changelog or mechanic ledger | [ROADMAP](ROADMAP.md) |
-| Preserves durable obligations without turning them into roadmap history | [QUESTBOOK](QUESTBOOK.md) |
+This repository keeps portable practice small enough to select, adapt, verify,
+and hand to a small agent after orchestration supplies context.
 
-This repository is strongest when it extracts one reusable move cleanly. It is
-weakest when it absorbs workflow orchestration, sibling-repo authority, private
-project residue, raw logs, or broad method chains.
+- Repository boundary: [CHARTER](CHARTER.md)
+- System form: [DESIGN](DESIGN.md)
+- Agent-surface form: [DESIGN.AGENTS](DESIGN.AGENTS.md)
+- AoA layer position: [ECOSYSTEM_CONTEXT](docs/ECOSYSTEM_CONTEXT.md)
+- First repo-owned route: [START_HERE](docs/START_HERE.md)
+- Live corpus map: [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md)
+- Atomic technique contract: [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- Classification and path law: [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md)
+  and [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md)
+- Direction and durable follow-through: [ROADMAP](ROADMAP.md) and
+  [QUESTBOOK](QUESTBOOK.md)
+
+Keep broad workflows, private residue, raw logs, sibling-repo authority, and
+multi-step scenario choreography out of this canon unless they have been
+distilled into one reusable move.
 
 ## Start Here
 
-Read only what matches the entry need.
+Read only the surface that matches the job.
 
-| Need | Route |
-|---|---|
-| Shortest bounded overview | this README, then [CHARTER](CHARTER.md), [START_HERE](docs/START_HERE.md), and [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md) |
-| One concrete example bundle | [plan-diff-apply-verify-report](techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md) |
-| Decide whether a candidate belongs here | [CHARTER](CHARTER.md), then [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| Classify or place a technique | [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md), [TECHNIQUE_KIND_GUIDE](docs/selection/TECHNIQUE_KIND_GUIDE.md), [TECHNIQUE_KIND_HANDOFF_PACK](docs/selection/TECHNIQUE_KIND_HANDOFF_PACK.md), and [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) |
-| Pick a compact runtime card | [TECHNIQUE_CAPSULES](docs/readers/runtime/TECHNIQUE_CAPSULES.md) or [technique_capsules.min.json](generated/technique_capsules.min.json) |
-| Understand maturity, review, or promotion posture | [Canonical Review Guide](docs/review/CANONICAL_REVIEW_GUIDE.md), [Canonical Rubric](docs/review/CANONICAL_RUBRIC.md), and [mechanics/audit](mechanics/audit/README.md) |
-| Understand current direction or parked work | [ROADMAP](ROADMAP.md) and [QUESTBOOK](QUESTBOOK.md) |
-| Work on root or docs-root placement | [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) |
-| Work as an agent in this repo | [AGENTS](AGENTS.md), then the nearest nested `AGENTS.md` |
-| Need the deeper docs tree | [Documentation Map](docs/README.md) and [Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md) |
+- Short bounded overview: this README -> [CHARTER](CHARTER.md) ->
+  [START_HERE](docs/START_HERE.md) -> [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md)
+- One concrete example bundle:
+  [plan-diff-apply-verify-report](techniques/execution/agent-workflows-core/plan-diff-apply-verify-report/TECHNIQUE.md)
+- Decide whether a candidate belongs: [CHARTER](CHARTER.md) ->
+  [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- Classify or place a bundle:
+  [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md) ->
+  [TECHNIQUE_KIND_GUIDE](docs/selection/TECHNIQUE_KIND_GUIDE.md) ->
+  [TECHNIQUE_KIND_HANDOFF_PACK](docs/selection/TECHNIQUE_KIND_HANDOFF_PACK.md) ->
+  [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md)
+- Pick compact runtime cards:
+  [TECHNIQUE_CAPSULES](docs/readers/runtime/TECHNIQUE_CAPSULES.md) or
+  [technique_capsules.min.json](generated/technique_capsules.min.json)
+- Inspect docs and route surfaces: [Documentation Map](docs/README.md),
+  [Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md), and
+  [repo_doc_surface_manifest.min.json](generated/repo_doc_surface_manifest.min.json)
+- Work as an agent: [AGENTS](AGENTS.md), then the nearest nested `AGENTS.md`
 
-Deep mechanic runbooks, review packets, ledgers, scout reports, generated
-readers, and shadow or semantic review artifacts are intentionally not
-re-indexed here. Start from the docs map or the owning `mechanics/<slug>/`
-route when you need that detail.
+Deep mechanic runbooks, review packets, scout reports, generated readers, and
+semantic or shadow review artifacts stay in the docs map, generated readers, or
+owning [mechanics](mechanics/README.md) package.
 
 ## Route Modes
 
-| Route mode | Use when | Start surface |
-|---|---|---|
-| `first-reading` | you need the shortest public overview | [README](README.md) |
-| `technique-authoring` | you will add, split, promote, or revise one technique | [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| `classification` | domain, kind, topology, relation, or path placement matters | [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md) |
-| `tree-structure` | corpus path architecture or bundle moves matter | [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) |
-| `review-posture` | maturity, canonical readiness, or evidence posture matters | [Canonical Review Guide](docs/review/CANONICAL_REVIEW_GUIDE.md) |
-| `mechanic-change` | donor intake, audit, recurrence, checkpoint, release-support, or practice movement changes | [mechanics](mechanics/README.md) |
-| `root-editing` | root or docs-root surfaces move | [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) |
-| `agent-surface-design` | local `AGENTS.md` cards or generated mesh surfaces move | [DESIGN.AGENTS](DESIGN.AGENTS.md) |
-| `generated-parity` | generated catalogs, capsules, source-lift, or repo-doc mirrors move | source doc, builder, generated output, then validator |
+- `first-reading`: [README](README.md)
+- `technique-authoring`: [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- `classification`: [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md)
+- `tree-structure`: [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md)
+- `review-posture`: [Canonical Review Guide](docs/review/CANONICAL_REVIEW_GUIDE.md)
+- `mechanic-change`: [mechanics](mechanics/README.md)
+- `root-editing`: [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md)
+- `agent-surface-design`: [DESIGN.AGENTS](DESIGN.AGENTS.md)
+- `generated-parity`: authored source -> builder -> generated output -> validator
 
 ## Technique Check
 
-Before adding, promoting, or trusting a technique, route the claim through the
-smallest source that can answer it.
+Before adding, promoting, or trusting a technique, ask the narrowest owner:
 
-| Question | Check |
-|---|---|
-| Is this one atomic executable move? | [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| Can it stand alone outside the private AoA workspace? | [CHARTER](CHARTER.md) and [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| Is the classification honest? | [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md), [TECHNIQUE_KIND_GUIDE](docs/selection/TECHNIQUE_KIND_GUIDE.md), and [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md) |
-| Does the path match the current corpus tree? | [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) |
-| Is the text technique meaning rather than a skill, eval, route, playbook, memory object, role, or runtime behavior? | [CHARTER](CHARTER.md) and [AGENTS](AGENTS.md) |
-| Is this current direction rather than released history, durable obligation, or mechanic-local planning? | [ROADMAP](ROADMAP.md), [CHANGELOG](CHANGELOG.md), [QUESTBOOK](QUESTBOOK.md), and `mechanics/<slug>/ROADMAP.md` |
-| Does a generated companion still match its authored source? | the owning source surface and generated mirror listed in [Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md) |
+- Atomic move: [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- Portability: [CHARTER](CHARTER.md) and
+  [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- Classification: [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md),
+  [TECHNIQUE_KIND_GUIDE](docs/selection/TECHNIQUE_KIND_GUIDE.md), and
+  [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md)
+- Corpus path: [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md)
+- Neighboring-object boundary: [CHARTER](CHARTER.md) and [AGENTS](AGENTS.md)
+- Direction, history, obligation, or mechanic-local planning: [ROADMAP](ROADMAP.md),
+  [CHANGELOG](CHANGELOG.md), [QUESTBOOK](QUESTBOOK.md), or the owning mechanic roadmap
+- Generated freshness: source and mirror in
+  [Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md)
 
 ## Current Contour
 
-The current public corpus is a tree of technique bundles under
-`techniques/<trunk>/<shelf>/<slug>/`, with authored meaning in each
-`TECHNIQUE.md`.
+The corpus is a tree of bundles under `techniques/<trunk>/<shelf>/<slug>/`.
+Each bundle's authored meaning lives in `TECHNIQUE.md`.
 
-Current anchors:
-
-- [CHARTER](CHARTER.md), [DESIGN](DESIGN.md), and [DESIGN.AGENTS](DESIGN.AGENTS.md)
-  for repo authority, system form, and agent-surface form
-- [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md) and
-  [technique_catalog.min.json](generated/technique_catalog.min.json) for the
-  current corpus map
-- [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md),
-  [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md), and
-  [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) for authoring,
-  classification, and path law
-- [ROADMAP](ROADMAP.md) for live repo direction and future triggers
-- [mechanics](mechanics/README.md) for practice movement around the canon
-- [generated](generated/) for compact machine companions
-
-Live counts and generated views belong in generated outputs and roadmap
-contour, not in this README.
+Use [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md) and
+[technique_catalog.min.json](generated/technique_catalog.min.json) for the live
+map. Use [ROADMAP](ROADMAP.md) for current direction and corpus-scale pressure.
+Do not treat this README as a status ledger.
 
 ## Practice Mechanics
 
-Mechanics live under [mechanics](mechanics/README.md). They preserve movement,
-provenance, review posture, donor intake, recurrence, checkpoint, RPG,
-release-support, and other practice-canon work around the published technique
-bundles.
+[Mechanics](mechanics/README.md) preserve practice movement around the canon:
+donor intake, audit, evidence, recurrence, checkpoint, release support,
+provenance, and package-local routes.
 
-Use a mechanic package when the question is how a technique candidate moves
-toward canon, how evidence is prepared, how a review packet is interpreted, or
-where historical movement should be preserved. Use a technique bundle when the
-question is the reusable practice itself.
+Use `mechanics/<slug>/` when a candidate is still moving toward canon. Use the
+technique bundle when the reusable practice itself is already authored.
 
 ## Technical Districts
-
-Root-adjacent technical districts have local gates:
 
 | District | Use for |
 |---|---|
@@ -138,33 +119,32 @@ Root-adjacent technical districts have local gates:
 | [generated](generated/) | reproducible catalogs, capsules, source-lift, review, and mesh companions |
 | [examples](examples/README.md) | public-safe repo-wide worked examples |
 | [templates](templates/) | technique authoring and promotion scaffolds |
-| [legacy](legacy/README.md) | public-safe repo-wide raw, archive, and migration receipts after active distillation |
+| [legacy](legacy/README.md) | public-safe repo-wide raw, archive, and migration receipts |
 | [.agents](.agents/AGENTS.md) | agent-facing companion lanes and local route support |
 | [scripts](scripts/) | repo-wide builders and validators |
 | [tests](tests/AGENTS.md) | repo-wide validation surfaces |
 
-District gates explain local handling. They do not replace technique meaning,
-source docs, mechanic packages, or sibling-owner repositories.
+District gates narrow local handling. They do not replace source docs, bundle
+meaning, mechanic packages, or sibling-owner repositories.
 
 ## Machine Companions
 
-Machine-facing surfaces summarize and validate the human route:
+Machine-facing companions summarize the route:
 
-| Surface | Role |
-|---|---|
-| [technique_catalog.min.json](generated/technique_catalog.min.json) | compact corpus catalog |
-| [technique_capsules.min.json](generated/technique_capsules.min.json) | small runtime technique cards |
-| [repo_doc_surface_manifest.min.json](generated/repo_doc_surface_manifest.min.json) | compact map of bounded public route/canon/status docs |
-| [agents_mesh.min.json](generated/agents_mesh.min.json) | compact AGENTS mesh coverage companion |
-| [kag_export.min.json](generated/kag_export.min.json) | source-owned KAG export companion |
+- [technique_catalog.min.json](generated/technique_catalog.min.json): compact corpus catalog
+- [technique_capsules.min.json](generated/technique_capsules.min.json): small runtime technique cards
+- [repo_doc_surface_manifest.min.json](generated/repo_doc_surface_manifest.min.json):
+  compact map of bounded public route/canon/status docs
+- [agents_mesh.min.json](generated/agents_mesh.min.json): compact AGENTS mesh coverage companion
+- [kag_export.min.json](generated/kag_export.min.json): source-owned KAG export companion
 
-Generated surfaces are companions, not authority. Authored technique bundles,
-contracts, route docs, and owner-local mechanics keep meaning.
+Generated files route and compress. Authored bundles, contracts, route docs,
+and owner-local mechanics keep authority.
 
 ## Working Rule
 
 Grow the canon by extracting one reusable move cleanly.
 
-When a detail belongs to another repository, mechanic, generated mirror,
+If a detail belongs to a sibling repository, mechanic, generated mirror,
 roadmap, changelog, quest, decision record, or legacy receipt, route it there
-instead of making the root README carry it.
+instead of making this README carry it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,22 +1,17 @@
 # Roadmap
 
-This roadmap tracks the current direction of `aoa-techniques` as a public
+This roadmap tracks current direction for `aoa-techniques` as a public
 practice canon and standalone technique library.
 
-Use it when the question is not "which technique should I open?", but "which
-repo-level direction should shape the next change?"
+Use it when the question is "what repo-level direction should shape the next
+change?", not "which technique should I open?"
 
 ## Authority
 
-Root [ROADMAP](ROADMAP.md) owns:
-
-- repo-level direction
-- technique-canon horizons
-- corpus-scale pressure
-- standalone portability pressure
-- root entry and source-of-truth pressure
-- mechanics-to-canon interface pressure
-- concrete future triggers that belong to this repository
+Root [ROADMAP](ROADMAP.md) owns repo-level direction, technique-canon horizons,
+corpus-scale pressure, standalone portability pressure, root source-of-truth
+pressure, mechanics-to-canon interface pressure, and concrete future triggers
+that belong to this repository.
 
 It does not own technique status by itself, generated manifest truth, mechanic
 local roadmaps, checked mechanic landings, release history, quest state, donor
@@ -31,13 +26,11 @@ Use the stronger surface when the change is narrower:
 - root and docs placement: [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md)
 - promotion readiness and evidence lanes: [Audit parts](mechanics/audit/parts/)
 - donor intake and candidate extraction: [Distillation parts](mechanics/distillation/parts/)
-- checked mechanic landings: `mechanics/<slug>/LANDING_LOG.md`
-- mechanic-local future pressure: `mechanics/<slug>/ROADMAP.md`
 - durable obligations: [QUESTBOOK](QUESTBOOK.md) and [quests](quests/)
 - released history: [CHANGELOG](CHANGELOG.md)
 
-Historical tree migration, closure audit, scout, and bundle-reform detail lives
-in the owner surfaces that produced or reviewed it:
+Historical migration, closure audit, scout, and bundle-reform detail stays with
+the surfaces that produced or reviewed it:
 
 - [Distillation roadmap](mechanics/distillation/ROADMAP.md)
 - [final tree migration ledger](mechanics/distillation/parts/technique-reform-ingress/reviews/final-tree-migration-ledger.md)
@@ -46,52 +39,43 @@ in the owner surfaces that produced or reviewed it:
 - [root roadmap tree migration breadcrumbs receipt](mechanics/distillation/legacy/raw/ROOT_ROADMAP_TREE_MIGRATION_BREADCRUMBS_2026-05-14.md)
 - [root closure audit roadmap receipt](mechanics/audit/legacy/raw/ROOT_CLOSURE_AUDIT_ROADMAP_2026-05-03.md)
 
-Treat those as evidence and mechanic-local direction, not as live root roadmap
-text.
+Those are evidence, not live root-roadmap body.
 
 ## Update Rule
 
-Update this roadmap when a change moves repo-level direction, corpus topology,
-root source-of-truth posture, standalone portability, mechanics-to-canon
-interface, or a concrete future trigger for this repository.
+Update this roadmap only when a change moves repo-level direction, corpus
+topology, root source-of-truth posture, standalone portability,
+mechanics-to-canon interface, or a concrete future trigger for this repository.
 
-Do not update this roadmap for a local mechanic landing, generated refresh,
+Do not update it for a local mechanic landing, generated refresh,
 bundle-local evidence note, quest lifecycle move, release note, or donor ledger
-entry unless it changes one of those repo-level directions. Route those changes
-to their owning surfaces.
-
-Before closeout, ask: did this change move the practice canon's direction, or
-did it only land a local surface?
+entry unless that local change alters a repo-level direction.
 
 ## Current Direction
 
 `aoa-techniques` is moving from closure-audit hardening into canon-scale
-architecture.
+architecture:
 
-The current direction is:
-
-- keep root entry surfaces compact, with [README](README.md) as a front door rather
-  than a warehouse for every route
+- keep root entry surfaces compact, with [README](README.md) as a front door
+  rather than a warehouse
 - keep [CHARTER](CHARTER.md), [DESIGN](DESIGN.md),
   [DESIGN.AGENTS](DESIGN.AGENTS.md), [START_HERE](docs/START_HERE.md),
   [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md),
   [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md),
   [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md), and
-  [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) aligned as the route and
-  contract stack
-- keep the repository usable as a standalone public technique library, not only
-  as an OS Abyss organ
-- keep each technique as one atomic executable move suitable for templating,
-  capsule projection, validation, and small-agent execution after orchestration
+  [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) aligned without restating each
+  other
+- keep the corpus usable outside OS Abyss while preserving AoA provenance and
+  sibling-owner routes
+- keep each technique one atomic executable move suitable for templating,
+  capsule projection, validation, and small-agent use after orchestration
   supplies context
-- grow toward `1000+` techniques through faceted topology rather than overloaded
-  root categories
-- keep mechanics active as movement, provenance, review, and candidate routes
-  around canon rather than as substitutes for technique bundles
-- keep generated catalogs, capsules, source-lift readers, and manifests
-  subordinate to authored sources
-- keep agent-facing route cards and generated agent mesh mirrors checkable
-  without letting them replace public docs or technique meaning
+- grow toward `1000+` techniques through faceted topology, not overloaded root
+  categories
+- keep mechanics as movement, provenance, review, and candidate routes around
+  canon
+- keep generated catalogs, capsules, source-lift readers, repo-doc manifests,
+  and agent-mesh mirrors subordinate to authored sources
 
 ## Current Checked Contour
 
@@ -108,123 +92,137 @@ Current public corpus after the latest validation:
 
 Current anchors:
 
-| Anchor | Surface |
-|---|---|
-| Repository authority | [CHARTER](CHARTER.md) |
-| Public front door | [README](README.md) |
-| Shortest route | [START_HERE](docs/START_HERE.md) |
-| Root placement law | [ROOT_SURFACE_LAW](docs/ROOT_SURFACE_LAW.md) |
-| Technique atom contract | [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md) |
-| Technique topology contract | [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md) |
-| Technique tree contract | [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md) |
-| Corpus map | [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md), [technique catalog](generated/technique_catalog.min.json) |
-| Small runtime cards | [TECHNIQUE_CAPSULES](docs/readers/runtime/TECHNIQUE_CAPSULES.md), [technique capsules](generated/technique_capsules.min.json) |
-| Mechanics atlas | [mechanics README](mechanics/README.md), [mechanics AGENTS](mechanics/AGENTS.md), mechanic package `README.md` files |
-| Audit and evidence posture | [Audit parts](mechanics/audit/parts/) |
-| Donor and candidate extraction | [Distillation parts](mechanics/distillation/parts/) |
-| Durable obligations | [QUESTBOOK](QUESTBOOK.md), [quests](quests/) |
-| Release history and release path | [CHANGELOG](CHANGELOG.md), [RELEASING](docs/RELEASING.md) |
+- Claim boundary: [CHARTER](CHARTER.md)
+- Reader entry: [README](README.md), then [START_HERE](docs/START_HERE.md)
+- Atomic technique: [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+- Classification and placement:
+  [TECHNIQUE_TOPOLOGY_CONTRACT](docs/TECHNIQUE_TOPOLOGY_CONTRACT.md),
+  [TECHNIQUE_TREE_CONTRACT](docs/TECHNIQUE_TREE_CONTRACT.md), and
+  [TECHNIQUE_INDEX](TECHNIQUE_INDEX.md)
+- Generated views: [technique catalog](generated/technique_catalog.min.json),
+  [technique capsules](generated/technique_capsules.min.json), and
+  [repo doc surface manifest](generated/repo_doc_surface_manifest.min.json)
+- Movement and evidence: [mechanics README](mechanics/README.md),
+  [Audit parts](mechanics/audit/parts/), and
+  [Distillation parts](mechanics/distillation/parts/)
+- Obligations and history: [QUESTBOOK](QUESTBOOK.md), [quests](quests/),
+  [CHANGELOG](CHANGELOG.md), and [RELEASING](docs/RELEASING.md)
 
-[ROADMAP](ROADMAP.md) keeps current direction and future contour. Mechanic
-`LANDING_LOG.md` surfaces keep checked mechanic landings.
-[CHANGELOG](CHANGELOG.md) keeps released history. [QUESTBOOK](QUESTBOOK.md)
-keeps durable obligations.
+[ROADMAP](ROADMAP.md) keeps direction. Mechanic landing logs keep checked
+mechanic landings. [CHANGELOG](CHANGELOG.md) keeps released history.
+[QUESTBOOK](QUESTBOOK.md) keeps durable obligations.
 
 ## Horizon: Root Clarity
 
-| Field | Direction |
-|---|---|
-| Current posture | The root file set is small and allowed, but old root prose has repeatedly tried to become a route maze. |
-| Next honest move | Keep root Markdown short and role-bound: entry, authority, direction, obligation, release, contribution, agent route, and one example. Put detailed inventories in [Documentation Map](docs/README.md), [Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md), generated manifests, or owner-local mechanics. |
-| Guardrail | Root files should not become warehouses for audit history, generated detail, donor ledgers, mechanic-local runbooks, or semantic/shadow review packets. |
+Root Markdown should remain role-bound: entry, authority, system form,
+agent-surface form, direction, obligation, release history, contribution route,
+conduct, security, and the corpus index.
+
+Next: keep inventories in [Documentation Map](docs/README.md),
+[Repo Doc Surfaces](docs/readers/repo/REPO_DOC_SURFACES.md), generated
+manifests, or owner-local mechanics. Stop: do not move audit history, generated
+detail, donor ledgers, mechanic-local runbooks, or semantic/shadow review
+packets back into root.
 
 ## Horizon: Technique Atom
 
-| Field | Direction |
-|---|---|
-| Current posture | The technique atom contract names one atomic executable move as the unit of canon. |
-| Next honest move | Pressure every new candidate through atom checks before drafting a bundle, especially mechanics candidates and donor imports. |
-| Guardrail | Do not patch broad candidates with more prose; split, narrow, keep in mechanics, or route to a stronger owner. |
+The technique atom contract names one atomic executable move as the unit of
+canon.
+
+Next: pressure every candidate through [TECHNIQUE_ATOM_CONTRACT](docs/TECHNIQUE_ATOM_CONTRACT.md)
+before drafting or promoting. Stop: split, narrow, hold in mechanics, or route
+to a stronger owner instead of padding broad candidates with prose.
 
 ## Horizon: Corpus Topology
 
-| Field | Direction |
-|---|---|
-| Current posture | `domain` and `kind` are authoritative frontmatter; family, capability, substrate, execution profile, risk posture, and richer relations are explicit design axes. |
-| Next honest move | Enter selector and relation work through [Technique Reform Ingress](mechanics/distillation/parts/technique-reform-ingress/README.md). Keep [technique_topology_axes.yaml](mechanics/distillation/parts/technique-reform-ingress/config/technique_topology_axes.yaml) and [technique_topology_scout.md](mechanics/distillation/parts/technique-reform-ingress/reports/technique_topology_scout.md) as scout evidence, and strengthen relations only when bundle inputs and contracts justify an existing relation type. |
-| Guardrail | Do not turn `agent-workflows`, `docs`, or tags into junk drawers for missing topology. |
+`domain` and `kind` are authoritative frontmatter. Family, capability,
+substrate, execution profile, risk posture, and richer relations remain design
+axes until evidence justifies stronger status.
+
+Next: enter selector and relation work through
+[Technique Reform Ingress](mechanics/distillation/parts/technique-reform-ingress/README.md),
+with [technique_topology_axes.yaml](mechanics/distillation/parts/technique-reform-ingress/config/technique_topology_axes.yaml)
+and [technique_topology_scout.md](mechanics/distillation/parts/technique-reform-ingress/reports/technique_topology_scout.md)
+as scout evidence. Stop: do not turn `agent-workflows`, `docs`, or tags into
+junk drawers for missing topology.
 
 ## Horizon: Corpus Tree
 
-| Field | Direction |
-|---|---|
-| Current posture | The full tree migration is closed: `107` bundles now sit under active `techniques/<trunk>/<shelf>/<slug>/` paths across `10` active trunks and `28` shelves, with generated path parity and root legacy receipts validated by the Distillation closeout surfaces. |
-| Next honest move | Keep the landed tree stable while reform waves work through selector, relation, portability, execution-profile, and bundle-anatomy evidence. Use the Distillation ingress packet before any new broad path, schema, or classification movement. |
-| Guardrail | Do not put shelf-by-shelf migration breadcrumbs, pilot queues, or parity ledgers back into root roadmap. Do not add `tree_path` frontmatter or move paths without a fresh owner-local review surface. |
+The full tree migration is closed: `107` bundles sit under active
+`techniques/<trunk>/<shelf>/<slug>/` paths across `10` trunks and `28` shelves.
+
+Next: keep the landed tree stable while reform waves work through selector,
+relation, portability, execution-profile, and bundle-anatomy evidence. Stop:
+do not put shelf-by-shelf breadcrumbs, pilot queues, or parity ledgers back
+into root roadmap, and do not add `tree_path` frontmatter without a fresh
+owner-local review surface.
 
 ## Horizon: Small-Agent Usability
 
-| Field | Direction |
-|---|---|
-| Current posture | Capsules and generated catalogs provide compact lookup surfaces; template-modernization and bundle-anatomy closeouts have already moved broad usability pressure into targeted reform surfaces. |
-| Next honest move | Move from template-shape review to concrete content-level technique reform only where direct bundle reading finds a real source, selector, relation, portability, owner-boundary, or execution-shape problem. |
-| Guardrail | Small-agent usability does not mean autonomous selection; routing and composition may belong to larger agents or neighboring layers. |
+Capsules and generated catalogs provide compact lookup surfaces, while
+bundle-anatomy work handles content-level usability.
+
+Next: reform only where direct bundle reading finds a real source, selector,
+relation, portability, owner-boundary, or execution-shape problem. Stop:
+small-agent usability does not mean autonomous selection; routing and
+composition can belong to larger agents or neighboring layers.
 
 ## Horizon: Mechanics To Canon
 
-| Field | Direction |
-|---|---|
-| Current posture | Mechanics packages keep active routes, parts, provenance, landing logs, package roadmaps, and legacy scaffolds; the root mechanics surface stays an atlas and local law route rather than a second roadmap authority. |
-| Next honest move | Use mechanics to preserve lineage and candidate pressure while extracting only one atomic practice at a time into [techniques](techniques/), and keep package roadmaps strong enough for small-agent route choice without importing AoA center authority. |
-| Guardrail | Mechanics can prepare canon. They do not replace canon or silently change status. |
+Mechanics packages keep active routes, parts, provenance, landing logs, package
+roadmaps, and legacy scaffolds around canon.
+
+Next: use mechanics to preserve lineage and candidate pressure while
+extracting only one atomic practice at a time into [techniques](techniques/).
+Stop: mechanics can prepare canon, but they do not replace canon or silently
+change status.
 
 ## Horizon: Evidence And Promotion
 
-| Field | Direction |
-|---|---|
-| Current posture | Audit parts carry promotion readiness, evidence sprinting, searched-lane memory, and canonical retro-audit work. |
-| Next honest move | Keep external-evidence work routed through the Audit and Distillation parts, then update bundle-local notes before shared queues. |
-| Guardrail | Root roadmap should name evidence pressure only at the horizon level; ledgers and queue details belong in Audit. |
+Audit parts carry promotion readiness, evidence sprinting, searched-lane
+memory, and canonical retro-audit work.
+
+Next: route external-evidence work through Audit and Distillation, then update
+bundle-local notes before shared queues. Stop: root roadmap names evidence
+pressure only at horizon level; ledgers and queue detail belong in Audit.
 
 ## Horizon: Standalone Portability
 
-| Field | Direction |
-|---|---|
-| Current posture | The repository explicitly serves both external builders and AoA sibling repos. |
-| Next honest move | Keep AoA references as provenance and integration context while making the portable practice understandable without OS Abyss. |
-| Guardrail | Do not let AoA organ fidelity become a hidden dependency for public reuse. |
+The repository serves both external builders and AoA sibling repos.
+
+Next: keep AoA references as provenance and integration context while making
+portable practice understandable without OS Abyss. Stop: do not let AoA organ
+fidelity become a hidden dependency for public reuse.
 
 ## Horizon: Generated Companions
 
-| Field | Direction |
-|---|---|
-| Current posture | Generated catalogs, capsules, source-lift readers, repo-doc surfaces, and agent mesh mirrors give machines compact routes over authored sources. |
-| Next honest move | Keep generated parity validator-backed whenever source docs, templates, route maps, mesh config, or surface specs change. |
-| Guardrail | Generated outputs route and compress; they do not author technique meaning, root law, agent law, or status. |
+Generated catalogs, capsules, source-lift readers, repo-doc surfaces, and
+agent-mesh mirrors give machines compact routes over authored sources.
+
+Next: keep generated parity validator-backed whenever source docs, templates,
+route maps, mesh config, or surface specs change. Stop: generated outputs
+route and compress; they do not author technique meaning, root law, agent law,
+or status.
 
 ## When The Time Comes
 
-Use this block for likely repo-level work that is not useful to land until its
-trigger is real.
+These are repo-level triggers that should wait for real evidence:
 
-- Promote `family` from scout-only to optional reviewed frontmatter only after
-  examples and tie-break rules stay stable across multiple technique waves.
-- Add generated projections for `capability_class`, `substrate`,
-  `execution_profile`, and `risk_posture` only after mechanics candidates prove
-  the axes help selection without false precision.
-- Use the technique reform ingress packet before any broad classification
-  change so the first reform pass stays bounded and evidence-linked.
-- Add richer typed relation guidance only when direct relations are repeatedly
-  useful for composition, conflict, sequence, or prerequisite routing.
-- Keep [examples](examples/README.md) as the home for public worked examples;
-  move any technique-local tutorial back to the owning bundle before root grows
-  another example article.
-- Add a machine-facing root route capsule only after the human route stabilizes
-  enough that a generated companion would reduce real reader load.
+- promote `family` from scout-only to optional reviewed frontmatter after
+  examples and tie-break rules stay stable across multiple waves
+- add projections for `capability_class`, `substrate`, `execution_profile`,
+  and `risk_posture` after mechanics candidates prove the axes improve
+  selection without false precision
+- use the technique reform ingress packet before any broad classification
+  change
+- add richer typed relation guidance only when relations repeatedly help
+  composition, conflict, sequence, or prerequisite routing
+- keep [examples](examples/README.md) as the home for public worked examples
+- add a machine-facing root route capsule only after the human route stabilizes
+  enough that a generated companion reduces real reader load
 
-An item belongs here only when its trigger is concrete and repo-level. If the
-future pressure is mechanic-local, use `mechanics/<slug>/ROADMAP.md`. If it is
-a durable obligation, use [QUESTBOOK](QUESTBOOK.md) and [quests](quests/).
+Mechanic-local future pressure belongs in the owning mechanic roadmap. Durable
+obligation belongs in [QUESTBOOK](QUESTBOOK.md) and [quests](quests/).
 
 ## Standing Direction
 


### PR DESCRIPTION
## Summary

- clarified root document roles across README, CHARTER, DESIGN, DESIGN.AGENTS, ROADMAP, CONTRIBUTING, QUESTBOOK, and CHANGELOG
- reduced avoidable duplicated doctrine while keeping active route links and required root contracts discoverable
- kept README as the public front door and ROADMAP as the repo-level direction surface

## Validation

- git diff --check
- python scripts/validate_repo.py
- python scripts/run_tests.py
- python scripts/release_check.py

## Public Safety

- public docs only
- no secrets, private project residue, runtime configuration, or generated authority changes
- generated repo-doc surfaces were rebuilt and remained clean after release_check

## Remaining Risk

- low; this is route and wording cleanup over existing public root docs
