### PR TITLE
Require modeled surfaces to be explicit lists

### DIFF
--- a/docs/decisions/indexes/index_contract.yaml
+++ b/docs/decisions/indexes/index_contract.yaml
@@ -10,7 +10,7 @@ generated_indexes:
   - docs/decisions/indexes/by-technique-axis.md
   - docs/decisions/indexes/by-mechanic.md
   - docs/decisions/indexes/by-guard.md
-modeled_surfaces:
+modeled_surfaces: []
 fields:
   decision_id:
     required: true

--- a/scripts/decision_indexes.py
+++ b/scripts/decision_indexes.py
@@ -428,8 +428,9 @@ def modeled_decision_lane_surfaces(
     contract: dict[str, object],
     issues: list[tuple[str, str]],
 ) -> set[str]:
-    modeled = contract.get("modeled_surfaces", [])
+    modeled = contract.get("modeled_surfaces")
     if modeled is None:
+        issues.append((INDEX_CONTRACT_PATH.as_posix(), "modeled_surfaces must be a list of repo-relative docs/decisions paths"))
         return set()
     if not isinstance(modeled, list) or not all(isinstance(item, str) for item in modeled):
         issues.append((INDEX_CONTRACT_PATH.as_posix(), "modeled_surfaces must be a list of repo-relative docs/decisions paths"))


### PR DESCRIPTION
## Summary
- make empty `modeled_surfaces` contracts explicit with `[]`
- reject null or missing modeled-surface lists in decision-index validation

## Validation
- decision-index `--check` passed locally
- null modeled-surfaces harness rejected blank/null values locally