### PR TITLE
[codex] Require subject-store trust gate for KAG export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is intentionally simple and human-first.
 
 ### Changed
 
+- tightened the OS Abyss KAG export artifact envelope so the manifest, validator,
+  and downstream contract test require durable evidence promotion,
+  materialized subject-store admission, source/trust-root matching, and
+  fail-closed allow/deny consumer verdicts before agent consumption
 - moved validation command authority into `config/validation_lanes.json`, added
   `scripts/validation_lanes.py` and `scripts/ci_gate.py`, and changed GitHub
   `Repo Validation` to run the `source-fast` lane instead of the full

--- a/docs/source-lift/artifact-bundles/kag_export.bundle.json
+++ b/docs/source-lift/artifact-bundles/kag_export.bundle.json
@@ -68,8 +68,11 @@
   },
   "consumer_contract": {
     "stable_interface": "python scripts/validate_abyss_machine_kag_export_bundle.py --json and abyss-machine artifacts trust-gate --artifact-class source_owned_kag_export_capsule --consumer-intent agent --json",
-    "consumer_expectation": "KAG-adjacent consumers select a source_owned_kag_export_capsule bundle from the registry latest read-model only after ABI verification, SLSA/in-toto generation provenance, materialized subject-store verification, build_kag_export parity, validate_repo, and source-lift boundary checks pass; the capsule remains source-owned handoff material and does not define KAG substrate behavior.",
-    "registry_required": true
+    "consumer_expectation": "KAG-adjacent consumers select a source_owned_kag_export_capsule bundle from the registry latest read-model only after ABI verification, SLSA/in-toto generation provenance, durable evidence promotion, materialized subject-store verification, source/trust-root matching, build_kag_export parity, validate_repo, and source-lift boundary checks pass; the capsule remains source-owned handoff material and does not define KAG substrate behavior.",
+    "registry_required": true,
+    "subject_store_required": true,
+    "admission_gate": "fail_closed_consumer_admission",
+    "consumer_verdict": "allow_or_deny_required_before_use"
   },
   "consumer_command": [
     "abyss-machine artifacts build-sidecars --manifest docs/source-lift/artifact-bundles/kag_export.bundle.json --bundle-dir BUNDLE_DIR",
@@ -77,7 +80,7 @@
     "abyss-machine artifacts verify BUNDLE_DIR",
     "abyss-machine artifacts release-check BUNDLE_DIR",
     "abyss-machine artifacts evidence-promote BUNDLE_DIR --registry-dir REGISTRY_DIR --lifecycle-state release-ready --consumer-ref aoa-techniques:kag-export-capsule --evidence-ref BUNDLE_DIR/artifact.verify.json --source-repo aoa-techniques --source-ref docs/source-lift/artifact-bundles/kag_export.bundle.json --producer aoa-techniques-kag-export-generator --trust-root-mode host_managed --json",
-    "abyss-machine artifacts materialize-subjects BUNDLE_DIR --registry-dir REGISTRY_DIR --manifest docs/source-lift/artifact-bundles/kag_export.bundle.json --consumer-intent agent --source-repo aoa-techniques --trust-root-mode host_managed --json",
+    "abyss-machine artifacts materialize-subjects BUNDLE_DIR --registry-dir REGISTRY_DIR --store-root SUBJECT_STORE_ROOT --manifest docs/source-lift/artifact-bundles/kag_export.bundle.json --consumer-intent agent --source-repo aoa-techniques --trust-root-mode host_managed --json",
     "abyss-machine artifacts trust-gate --registry-dir REGISTRY_DIR --artifact-class source_owned_kag_export_capsule --consumer-intent agent --source-repo aoa-techniques --trust-root-mode host_managed --json",
     "abyss-machine artifacts registry-latest --registry-dir REGISTRY_DIR --artifact-class source_owned_kag_export_capsule --consumer-intent agent --source-repo aoa-techniques --trust-root-mode host_managed --json",
     "python scripts/validate_abyss_machine_kag_export_bundle.py --json",

--- a/scripts/validate_abyss_machine_kag_export_bundle.py
+++ b/scripts/validate_abyss_machine_kag_export_bundle.py
@@ -100,8 +100,18 @@ def _sanitize_public_payload(payload: Any) -> Any:
         return {key: _sanitize_public_payload(value) for key, value in payload.items()}
     if isinstance(payload, list):
         return [_sanitize_public_payload(item) for item in payload]
-    if isinstance(payload, str) and (payload == local_root or payload.startswith(local_root + os.sep)):
-        return _portable_ref(Path(payload))
+    if isinstance(payload, str):
+        if payload == local_root or payload.startswith(local_root + os.sep):
+            return _portable_ref(Path(payload))
+        tmp_root = "/srv/abyss-machine/tmp"
+        if payload == tmp_root:
+            return "host-tmp:abyss-machine"
+        if payload.startswith(tmp_root + os.sep):
+            suffix = Path(payload).resolve().relative_to(Path(tmp_root)).as_posix()
+            return f"host-tmp:abyss-machine/{suffix}"
+        home = Path.home().resolve()
+        if payload == str(home) or payload.startswith(str(home) + os.sep):
+            return "host-home-redacted"
     return payload
 
 
@@ -155,6 +165,25 @@ def _assert_manifest_matches_subject(manifest: Path, subject: Path) -> None:
         raise ValueError(f"manifest artifact_class must be {ARTIFACT_CLASS}")
     if payload.get("owner_repo") != "aoa-techniques":
         raise ValueError("manifest owner_repo must be aoa-techniques")
+    contract = payload.get("consumer_contract")
+    if not isinstance(contract, dict):
+        raise ValueError("manifest consumer_contract must be an object")
+    if contract.get("subject_store_required") is not True:
+        raise ValueError("manifest consumer_contract.subject_store_required must be true")
+    if contract.get("admission_gate") != "fail_closed_consumer_admission":
+        raise ValueError("manifest consumer_contract.admission_gate must be fail_closed_consumer_admission")
+    commands = "\n".join(str(item) for item in payload.get("consumer_command") or [])
+    for token in (
+        "artifacts evidence-promote",
+        "artifacts materialize-subjects",
+        "artifacts trust-gate",
+        "artifacts registry-latest",
+        "--store-root SUBJECT_STORE_ROOT",
+        "--source-repo aoa-techniques",
+        "--trust-root-mode host_managed",
+    ):
+        if token not in commands:
+            raise ValueError(f"manifest consumer_command must include {token}")
     payload["_manifest_path"] = str(manifest)
     paths = _manifest_subject_paths(payload)
     if subject.resolve() not in {path.resolve() for path in paths}:
@@ -654,7 +683,7 @@ def _validate_in_bundle_dir(
     registry = artifact_bundles.read_bundle_registry(registry_dir, artifact_class=ARTIFACT_CLASS)
     adversarial = _run_adversarial_checks(artifact_bundles, abyss_repo_root, manifest, subject, bundle_dir)
 
-    return {
+    payload = {
         "ok": bool(
             build.get("ok")
             and sign.get("ok")
@@ -697,6 +726,7 @@ def _validate_in_bundle_dir(
             "release_check": release_check,
         },
     }
+    return _sanitize_public_payload(payload)
 
 
 def validate_bundle(

--- a/tests/test_downstream_feed_contracts.py
+++ b/tests/test_downstream_feed_contracts.py
@@ -166,15 +166,24 @@ class DownstreamFeedContractsTests(unittest.TestCase):
         self.assertIn("revoked", manifest["lifecycle"]["promotion_path"])
         self.assertTrue(manifest["consumer_contract"]["registry_required"])
         self.assertIn("SLSA/in-toto generation provenance", manifest["consumer_contract"]["consumer_expectation"])
+        self.assertIn("durable evidence promotion", manifest["consumer_contract"]["consumer_expectation"])
         self.assertIn("materialized subject-store verification", manifest["consumer_contract"]["consumer_expectation"])
+        self.assertIn("source/trust-root matching", manifest["consumer_contract"]["consumer_expectation"])
         self.assertIn("does not define KAG substrate behavior", manifest["consumer_contract"]["consumer_expectation"])
         self.assertIn("trust-gate", manifest["consumer_contract"]["stable_interface"])
+        self.assertTrue(manifest["consumer_contract"]["subject_store_required"])
+        self.assertEqual(manifest["consumer_contract"]["admission_gate"], "fail_closed_consumer_admission")
+        self.assertEqual(manifest["consumer_contract"]["consumer_verdict"], "allow_or_deny_required_before_use")
         self.assertTrue(
             any("evidence-promote" in command for command in manifest["consumer_command"]),
             manifest["consumer_command"],
         )
         self.assertTrue(
             any("materialize-subjects" in command for command in manifest["consumer_command"]),
+            manifest["consumer_command"],
+        )
+        self.assertTrue(
+            any("--store-root SUBJECT_STORE_ROOT" in command for command in manifest["consumer_command"]),
             manifest["consumer_command"],
         )
         self.assertTrue(


### PR DESCRIPTION
## Summary
- require subject_store_required/admission_gate/consumer verdict in the KAG export artifact manifest
- require materialize-subjects to name SUBJECT_STORE_ROOT and make the validator enforce the manifest trust-gate contract
- sanitize host-local roots in validator JSON output and cover the contract in downstream feed tests

## Validation
- python -m json.tool docs/source-lift/artifact-bundles/kag_export.bundle.json > /tmp/aoa-techniques-kag-export-manifest.pretty.json
- python -m py_compile scripts/validate_abyss_machine_kag_export_bundle.py
- python -m unittest tests.test_downstream_feed_contracts.DownstreamFeedContractsTests.test_kag_export_artifact_bundle_requires_trust_gate_subject_store_and_slsa
- python scripts/validate_abyss_machine_kag_export_bundle.py --json > /tmp/aoa-techniques-kag-export-final-validator.json
- leak scan against validator JSON and dist artifact outputs
- python scripts/ci_gate.py --mode source-fast
- python scripts/ci_gate.py --mode generated
- python scripts/release_check.py

## OS Abyss Trust Evidence
- artifact_class=source_owned_kag_export_capsule
- required/verified controls=abi_signature,slsa_in_toto
- trust_gate=allow; subject_store_gate=allow
- source_repo=aoa-techniques; trust_root=host_managed
- adversarial_checks.ok=true
- abyss_machine_repo_root is host-home-redacted in public JSON
