### PR TITLE
Fix bundle anatomy Wave A counts

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-execution-instruction-review.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-execution-instruction-review.md
@@ -99,8 +99,8 @@ owners.
 | `anatomy-pass` | 33 |
 | `old-template-watch` | 33 |
 | `owner-boundary-watch` | 21 |
-| `promotion-evidence-hold` | 24 |
-| `portability-watch` | 4 |
+| `promotion-evidence-hold` | 22 |
+| `portability-watch` | 3 |
 | `no-repair` | 33 |
 
 ## Findings

--- a/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
+++ b/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 import sys
 import unittest
 from pathlib import Path
@@ -28,6 +29,42 @@ class DistillationReformIngressReviewsTests(unittest.TestCase):
         self.assertIn(review_root / "README.md", source_paths)
         self.assertTrue(individual_review_packets)
         self.assertTrue(individual_review_packets.isdisjoint(source_paths))
+
+    def test_bundle_anatomy_execution_instruction_label_counts_match_rows(self) -> None:
+        review = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "bundle-anatomy-execution-instruction-review.md"
+        )
+        text = review.read_text(encoding="utf-8")
+        rows_section = text.split("## Bundle Rows", maxsplit=1)[1].split(
+            "## Wave A Label Counts", maxsplit=1
+        )[0]
+        counts_section = text.split("## Wave A Label Counts", maxsplit=1)[1].split(
+            "## Findings", maxsplit=1
+        )[0]
+
+        observed: Counter[str] = Counter()
+        for line in rows_section.splitlines():
+            if not line.startswith("| `AOA-T-"):
+                continue
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            for label in cells[2].split(","):
+                observed[label.strip().strip("`")] += 1
+            observed[cells[3].strip("`")] += 1
+
+        expected: dict[str, int] = {}
+        for line in counts_section.splitlines():
+            if not line.startswith("| `"):
+                continue
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            expected[cells[0].strip("`")] = int(cells[1])
+
+        self.assertEqual(expected, dict(observed))
 
     def test_technique_reform_ingress_is_bounded_before_schema_change(self) -> None:
             ingress = (

--- a/tests/test_test_topology.py
+++ b/tests/test_test_topology.py
@@ -139,7 +139,7 @@ class TestTopologyAuthorityTests(unittest.TestCase):
                 self.assertIn("mechanics/distillation", entry["owner_surface"])
                 self.assertIn("Fix ", entry["failure_route"])
                 test_count += text.count("    def test_")
-        self.assertEqual(116, test_count)
+        self.assertEqual(117, test_count)
 
     def test_run_tests_covers_root_and_mechanic_level_homes(self) -> None:
         entries = topology_inventory.normalized_inventory_entries()


### PR DESCRIPTION
## Summary
- Correct Wave A label totals in the bundle anatomy execution/instruction review packet.
- Add a regression test that derives label and repair-action counts from Bundle Rows and compares them with the summary table.
- Update the distillation topology test count for the new regression.

## Validation
- python -m unittest mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
- python -m unittest discover -s mechanics/distillation/tests
- python -m unittest tests.test_test_topology
- python scripts/validate_repo.py
- python scripts/ci_gate.py --mode source-fast
- python scripts/release_check.py

## Scope
- Review evidence only; no technique source, schema, generated truth, or promotion state changed.