### PR TITLE
Define promotion evidence hold rubric label

### DIFF
--- a/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-rubric-hardening.md
+++ b/mechanics/distillation/parts/technique-reform-ingress/reviews/bundle-anatomy-rubric-hardening.md
@@ -60,6 +60,7 @@ Use these after direct reading authored bundle meaning and support surfaces.
 | `small-agent-gap` | selected technique would leave a small model unsure about action, stop line, or output | repair only after bundle-specific evidence |
 | `portability-watch` | technique is portable, but one origin-specific boundary must stay visible | caution label, not failure |
 | `owner-boundary-watch` | sibling-owner pressure is real but currently held outside the atom | do not route away unless the atom collapses |
+| `promotion-evidence-hold` | bundle anatomy is healthy, but canonical/promotion readiness still needs stronger adoption, owner, or proof evidence | not an anatomy failure or repair action |
 | `capsule-gap` | generated capsule or source summary fails to carry the executable center | inspect source vs builder before repair |
 | `atomicity-risk` | more than one independent move competes for the center | split or narrow only after direct review |
 | `route-away-risk` | object is likely a skill, eval, routing object, playbook, role, memory/KAG object, or runtime object | owner route note before moving content |

--- a/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
+++ b/mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -65,6 +66,32 @@ class DistillationReformIngressReviewsTests(unittest.TestCase):
             expected[cells[0].strip("`")] = int(cells[1])
 
         self.assertEqual(expected, dict(observed))
+
+    def test_bundle_anatomy_rubric_defines_finding_tokens(self) -> None:
+        rubric = (
+            REPO_ROOT
+            / "mechanics"
+            / "distillation"
+            / "parts"
+            / "technique-reform-ingress"
+            / "reviews"
+            / "bundle-anatomy-rubric-hardening.md"
+        )
+        text = rubric.read_text(encoding="utf-8")
+        layer_tables = text.split("## Direct-Read Findings", maxsplit=1)[0]
+        defined_tokens = {
+            match.group(1)
+            for match in re.finditer(r"^\| `([^`]+)` \|", layer_tables, re.MULTILINE)
+        }
+        finding_tokens = {
+            token
+            for line in text.splitlines()
+            if line.startswith("Finding:")
+            for token in re.findall(r"`([^`]+)`", line)
+        }
+
+        self.assertTrue(finding_tokens)
+        self.assertEqual(set(), finding_tokens - defined_tokens)
 
     def test_technique_reform_ingress_is_bounded_before_schema_change(self) -> None:
             ingress = (

--- a/tests/test_test_topology.py
+++ b/tests/test_test_topology.py
@@ -139,7 +139,7 @@ class TestTopologyAuthorityTests(unittest.TestCase):
                 self.assertIn("mechanics/distillation", entry["owner_surface"])
                 self.assertIn("Fix ", entry["failure_route"])
                 test_count += text.count("    def test_")
-        self.assertEqual(117, test_count)
+        self.assertEqual(118, test_count)
 
     def test_run_tests_covers_root_and_mechanic_level_homes(self) -> None:
         entries = topology_inventory.normalized_inventory_entries()


### PR DESCRIPTION
## Summary
- Define `promotion-evidence-hold` in the bundle anatomy rubric Layer 2 verdict table.
- Add a regression that every token used in rubric `Finding:` lines is defined by the Layer 1/2 label tables or Layer 3 action table.
- Update the distillation topology test count for the new regression.

## Validation
- python -m unittest mechanics/distillation/tests/test_distillation_reform_ingress_reviews.py
- python -m unittest tests.test_test_topology
- python -m unittest discover -s mechanics/distillation/tests
- python scripts/validate_repo.py
- python scripts/ci_gate.py --mode source-fast
- python scripts/release_check.py

## Scope
- Review rubric evidence only; no technique source, schema, generated truth, or promotion state changed.