### PR TITLE
Harden recurrence ORQ receipt test

### DIFF
--- a/mechanics/recurrence/tests/test_recurrence_mechanics_topology.py
+++ b/mechanics/recurrence/tests/test_recurrence_mechanics_topology.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -72,13 +73,14 @@ class RecurrenceMechanicsTopologyTestCase(unittest.TestCase):
         )
         direct_section = receipts.split("## Non-ORQ Center Pressure", 1)[0]
         non_orq_section = receipts.split("## Non-ORQ Center Pressure", 1)[1]
+        normalized_non_orq_section = re.sub(r"\s+", " ", non_orq_section)
 
         self.assertNotIn("ORQ-RECURRENCE-TECHNIQUES", direct_section)
         self.assertIn("### [recurrence](recurrence/README.md)", non_orq_section)
         self.assertIn("Current status: `candidate-only`", non_orq_section)
         self.assertIn(
-            "no direct\n  `ORQ-RECURRENCE-TECHNIQUES-*` request",
-            non_orq_section,
+            "no direct `ORQ-RECURRENCE-TECHNIQUES-*` request",
+            normalized_non_orq_section,
         )
         self.assertIn("automatic technique promotion", non_orq_section)
 


### PR DESCRIPTION
## Summary
- normalize whitespace in the recurrence ORQ receipt test before checking the stable request phrase
- keep the assertion tied to recurrence policy meaning rather than Markdown hard wrapping
- leave recurrence source surfaces, generated outputs, and public posture unchanged

## Validation
- python -m unittest mechanics.recurrence.tests.test_recurrence_mechanics_topology
- python scripts/validate_repo.py
- python scripts/ci_gate.py --mode source-fast
- python scripts/run_tests.py
- git diff --check

## Risk
- Test-only change; rollback is reverting commit 2049f497 if needed.