### PR TITLE
Enforce bundle review draft kind

### DIFF
--- a/mechanics/distillation/tests/test_distillation_part_ledgers_handoff.py
+++ b/mechanics/distillation/tests/test_distillation_part_ledgers_handoff.py
@@ -299,6 +299,7 @@ class DistillationPartLedgersHandoffTests(unittest.TestCase):
                     if "bundle-reviews" in gate_path.parts:
                         self.assertIn("Verdict", text)
                         self.assertIn("ready for one-bundle draft", text)
+                        self.assertRegex(text, r"draft kind: `[^`]+`")
                         if gate_path.name == "request-evidence-bundle-readiness-review.md":
                             self.assertIn("draft kind: `guardrail`", text)
                         if gate_path.name == "offer-evidence-reference-bundle-readiness-review.md":


### PR DESCRIPTION
## Changed surfaces

- Tightens `mechanics/distillation/tests/test_distillation_part_ledgers_handoff.py` so every markdown file under `gates/bundle-reviews/` must declare a `draft kind: ...` line.
- Keeps the existing filename-specific exact kind checks for current request/offer bundle reviews.

## Validation

- `python -m unittest mechanics.distillation.tests.test_distillation_part_ledgers_handoff`
- `python -m pytest -q mechanics/distillation/parts/agon-candidate-handoff/tests/test_agon_candidate_handoff.py`
- `python mechanics/distillation/parts/agon-candidate-handoff/scripts/build_agon_candidate_handoff.py --check`
- `python mechanics/distillation/parts/agon-candidate-handoff/scripts/validate_agon_candidate_handoff.py`
- `python scripts/ci_gate.py --mode source-fast`
- `python scripts/validate_repo.py`
- `git diff --check`
- `aoa checkpoint review-note /srv/AbyssOS/aoa-techniques --commit-ref 4996d8583d02ebd7c6b81ea66e2ac760e506e909 --auto --root /srv/AbyssOS`

## Public-safety and generated parity

No generated artifacts or public content changed. This is a test-only invariant hardening for public-safe Distillation gate review files.

## Remaining risk

Low. The change only broadens an existing assertion from two named files to all bundle-readiness review files.
