### PR TITLE
Refresh self-diagnose skill export

### DIFF
--- a/.agents/skills/aoa-session-self-diagnose/references/diagnosis-packet-receipt-schema.yaml
+++ b/.agents/skills/aoa-session-self-diagnose/references/diagnosis-packet-receipt-schema.yaml
@@ -19,5 +19,5 @@ rules:
   - set `skill_name` to `aoa-session-self-diagnose`
   - set `result_kind` to `diagnosis_packet`
   - keep probable causes probabilistic when evidence is thin
-  - `evidence_posture` must separate reviewed symptoms, reviewed inferences, provisional hints, contested evidence, stale evidence, and unknowns
+  - '`evidence_posture` must separate reviewed symptoms, reviewed inferences, provisional hints, contested evidence, stale evidence, and unknowns'
   - checkpoint, closeout, generated, or stale hints must not appear as settled diagnosis evidence


### PR DESCRIPTION
Changed surfaces:
- Refreshed the portable aoa-session-self-diagnose skill export from landed aoa-skills source.
- The refreshed diagnosis packet receipt schema quotes the evidence_posture rule so the YAML reference parses correctly.

Validation:
- Local repository validation was run before commit.
- Direct YAML parse check passed across the refreshed downstream copies.

Notes:
- Source owner fix landed first in aoa-skills#220.
- Tree-of-Sophia was already aligned and was not changed.
- Decision record: not needed; this is copy-mode downstream parity for a source-owned skill export.

Remaining risk:
- No known repository-local risk beyond normal GitHub Repo Validation.