### PR TITLE
Fix distillation reform context guard

### DIFF
--- a/mechanics/distillation/tests/support/distillation_topology_fixtures.py
+++ b/mechanics/distillation/tests/support/distillation_topology_fixtures.py
@@ -200,9 +200,11 @@ class ReformContext(str):
         )
 
 
-@lru_cache(maxsize=1)
-def read_distillation_reform_context() -> ReformContext:
-    """Read the active Distillation contour plus its owning reform evidence."""
+def _read_reform_context(paths: tuple[Path, ...]) -> ReformContext:
+    return ReformContext("\n\n".join(path.read_text(encoding="utf-8") for path in paths))
+
+
+def distillation_reform_context_paths() -> tuple[Path, ...]:
     reform_root = (
         REPO_ROOT
         / "mechanics"
@@ -210,19 +212,21 @@ def read_distillation_reform_context() -> ReformContext:
         / "parts"
         / "technique-reform-ingress"
     )
-    source_paths = [
+    return (
         REPO_ROOT / "mechanics" / "distillation" / "ROADMAP.md",
         REPO_ROOT / "mechanics" / "distillation" / "LANDING_LOG.md",
         reform_root / "README.md",
         reform_root / "reviews" / "README.md",
-        *sorted((reform_root / "reviews").glob("*.md")),
-    ]
-    return ReformContext("\n\n".join(path.read_text(encoding="utf-8") for path in source_paths))
+    )
 
 
 @lru_cache(maxsize=1)
-def read_tree_migration_context() -> ReformContext:
-    """Read current tree law plus historical migration evidence."""
+def read_distillation_reform_context() -> ReformContext:
+    """Read the active Distillation contour without individual review packets."""
+    return _read_reform_context(distillation_reform_context_paths())
+
+
+def tree_migration_context_paths() -> tuple[Path, ...]:
     reform_root = (
         REPO_ROOT
         / "mechanics"
@@ -231,12 +235,17 @@ def read_tree_migration_context() -> ReformContext:
         / "technique-reform-ingress"
     )
     receipt_root = REPO_ROOT / "legacy" / "receipts"
-    source_paths = [
+    return (
         REPO_ROOT / "docs" / "TECHNIQUE_TREE_CONTRACT.md",
         TREE_MIGRATION_BREADCRUMB_ROADMAP,
         reform_root / "README.md",
         reform_root / "reviews" / "README.md",
         *sorted((reform_root / "reviews").glob("*.md")),
         *sorted(receipt_root.glob("*-tree-pilot.md")),
-    ]
-    return ReformContext("\n\n".join(path.read_text(encoding="utf-8") for path in source_paths))
+    )
+
+
+@lru_cache(maxsize=1)
+def read_tree_migration_context() -> ReformContext:
+    """Read current tree law plus historical migration evidence."""
+    return _read_reform_context(tree_migration_context_paths())

--- a/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
+++ b/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
@@ -13,6 +13,22 @@ from distillation_topology_fixtures import *  # noqa: F403
 
 
 class DistillationReformIngressReviewsTests(unittest.TestCase):
+    def test_reform_context_excludes_individual_review_packets(self) -> None:
+        review_root = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+        )
+        source_paths = set(distillation_reform_context_paths())
+        individual_review_packets = set(review_root.glob("*.md")) - {review_root / "README.md"}
+
+        self.assertIn(review_root / "README.md", source_paths)
+        self.assertTrue(individual_review_packets)
+        self.assertTrue(individual_review_packets.isdisjoint(source_paths))
+
     def test_technique_reform_ingress_is_bounded_before_schema_change(self) -> None:
             ingress = (
                 REPO_ROOT

--- a/tests/test_test_topology.py
+++ b/tests/test_test_topology.py
@@ -139,7 +139,7 @@ class TestTopologyAuthorityTests(unittest.TestCase):
                 self.assertIn("mechanics/distillation", entry["owner_surface"])
                 self.assertIn("Fix ", entry["failure_route"])
                 test_count += text.count("    def test_")
-        self.assertEqual(115, test_count)
+        self.assertEqual(116, test_count)
 
     def test_run_tests_covers_root_and_mechanic_level_homes(self) -> None:
         entries = topology_inventory.normalized_inventory_entries()


### PR DESCRIPTION
## Summary
- exclude individual technique-reform review packets from the Distillation reform roadmap context helper
- keep tree-migration context reading historical review evidence through its separate helper
- add a regression test and update topology test-count authority

## Validation
- python -m unittest mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
- python -m unittest tests/test_test_topology.py
- python -m unittest discover -s mechanics/distillation/tests -p 'test*.py'
- python scripts/ci_gate.py --mode source-fast
- python scripts/release_check.py

Fixes follow-up from Codex review thread on PR #359: PRRT_kwDORma57M6AI-Qq.