### PR TITLE
Align KAG provider validation route

### DIFF
--- a/kag/manifest.json
+++ b/kag/manifest.json
@@ -37,6 +37,10 @@
       "lane": "owner-local"
     },
     {
+      "route": "aoa-kag:scripts/validate_kag.py",
+      "lane": "local-kag"
+    },
+    {
       "route": "scripts/ci_gate.py --mode source-fast",
       "lane": "source-fast"
     }

--- a/kag/receipts/validation_receipt.json
+++ b/kag/receipts/validation_receipt.json
@@ -22,7 +22,7 @@
   "source_owner": "aoa-techniques",
   "provenance_mode": "strict_source_linked",
   "derived_method": "technique KAG export validation receipt",
-  "generated_or_authored": "generated_from_source",
+  "generated_or_authored": "authored_control",
   "status": "active",
   "owner_return_route": {
     "repo": "aoa-techniques",
@@ -32,15 +32,15 @@
   "freshness": {
     "mode": "validator_receipt",
     "state": "current",
-    "checked_ref": "scripts/validators/projection_kag.py"
+    "checked_ref": "kag/manifest.json"
   },
   "builder": {
-    "route": "python scripts/validate_repo.py",
-    "surface": "scripts/validate_repo.py"
+    "route": "local KAG provider authoring",
+    "surface": "kag/manifest.json"
   },
   "validator": {
-    "route": "scripts/validate_repo.py",
-    "lane": "owner-local"
+    "route": "aoa-kag:scripts/validate_kag.py",
+    "lane": "local-kag"
   },
   "storage_posture": {
     "git_surface": "receipt",
@@ -49,6 +49,6 @@
   },
   "consumer_route": "aoa-kag registry",
   "receipt_kind": "validation",
-  "result": "valid",
+  "result": "current",
   "fallback_route": "docs/source-lift/KAG_EXPORT.md"
 }


### PR DESCRIPTION
## Summary
- add the central aoa-kag local-kag validation route to the aoa-techniques KAG provider manifest
- align the validation receipt with the central validator while preserving the owner validation route as fallback

## Validation
- python scripts/ci_gate.py --mode source-fast