### PR TITLE
Restore Spark center decision references

### DIFF
--- a/.agents/spark/SPARK_EXTRAPOLATION_NOTEBOOK.md
+++ b/.agents/spark/SPARK_EXTRAPOLATION_NOTEBOOK.md
@@ -22,8 +22,8 @@ Primary source in `Agents-of-Abyss`:
 - `.agents/spark/schemas/**`
 - `.agents/spark/scripts/validate_spark_lane.py`
 - `.agents/spark/tests/test_spark_lane.py`
-- `docs/decisions/AOA-TECH-D-0054-spark-agent-lane-home.md`
-- `docs/decisions/AOA-TECH-D-0057-spark-registry-backed-technique-lane.md`
+- `docs/decisions/AOA-CENTER-D-0024-spark-session-lane-contract.md`
+- `docs/decisions/AOA-CENTER-D-0027-codex-spark-agent-lane-home.md`
 
 Local `aoa-techniques` surfaces that constrain the adaptation:
 
@@ -35,6 +35,7 @@ Local `aoa-techniques` surfaces that constrain the adaptation:
 - `.agents/spark/SWARM.md`
 - `docs/ROOT_SURFACE_LAW.md`
 - `docs/decisions/AOA-TECH-D-0054-spark-agent-lane-home.md`
+- `docs/decisions/AOA-TECH-D-0057-spark-registry-backed-technique-lane.md`
 - `docs/TECHNIQUE_ATOM_CONTRACT.md`
 - `docs/TECHNIQUE_TOPOLOGY_CONTRACT.md`
 - `docs/TECHNIQUE_TREE_CONTRACT.md`

--- a/tests/test_validate_repo_agents_mesh.py
+++ b/tests/test_validate_repo_agents_mesh.py
@@ -47,6 +47,33 @@ class ValidateRepoAgentsMeshTests(unittest.TestCase):
         self.assertIn("done-or-handoff", notebook_text)
         self.assertIn("registry-backed", notebook_text)
         self.assertIn("technique-refinement", notebook_text)
+
+        source_section = notebook_text.split(
+            "Local `aoa-techniques` surfaces that constrain the adaptation:",
+            maxsplit=1,
+        )[0]
+        local_section = notebook_text.split(
+            "Local `aoa-techniques` surfaces that constrain the adaptation:",
+            maxsplit=1,
+        )[1].split("## Center Pattern To Preserve", maxsplit=1)[0]
+        self.assertIn(
+            "docs/decisions/AOA-CENTER-D-0024-spark-session-lane-contract.md",
+            source_section,
+        )
+        self.assertIn(
+            "docs/decisions/AOA-CENTER-D-0027-codex-spark-agent-lane-home.md",
+            source_section,
+        )
+        self.assertNotIn("AOA-TECH-D-0054", source_section)
+        self.assertNotIn("AOA-TECH-D-0057", source_section)
+        self.assertIn(
+            "docs/decisions/AOA-TECH-D-0054-spark-agent-lane-home.md",
+            local_section,
+        )
+        self.assertIn(
+            "docs/decisions/AOA-TECH-D-0057-spark-registry-backed-technique-lane.md",
+            local_section,
+        )
         self.assertIn("aoa_techniques_spark_lane_registry_v1", registry)
         self.assertIn("technique-audit", registry)
         self.assertIn("release-prep", registry)


### PR DESCRIPTION
## Summary
- restore center-side `AOA-CENTER-D-*` decision references in the Spark extrapolation notebook source-study section
- keep local `AOA-TECH-D-*` decision references in the local adaptation section
- add a regression that prevents local technique decisions from replacing center provenance in the primary source section

Addresses review thread from #460.

## Validation
- `python -m unittest tests.test_validate_repo_agents_mesh.ValidateRepoAgentsMeshTests.test_spark_lane_lives_under_agents_district` (red before fix, green after)
- `python .agents/spark/scripts/validate_spark_lane.py`
- `python -m unittest discover -s .agents/spark/tests -p 'test*.py'`\n- `python scripts/ci_gate.py --mode source-fast`\n- `python scripts/release_check.py`\n- `git diff --check`