### PR TITLE
Key live receipt hooks by event id

### DIFF
--- a/mechanics/recurrence/parts/live-observation-producers/manifests/recurrence/hooks/component.techniques.canon-and-intake-beacons.hooks.json
+++ b/mechanics/recurrence/parts/live-observation-producers/manifests/recurrence/hooks/component.techniques.canon-and-intake-beacons.hooks.json
@@ -15,7 +15,7 @@
         ".aoa/live_receipts/technique-receipts.jsonl"
       ],
       "config": {
-        "record_id_field": "receipt_ref"
+        "record_id_field": "event_id"
       },
       "signal_rules": [
         {

--- a/mechanics/recurrence/tests/test_publish_live_receipts.py
+++ b/mechanics/recurrence/tests/test_publish_live_receipts.py
@@ -17,6 +17,17 @@ MODULE_PATH = (
     / "scripts"
     / "publish_live_receipts.py"
 )
+HOOK_BINDING_PATH = (
+    REPO_ROOT
+    / "mechanics"
+    / "recurrence"
+    / "parts"
+    / "live-observation-producers"
+    / "manifests"
+    / "recurrence"
+    / "hooks"
+    / "component.techniques.canon-and-intake-beacons.hooks.json"
+)
 
 
 def load_module():
@@ -55,6 +66,13 @@ def build_receipt(event_kind: str = "technique_promotion_receipt") -> dict:
 
 
 class TechniquePublishLiveReceiptsTests(unittest.TestCase):
+    def test_live_receipt_hook_keys_records_by_event_id(self) -> None:
+        payload = json.loads(HOOK_BINDING_PATH.read_text(encoding="utf-8"))
+        binding = payload["bindings"][0]
+
+        self.assertEqual(binding["binding_ref"], "techniques.live_receipts.session_stop")
+        self.assertEqual(binding["config"]["record_id_field"], "event_id")
+
     def test_publish_live_receipts_appends_once_and_skips_duplicates(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Updates the canon/intake live receipt hook binding to key JSONL records by `event_id`, matching `publish_live_receipts.py`.
- Adds regression coverage so the hook config cannot drift back to a non-existent `receipt_ref` key.

## Verification
- `python -m json.tool mechanics/recurrence/parts/live-observation-producers/manifests/recurrence/hooks/component.techniques.canon-and-intake-beacons.hooks.json`
- `python -m pytest -q mechanics/recurrence/tests/test_publish_live_receipts.py`

## Risk
- Narrow recurrence hook config change; no technique meaning or promotion policy changes.