### PR TITLE
Sanitize promotion incubation evidence handles

### DIFF
--- a/mechanics/growth-cycle/parts/promotion-readiness-incubation/README.md
+++ b/mechanics/growth-cycle/parts/promotion-readiness-incubation/README.md
@@ -37,10 +37,14 @@ session.
   `reanchor_owner`
 - nearest wrong target:
   `aoa-skills`
-- reviewed evidence refs:
-  - `repo:aoa-sdk/.aoa/session-growth/current/97a0427d-db7f-48ec-944c-ebe962709e89/aoa-memo/reviewed-closeout-live.md`
-  - `repo:aoa-sdk/.aoa/session-growth/current/97a0427d-db7f-48ec-944c-ebe962709e89/aoa-memo/closeout-context.json`
-  - `repo:aoa-sdk/.aoa/closeout/handoffs/session-2026-04-13T17-04-26-415462Z-aoa-memo-checkpoint-growth-97a0427d-db7.owner-handoff.json`
+- reviewed evidence handles:
+  - `session:2026-04-13T17-04-26-415462Z-aoa-memo-checkpoint-growth-97a0427d-db7`
+  - `candidate:pattern:aoa-techniques-technique-promotion-readiness-min`
+  - `cluster:pattern:candidate-pattern-aoa-techniques-technique-promotion-readiness-min`
+- evidence note:
+  the source closeout artifacts remain owner-local in `aoa-sdk`; this public
+  incubation note keeps only stable reviewed handles and does not publish
+  machine-local storage paths
 
 ## Survivor split
 

--- a/mechanics/growth-cycle/tests/test_growth_cycle_mechanics_topology.py
+++ b/mechanics/growth-cycle/tests/test_growth_cycle_mechanics_topology.py
@@ -158,6 +158,33 @@ class GrowthCycleMechanicsTopologyTestCase(unittest.TestCase):
         self.assertIn('"parts"', validator)
         self.assertIn('"questbook-integration"', validator)
 
+    def test_promotion_readiness_incubation_stays_public_safe(self) -> None:
+        readme = (
+            REPO_ROOT
+            / "mechanics"
+            / "growth-cycle"
+            / "parts"
+            / "promotion-readiness-incubation"
+            / "README.md"
+        ).read_text(encoding="utf-8")
+
+        for forbidden in (
+            "repo:aoa-sdk/.aoa/",
+            ".aoa/session-growth/",
+            ".aoa/closeout/",
+            "closeout-context.json",
+            "owner-handoff.json",
+            "reviewed-closeout-live.md",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, readme)
+
+        self.assertIn(
+            "session:2026-04-13T17-04-26-415462Z-aoa-memo-checkpoint-growth-97a0427d-db7",
+            readme,
+        )
+        self.assertIn("source closeout artifacts remain owner-local", readme)
+
     def test_mechanics_roadmaps_are_not_silently_ignored(self) -> None:
         gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Replaces owner-local `repo:aoa-sdk/.aoa/...` evidence paths in the promotion-readiness incubation note with stable public handles.
- Adds a regression test preventing that part README from publishing local `.aoa` storage paths or exact owner-local closeout filenames.

## Verification
- `python -m unittest mechanics.growth-cycle.tests.test_growth_cycle_mechanics_topology`

## Boundary
- Source closeout artifacts remain owner-local in `aoa-sdk`; this public technique-layer incubation surface now keeps only stable reviewed handles.