### PR TITLE
Align remediation snapshot cap policy

### DIFF
--- a/generated/technique_checklist_manifest.json
+++ b/generated/technique_checklist_manifest.json
@@ -344,7 +344,7 @@
             },
             {
               "order": 4,
-              "text": "applies an explicit cap to each bucket"
+              "text": "applies the documented candidate cap policy consistently at the chosen scope: per snapshot, per bucket, or by priority band"
             },
             {
               "order": 5,

--- a/generated/technique_intelligence_registry.json
+++ b/generated/technique_intelligence_registry.json
@@ -3870,8 +3870,8 @@
           "document_type": "checklist",
           "section_name": "remediation-snapshot-checklist",
           "source_ref": "techniques/proof/published-summary/published-summary-remediation-snapshot/checks/remediation-snapshot-checklist.md",
-          "text": "remediation-snapshot-checklist reads only latest published summary aliases does not replay history or recompute trend state uses one fixed documented bucket set applies an explicit cap to each bucket reports missing or stale inputs explicitly keeps source summary references on emitted candidates when several published summaries feed several downstream consumers, the snapshot is preferred over repeating direct per-source triage in each surface the same cap, determinism, and source-traceability rules still hold when latest summaries are published as object-store keys remains read-only with respect to source artifacts and upstream behavior",
-          "content_hash": "70dceca42044cb69f2111deacaaf2563f323d8ae3928ae168347e7429c59f17f"
+          "text": "remediation-snapshot-checklist reads only latest published summary aliases does not replay history or recompute trend state uses one fixed documented bucket set applies the documented candidate cap policy consistently at the chosen scope: per snapshot, per bucket, or by priority band reports missing or stale inputs explicitly keeps source summary references on emitted candidates when several published summaries feed several downstream consumers, the snapshot is preferred over repeating direct per-source triage in each surface the same cap, determinism, and source-traceability rules still hold when latest summaries are published as object-store keys remains read-only with respect to source artifacts and upstream behavior",
+          "content_hash": "11ff31b201d4575d8e1b79bb89eec96d392a7dceea9d9a59e4d14b22c1b04c5f"
         },
         {
           "document_id": "AOA-T-0008:example:001",

--- a/techniques/proof/published-summary/published-summary-remediation-snapshot/checks/remediation-snapshot-checklist.md
+++ b/techniques/proof/published-summary/published-summary-remediation-snapshot/checks/remediation-snapshot-checklist.md
@@ -3,7 +3,7 @@
 - reads only latest published summary aliases
 - does not replay history or recompute trend state
 - uses one fixed documented bucket set
-- applies an explicit cap to each bucket
+- applies the documented candidate cap policy consistently at the chosen scope: per snapshot, per bucket, or by priority band
 - reports missing or stale inputs explicitly
 - keeps source summary references on emitted candidates
 - when several published summaries feed several downstream consumers, the snapshot is preferred over repeating direct per-source triage in each surface

--- a/tests/test_validate_repo_source_contracts.py
+++ b/tests/test_validate_repo_source_contracts.py
@@ -512,6 +512,30 @@ relations:
         self.assertIn("delegated external planning surface", checklist)
         self.assertIn("delegated elsewhere", technique)
 
+    def test_remediation_snapshot_candidate_cap_policy_is_consistent(self) -> None:
+        technique = (
+            REPO_ROOT
+            / "techniques"
+            / "proof"
+            / "published-summary"
+            / "published-summary-remediation-snapshot"
+            / "TECHNIQUE.md"
+        ).read_text(encoding="utf-8")
+        checklist = (
+            REPO_ROOT
+            / "techniques"
+            / "proof"
+            / "published-summary"
+            / "published-summary-remediation-snapshot"
+            / "checks"
+            / "remediation-snapshot-checklist.md"
+        ).read_text(encoding="utf-8")
+
+        candidate_cap_scope = "per snapshot, per bucket, or by priority band"
+        self.assertIn(candidate_cap_scope, technique)
+        self.assertIn(candidate_cap_scope, checklist)
+        self.assertNotIn("cap to each bucket", checklist)
+
     def test_canonical_bundles_have_adverse_effects_reviews_and_promoted_bundles_do_not(self) -> None:
         schema_store = validate_repo.load_schema_store(REPO_ROOT)
         records = validate_repo.collect_techniques(REPO_ROOT, schema_store)


### PR DESCRIPTION
## Summary
- align remediation snapshot checklist with the technique's allowed candidate-cap scopes
- add a source-contract regression test for the cap policy wording
- refresh generated checklist/intelligence surfaces

## Validation
- python -m pytest -q tests/test_validate_repo_source_contracts.py -k 'remediation_snapshot_candidate_cap_policy_is_consistent or source_of_truth_checklist_supports_delegated_homes or telemetry_guardrail_status_language_is_consistent'
- python scripts/build_checklist_manifest.py
- python scripts/build_technique_intelligence.py
- python scripts/validate_repo.py
