### PR TITLE
Harden antifragility ORQ receipt test

### DIFF
--- a/mechanics/antifragility/tests/test_antifragility_mechanics_topology.py
+++ b/mechanics/antifragility/tests/test_antifragility_mechanics_topology.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -79,6 +80,7 @@ class AntifragilityMechanicsTopologyTestCase(unittest.TestCase):
         )
         direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
         non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+        normalized_non_orq_section = re.sub(r"\s+", " ", non_orq_section)
 
         self.assertNotIn("ORQ-ANTIFRAGILITY-TECHNIQUES", direct_section)
         self.assertIn(
@@ -87,11 +89,14 @@ class AntifragilityMechanicsTopologyTestCase(unittest.TestCase):
         )
         self.assertIn("Current status: `candidate-only`", non_orq_section)
         self.assertIn(
-            "no\n  direct `ORQ-ANTIFRAGILITY-TECHNIQUES-*` request",
-            non_orq_section,
+            "no direct `ORQ-ANTIFRAGILITY-TECHNIQUES-*` request",
+            normalized_non_orq_section,
         )
         self.assertIn("one-score health", non_orq_section)
-        self.assertIn("automatic\n  technique promotion", non_orq_section)
+        self.assertIn(
+            "automatic technique promotion",
+            normalized_non_orq_section,
+        )
 
     def test_antifragility_reference_paths_point_to_active_part_home(self) -> None:
         old_path = "mechanics/antifragility/CHAOS_WAVE1_PROGRAM.md"


### PR DESCRIPTION
## Summary
- normalize whitespace in the antifragility ORQ receipt test before checking policy phrases
- keep the test focused on stable meaning instead of Markdown hard wrapping
- leave source receipts, mechanic meaning, generated surfaces, and public posture unchanged

## Validation
- python -m unittest mechanics.antifragility.tests.test_antifragility_mechanics_topology
- python scripts/validate_repo.py
- python scripts/ci_gate.py --mode source-fast
- python scripts/run_tests.py
- git diff --check

## Risk
- Test-only change; rollback is reverting commit c5aa63d4 if needed.